### PR TITLE
fix: use bare :monterey symbol in Homebrew depends_on macos

### DIFF
--- a/scripts/release/render-formula.sh
+++ b/scripts/release/render-formula.sh
@@ -16,7 +16,9 @@ class Cynative < Formula
   on_macos do
     # cynative is built with Go 1.26, whose macOS floor is 12 (Monterey), so gate
     # installs there — unsupported hosts fail before downloading an unrunnable binary.
-    depends_on macos: ">= :monterey"
+    # A bare symbol means ">= that release"; the ">= :monterey" string form is
+    # deprecated and errors on current brew ("unknown or unsupported macOS version").
+    depends_on macos: :monterey
 
     on_arm do
       url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_arm64.tar.gz"


### PR DESCRIPTION
## Problem

`brew install cynative/tap/cynative` fails before it even downloads:

```
Error: cynative/tap/cynative: unknown or unsupported macOS version: ">= :monterey"
```

`render-formula.sh` emits `depends_on macos: ">= :monterey"`. The string-comparator form is deprecated; current Homebrew passes the whole literal (including `>= `) to its macOS-version lookup, which has no such symbol, so the formula fails at parse time.

## Fix

Use the canonical bare symbol — `depends_on macos: :monterey`. A bare symbol already means ">= that release" (comparator defaults to `>=`), so this keeps the intended Go 1.26 / macOS 12 (Monterey) floor and is the form homebrew-core uses.

Verified: the rendered formula passes `ruby -c` and `depends_on macos: :monterey`.

The already-published v1.4.0 formula in `cynative/homebrew-tap` was patched directly (same version, same checksums) so installs work immediately; this PR fixes the generator so every future release renders the valid form.