### PR TITLE
feat: add cynative --version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,11 @@ before:
 
 builds:
   - main: ./cmd/cynative
+    ldflags:
+      - -s -w
+      - -X github.com/cynative/cynative/internal/version.version={{.Version}}
+      - -X github.com/cynative/cynative/internal/version.commit={{.FullCommit}}
+      - -X github.com/cynative/cynative/internal/version.date={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ cynative -p "CI workflows that can assume privileged cloud roles"
 cat main.tf | cynative -p "review this Terraform for misconfigurations"
 ```
 
+Check the build with `--version` (prints version, commit, build date, Go version, and platform, then exits - no config or credentials required):
+
+```bash
+cynative --version
+```
+
 **Interactive session:**  the > prompt has full line editing and history - arrow keys move the cursor and recall earlier questions.
 
 **Stopping mid-task:** while a task is running, press **Esc** or **Ctrl-C** once to gracefully stop it (the agent finishes any already-running call, then stops and prints `⏸ Stopped`).

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -158,6 +158,7 @@ type deps struct {
 	hasTerminal          bool
 	readStdin            func() (data string, truncated bool, err error)
 	interrupter          agent.Interrupter
+	version              string // pre-rendered `--version` output; resolved in newDeps.
 }
 
 // runRoot reads any piped stdin, resolves the invocation, and dispatches to run.

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -219,6 +219,7 @@ func testDeps() *deps {
 		stdinIsTTY:  true,
 		hasTerminal: true,
 		readStdin:   func() (string, bool, error) { return "", false, nil },
+		version:     "cynative 9.9.9\n  commit:   deadbeefcafe",
 	}
 	d.run = d.runResearch
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,6 +52,14 @@ to seed it. Use -p/--print to run a single task non-interactively and exit
 	rootCmd.Flags().BoolVar(&flags.autoApprove, "auto-approve", false, "Skip interactive approval for tool calls")
 	rootCmd.Flags().BoolVarP(&flags.verbose, "verbose", "v", false, "Print tool call outputs to stderr")
 
+	// Version enables cobra's built-in --version flag, which short-circuits in
+	// Execute() before ValidateArgs/PersistentPreRunE — so `cynative --version`
+	// prints and exits without loading config or credentials. We registered
+	// --verbose/-v above, so by the time cobra's InitDefaultVersionFlag runs (at
+	// Execute) the -v shorthand is taken and --version gets none (we add no -V).
+	rootCmd.Version = d.version
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
 	return rootCmd
 }
 

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -205,3 +205,66 @@ func TestSilenceGracefulStop_SilencesLLMUnavailable(t *testing.T) {
 		t.Errorf("ExitCodeFor(ErrLLMUnavailable) = %d, want 1", ExitCodeFor(ErrLLMUnavailable))
 	}
 }
+
+func TestNewRootCmd_Version(t *testing.T) {
+	t.Parallel()
+
+	configLoaded := false
+
+	d := testDeps()
+	d.version = "cynative 9.9.9\n  commit:   deadbeefcafe"
+	d.loadConfig = func(string) (config.Config, error) {
+		configLoaded = true
+
+		return validCfg(), nil
+	}
+
+	buf, err := runWithArgs(t, d, []string{"--version"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := buf.String(), d.version+"\n"; got != want {
+		t.Errorf("--version output = %q, want %q", got, want)
+	}
+	if configLoaded {
+		t.Error("--version must short-circuit before PersistentPreRunE (loadConfig was called)")
+	}
+}
+
+func TestNewRootCmd_Version_BypassesArgValidation(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	d.version = "cynative 9.9.9"
+
+	// Three positional args would normally fail Args: cobra.MaximumNArgs(1); the
+	// version short-circuit runs before ValidateArgs, so this must still succeed.
+	buf, err := runWithArgs(t, d, []string{"--version", "extra", "args"})
+	if err != nil {
+		t.Fatalf("--version with extra args must not error: %v", err)
+	}
+	if got, want := buf.String(), "cynative 9.9.9\n"; got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestNewRootCmd_VerboseShorthandWinsOverVersion(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd(testDeps())
+	// InitDefaultVersionFlag is what Execute() calls; running it here registers the
+	// --version flag the same way, so we can assert the shorthand ownership.
+	rootCmd.InitDefaultVersionFlag()
+
+	if sh := rootCmd.Flags().ShorthandLookup("v"); sh == nil || sh.Name != "verbose" {
+		t.Fatalf("-v must resolve to --verbose, got %+v", sh)
+	}
+
+	vf := rootCmd.Flags().Lookup("version")
+	if vf == nil {
+		t.Fatal("--version flag must be registered when Version is set")
+	}
+	if vf.Shorthand != "" {
+		t.Errorf("--version must carry no shorthand, got -%s", vf.Shorthand)
+	}
+}

--- a/internal/cli/wire_shell.go
+++ b/internal/cli/wire_shell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cynative/cynative/internal/schema"
 	"github.com/cynative/cynative/internal/tools"
 	"github.com/cynative/cynative/internal/ui"
+	"github.com/cynative/cynative/internal/version"
 )
 
 // maxStdinBytes caps piped stdin folded into the task (1 MiB) so an unbounded or
@@ -143,6 +144,7 @@ func newDeps() *deps {
 		hasTerminal: hasTerminal,
 		readStdin:   readStdin,
 		interrupter: interrupter,
+		version:     version.Get().String(),
 	}
 	d.run = d.runResearch
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,133 @@
+// Package version resolves and renders the cynative build metadata reported by
+// the --version flag.
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// shortCommitLen is the number of leading hex characters of a commit SHA kept for
+// display. Twelve is collision-safe for a project of this size while staying compact.
+const shortCommitLen = 12
+
+// Info is the resolved build metadata rendered by the --version flag.
+type Info struct {
+	Version   string // e.g. "1.0.0" or "dev".
+	Commit    string // short commit, "+dirty" when built from a modified worktree, or "none".
+	Date      string // RFC3339 build/commit time, or "unknown".
+	GoVersion string // e.g. "go1.24.0".
+	Platform  string // e.g. "linux/amd64".
+}
+
+// Resolve applies the fallback chain from the ldflags-injected strings and the
+// runtime build info to a fully-populated Info. bi may be nil (when
+// [debug.ReadBuildInfo] reported ok == false); every build-info read is nil-guarded.
+func Resolve(
+	ldVersion, ldCommit, ldDate string,
+	bi *debug.BuildInfo,
+	goVersion, goos, goarch string,
+) Info {
+	return Info{
+		Version:   resolveVersion(ldVersion, bi),
+		Commit:    resolveCommit(ldCommit, bi),
+		Date:      resolveDate(ldDate, bi),
+		GoVersion: resolveGoVersion(goVersion, bi),
+		Platform:  goos + "/" + goarch,
+	}
+}
+
+// resolveVersion prefers a real ldflags stamp, then the module version, then "dev",
+// stripping a single leading "v" uniformly for a consistent display.
+func resolveVersion(ldVersion string, bi *debug.BuildInfo) string {
+	v := "dev"
+
+	switch {
+	case ldVersion != "" && ldVersion != "dev":
+		v = ldVersion
+	case bi != nil && bi.Main.Version != "" && bi.Main.Version != "(devel)":
+		v = bi.Main.Version
+	}
+
+	return strings.TrimPrefix(v, "v")
+}
+
+// resolveCommit prefers the ldflags stamp (release builds tag a clean tree, so it
+// never gets a +dirty suffix), else the vcs.revision setting with +dirty when the
+// worktree was modified, else "none". The commit is always shortened.
+func resolveCommit(ldCommit string, bi *debug.BuildInfo) string {
+	if ldCommit != "" {
+		return shortCommit(ldCommit)
+	}
+
+	rev := buildSetting(bi, "vcs.revision")
+	if rev == "" {
+		return "none"
+	}
+
+	c := shortCommit(rev)
+	if buildSetting(bi, "vcs.modified") == "true" {
+		c += "+dirty"
+	}
+
+	return c
+}
+
+// resolveDate prefers the ldflags stamp, then the vcs.time setting, then "unknown".
+func resolveDate(ldDate string, bi *debug.BuildInfo) string {
+	if ldDate != "" {
+		return ldDate
+	}
+	if t := buildSetting(bi, "vcs.time"); t != "" {
+		return t
+	}
+
+	return "unknown"
+}
+
+// resolveGoVersion prefers the build info's Go version, else the passed runtime value.
+func resolveGoVersion(goVersion string, bi *debug.BuildInfo) string {
+	if bi != nil && bi.GoVersion != "" {
+		return bi.GoVersion
+	}
+
+	return goVersion
+}
+
+// buildSetting returns the value of a [debug.BuildInfo] setting, or "" when bi is nil
+// or the key is absent.
+func buildSetting(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return ""
+	}
+	for _, s := range bi.Settings {
+		if s.Key == key {
+			return s.Value
+		}
+	}
+
+	return ""
+}
+
+// shortCommit truncates a commit SHA to shortCommitLen characters for display.
+func shortCommit(c string) string {
+	if len(c) > shortCommitLen {
+		return c[:shortCommitLen]
+	}
+
+	return c
+}
+
+// String renders the multi-line --version output without a trailing newline (the
+// cobra version template adds the final newline). Values align at one column.
+func (i Info) String() string {
+	var b strings.Builder
+
+	b.WriteString("cynative " + i.Version + "\n")
+	b.WriteString("  commit:   " + i.Commit + "\n")
+	b.WriteString("  built:    " + i.Date + "\n")
+	b.WriteString("  go:       " + i.GoVersion + "\n")
+	b.WriteString("  platform: " + i.Platform)
+
+	return b.String()
+}

--- a/internal/version/version_internal_test.go
+++ b/internal/version/version_internal_test.go
@@ -1,0 +1,236 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// settings builds a []debug.BuildSetting from alternating key/value pairs.
+func settings(kv ...string) []debug.BuildSetting {
+	out := make([]debug.BuildSetting, 0, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		out = append(out, debug.BuildSetting{Key: kv[i], Value: kv[i+1]})
+	}
+
+	return out
+}
+
+// buildInfo is a small constructor for a [debug.BuildInfo] test double.
+func buildInfo(mainVersion, goVersion string, s []debug.BuildSetting) *debug.BuildInfo {
+	bi := &debug.BuildInfo{GoVersion: goVersion, Settings: s} //nolint:exhaustruct // only fields under test.
+	bi.Main.Version = mainVersion
+
+	return bi
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                        string
+		ldVersion, ldCommit, ldDate string
+		bi                          *debug.BuildInfo
+		goVersion, goos, goarch     string
+		want                        Info
+	}{
+		{
+			name:      "ldflags release (commit truncated, dirty ignored on ldflags path)",
+			ldVersion: "1.0.0",
+			ldCommit:  "1a2b3c4d5e6f7a8b",
+			ldDate:    "2026-06-24T10:30:00Z",
+			bi:        buildInfo("(devel)", "go1.24.0", settings("vcs.modified", "true")),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "1.0.0",
+				Commit:    "1a2b3c4d5e6f",
+				Date:      "2026-06-24T10:30:00Z",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "ldflags version with leading v is stripped",
+			ldVersion: "v1.2.3",
+			ldCommit:  "abc123",
+			ldDate:    "2026-01-01T00:00:00Z",
+			bi:        nil,
+			goVersion: "go1.24.0",
+			goos:      "darwin",
+			goarch:    "arm64",
+			want: Info{
+				Version:   "1.2.3",
+				Commit:    "abc123",
+				Date:      "2026-01-01T00:00:00Z",
+				GoVersion: "go1.24.0",
+				Platform:  "darwin/arm64",
+			},
+		},
+		{
+			name:      "go install module version, no vcs settings",
+			ldVersion: "",
+			ldCommit:  "",
+			ldDate:    "",
+			bi:        buildInfo("v1.0.0", "go1.24.0", nil),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "1.0.0",
+				Commit:    "none",
+				Date:      "unknown",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "local dirty build: (devel) -> dev, vcs revision truncated + dirty",
+			ldVersion: "dev",
+			ldCommit:  "",
+			bi: buildInfo("(devel)", "go1.24.0", settings(
+				"vcs.revision", "9f8e7d6c5b4a3210fedcba9876543210deadbeef",
+				"vcs.time", "2026-06-23T22:05:00Z",
+				"vcs.modified", "true",
+			)),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "dev",
+				Commit:    "9f8e7d6c5b4a+dirty",
+				Date:      "2026-06-23T22:05:00Z",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "local clean build: vcs.modified false -> no dirty suffix",
+			ldVersion: "",
+			ldCommit:  "",
+			bi: buildInfo("(devel)", "go1.24.0", settings(
+				"vcs.revision", "9f8e7d6c5b4a3210fedcba9876543210deadbeef",
+				"vcs.modified", "false",
+			)),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "dev",
+				Commit:    "9f8e7d6c5b4a",
+				Date:      "unknown",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "revision present, vcs.modified absent entirely -> no dirty, date from vcs.time",
+			ldVersion: "",
+			ldCommit:  "",
+			bi: buildInfo("(devel)", "go1.24.0", settings(
+				"vcs.revision", "0123456789abcdef0123456789abcdef01234567",
+				"vcs.time", "2026-05-01T00:00:00Z",
+			)),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "dev",
+				Commit:    "0123456789ab",
+				Date:      "2026-05-01T00:00:00Z",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "ldCommit set + vcs.modified true -> bare ldCommit, NO dirty (gating pinned)",
+			ldVersion: "2.0.0",
+			ldCommit:  "feedface0000111122223333444455556666",
+			bi:        buildInfo("(devel)", "go1.24.0", settings("vcs.modified", "true")),
+			goVersion: "go1.24.0",
+			goos:      "linux",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "2.0.0",
+				Commit:    "feedface0000",
+				Date:      "unknown",
+				GoVersion: "go1.24.0",
+				Platform:  "linux/amd64",
+			},
+		},
+		{
+			name:      "empty ldVersion + nil build info -> dev/none/unknown, goVersion fallback",
+			ldVersion: "",
+			ldCommit:  "",
+			ldDate:    "",
+			bi:        nil,
+			goVersion: "go1.24.0",
+			goos:      "windows",
+			goarch:    "amd64",
+			want: Info{
+				Version:   "dev",
+				Commit:    "none",
+				Date:      "unknown",
+				GoVersion: "go1.24.0",
+				Platform:  "windows/amd64",
+			},
+		},
+		{
+			name:      "non-nil build info with empty GoVersion -> passed goVersion",
+			ldVersion: "3.1.4",
+			ldCommit:  "cafe",
+			ldDate:    "2026-03-14T00:00:00Z",
+			bi:        buildInfo("(devel)", "", nil),
+			goVersion: "go1.99.0",
+			goos:      "linux",
+			goarch:    "arm64",
+			want: Info{
+				Version:   "3.1.4",
+				Commit:    "cafe",
+				Date:      "2026-03-14T00:00:00Z",
+				GoVersion: "go1.99.0",
+				Platform:  "linux/arm64",
+			},
+		},
+		{
+			name:      "settings present but queried keys absent -> commit none, date unknown",
+			ldVersion: "", ldCommit: "",
+			bi:        buildInfo("(devel)", "go1.24.0", settings("GOOS", "linux", "GOARCH", "amd64")),
+			goVersion: "go1.24.0", goos: "linux", goarch: "amd64",
+			want: Info{Version: "dev", Commit: "none", Date: "unknown", GoVersion: "go1.24.0", Platform: "linux/amd64"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Resolve(tc.ldVersion, tc.ldCommit, tc.ldDate, tc.bi, tc.goVersion, tc.goos, tc.goarch)
+			if got != tc.want {
+				t.Errorf("Resolve()\n got = %+v\nwant = %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	t.Parallel()
+
+	info := Info{
+		Version:   "1.0.0",
+		Commit:    "1a2b3c4d5e6f",
+		Date:      "2026-06-24T10:30:00Z",
+		GoVersion: "go1.24.0",
+		Platform:  "linux/amd64",
+	}
+
+	want := "cynative 1.0.0\n" +
+		"  commit:   1a2b3c4d5e6f\n" +
+		"  built:    2026-06-24T10:30:00Z\n" +
+		"  go:       go1.24.0\n" +
+		"  platform: linux/amd64"
+
+	if got := info.String(); got != want {
+		t.Errorf("String()\n got = %q\nwant = %q", got, want)
+	}
+}

--- a/internal/version/version_shell.go
+++ b/internal/version/version_shell.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+// version, commit, and date are stamped at link time via `-ldflags -X` (goreleaser
+// for releases). They are immutable after link; declared as vars only because -X can
+// patch only package-level string vars.
+//
+//nolint:gochecknoglobals // link-time build stamps set via -ldflags -X; never mutated at runtime.
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
+
+// Get reads the runtime build info and resolves the build metadata. [debug.ReadBuildInfo]
+// returns (nil, false) together, so the ok bool is discarded — a nil bi already
+// encodes "no build info" for Resolve.
+func Get() Info {
+	bi, _ := debug.ReadBuildInfo()
+
+	return Resolve(version, commit, date, bi, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/version/version_shell_test.go
+++ b/internal/version/version_shell_test.go
@@ -1,0 +1,28 @@
+package version_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cynative/cynative/internal/version"
+)
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	info := version.Get()
+
+	if info.Version == "" {
+		t.Error("Version must not be empty (defaults to \"dev\" under go test)")
+	}
+	if info.GoVersion == "" {
+		t.Error("GoVersion must not be empty")
+	}
+	if !strings.Contains(info.Platform, "/") {
+		t.Errorf("Platform = %q, want a goos/goarch form", info.Platform)
+	}
+	// String must render without panicking and start with the wordmark prefix.
+	if !strings.HasPrefix(info.String(), "cynative ") {
+		t.Errorf("String() = %q, want it to start with \"cynative \"", info.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `cynative --version` flag that prints full build metadata (version, commit, build date, Go version, platform) and exits — **without loading config or credentials**, so it works on a fresh install with no API key.

## What changed

- **New `internal/version` leaf package** (stdlib-only): a pure, 100%-covered core (`Resolve`/`Info`/`String`/`shortCommit`) split from a thin shell (`version_shell.go`: the `-ldflags -X` build-stamp vars + `Get()`).
- **cli wiring**: a `version` field on the `deps` struct; `rootCmd.Version` + `SetVersionTemplate("{{.Version}}\n")` in `NewRootCmd` (cobra's `--version` short-circuits before `PersistentPreRunE`/`ValidateArgs`); `version.Get().String()` resolved once in the `newDeps` composition root.
- **goreleaser**: explicit `ldflags` now target the package's stamp vars — the prior default `-X main.version=…` landed nowhere (`package main` declared no such var).
- **README**: documents the flag.

## Output

Release binary / `go install …@vX` (clean):

```
$ cynative --version
cynative 1.0.0
  commit:   1a2b3c4d5e6f
  built:    2026-06-24T10:30:00Z
  go:       go1.24.0
  platform: linux/amd64
```

## Design notes

- **No `-V` shorthand; `--version` is long-only.** `--verbose`/`-v` is registered first, so cobra's `InitDefaultVersionFlag` sees `-v` taken and gives `--version` no shorthand — locked by a regression test. (Grounded in a survey of cobra/clap/curl/clig.dev conventions: lowercase `-v` = verbose is the dominant split.)
- **Local `go build` shows a VCS pseudo-version** (e.g. `1.0.1-0.…-c365b73d05c2+dirty`) rather than literally `dev`, because Go 1.24+ derives the main-module version from the latest tag. Accepted by design (informative for bug reports); release/`go install` builds are unaffected.

## Verification

- `make check` green: lint, shell-complexity, format, tests under `-race -shuffle=on`, **100% core coverage** (`internal/version` at 100.0%).
- Smoke tests: simulated release ldflags build prints clean output (commit truncated to 12 chars); `--version` works with empty `HOME`/no provider env; `--version extra args` exits 0; `-v` remains `--verbose`.
