### PR TITLE
docs: add README badges, fix v1.0.0 install refs and release-attestation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Cynative - Security Research Agent
 
+[![CI](https://github.com/cynative/cynative/actions/workflows/ci.yaml/badge.svg)](https://github.com/cynative/cynative/actions/workflows/ci.yaml)
+[![Release](https://img.shields.io/github/v/release/cynative/cynative)](https://github.com/cynative/cynative/releases/latest)
+[![License: Apache-2.0](https://img.shields.io/github/license/cynative/cynative)](LICENSE)
+
 <!-- BEGIN agent-about -->
 Cynative runs frontier models to secure your stack. It researches your code, cloud and runtime by writing and running code in a read-only sandbox and verifies every finding live.
 
@@ -30,9 +34,9 @@ Upgrade with `brew upgrade cynative`; uninstall with `brew uninstall --cask cyna
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cynative/cynative/main/install.sh | sh
 ```
-The script detects your OS/arch, downloads the release binary, **verifies its SHA-256 against the release `checksums.txt`, failing closed on a mismatch** — and, when `gh` is installed, checks the SLSA build-provenance attestation (advisory by default; set `CYNATIVE_REQUIRE_ATTESTATION=1` to make a failed attestation fatal) — then installs (no `sudo`) to `~/.local/bin` (override with `CYNATIVE_INSTALL_DIR`). Pin a version with `CYNATIVE_VERSION=v0.0.1`; for a high-integrity install, fetch the script itself from an immutable tag rather than `main`:
+The script detects your OS/arch, downloads the release binary, **verifies its SHA-256 against the release `checksums.txt`, failing closed on a mismatch** — and, when `gh` is installed, checks the GitHub release attestation (advisory by default; set `CYNATIVE_REQUIRE_ATTESTATION=1` to make a failed attestation fatal) — then installs (no `sudo`) to `~/.local/bin` (override with `CYNATIVE_INSTALL_DIR`). Pin a version with `CYNATIVE_VERSION=v1.0.0`; for a high-integrity install, fetch the script itself from an immutable tag rather than `main`:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cynative/cynative/v0.0.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/cynative/cynative/v1.0.0/install.sh | sh
 ```
 Re-run the one-liner to upgrade; uninstall with `curl -fsSL …/install.sh | sh -s -- --uninstall`.
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # cynative installer.
 #   curl -fsSL https://raw.githubusercontent.com/cynative/cynative/main/install.sh | sh
 # Env: CYNATIVE_VERSION (default: latest), CYNATIVE_INSTALL_DIR (default: ~/.local/bin),
-#      CYNATIVE_REQUIRE_ATTESTATION=1 (make a failed `gh attestation verify` fatal).
+#      CYNATIVE_REQUIRE_ATTESTATION=1 (make a failed release-attestation check fatal).
 # For high-integrity installs, fetch this script from an immutable ref instead of `main`:
 #   curl -fsSL https://raw.githubusercontent.com/cynative/cynative/<tag-or-sha>/install.sh | sh
 set -eu
@@ -76,7 +76,7 @@ got=$(cd "$tmp" && sha256 "$ARCHIVE" | awk '{print $1}')
 [ "$matches" = "$got" ] || err "checksum mismatch: want ${matches} got ${got}"
 
 if command -v gh >/dev/null 2>&1; then
-  if gh attestation verify "$tmp/$ARCHIVE" -R "$REPO" >/dev/null 2>&1; then
+  if gh release verify-asset "$VERSION" "$tmp/$ARCHIVE" --repo "$REPO" >/dev/null 2>&1; then
     printf 'attestation verified\n' >&2
   elif [ "${CYNATIVE_REQUIRE_ATTESTATION:-0}" = "1" ]; then
     err "attestation verification failed (CYNATIVE_REQUIRE_ATTESTATION=1)"
@@ -96,5 +96,8 @@ mv "$INSTALL_DIR/.${BINARY}.tmp.$$" "$INSTALL_DIR/$BINARY" || err "install move 
 printf 'installed %s %s to %s/%s\n' "$BINARY" "$VERSION" "$INSTALL_DIR" "$BINARY" >&2
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;
-  *) printf 'note: %s is not on PATH — add: export PATH="%s:$PATH"\n' "$INSTALL_DIR" "$INSTALL_DIR" >&2 ;;
+  *)
+    # shellcheck disable=SC2016  # the printed $PATH is intentionally literal (a copy-paste hint).
+    printf 'note: %s is not on PATH — add: export PATH="%s:$PATH"\n' "$INSTALL_DIR" "$INSTALL_DIR" >&2
+    ;;
 esac


### PR DESCRIPTION
Post-launch polish for the v1.0.0 public release:

- **README badges** — CI, latest release, license.
- **Fix stale `v0.0.1` references** in the install docs → `v1.0.0` (the launch version; `v0.0.1` is unusable on this repo).
- **install.sh attestation check** — use `gh release verify-asset` (the immutable-releases attestation this repo actually produces) instead of `gh attestation verify` (SLSA build-provenance, which this repo does not emit — the advisory check always 404'd). Checksum verification (the hard, fail-closed gate) is unchanged.
- Reword the README attestation line accordingly ("GitHub release attestation").

Verified: `gh release verify-asset v1.0.0 <archive>` succeeds; `curl|bash` install works end-to-end.

https://claude.ai/code/session_01NPWd4cD7EXXfrmjL1iLZup