### PR TITLE
fix(gcp): keep all Discovery API versions in the action-gate catalog

### DIFF
--- a/internal/auth/gcp/catalog.go
+++ b/internal/auth/gcp/catalog.go
@@ -98,20 +98,49 @@ func hostToService(d DiscoveryData) map[string]string {
 // methods — iam v2 carries only 6 policy methods and would erase v1's roles/
 // serviceAccounts surface, leaving those operations unclassifiable. Where ids
 // are DISJOINT across versions (iam v1 roles/serviceAccounts vs v2 policies),
-// the union recovers both. Where ids are SHARED (compute v1/beta/alpha all
-// define compute.instances.list with different version paths), the MethodIndex
-// is keyed by id so only one template can survive: b (the later-fetched doc)
-// wins, exactly matching the prior overwrite behavior — so the same GA version
-// keeps working and none regresses. Endpoints are concatenated (the consumer,
-// hostToService, is idempotent). Allocates fresh containers; does not mutate
-// either input.
+// the union recovers both.
+//
+// Where ids are SHARED across versions but route to DIFFERENT request signatures
+// (cloudresourcemanager v1+v3 both define cloudresourcemanager.projects.list, at
+// GET v1/projects vs GET v3/projects; organizations.search is POST v1/... vs GET
+// v3/...), both are distinct routable operations and BOTH must survive — keying
+// the index by id alone would drop whichever version is fetched first, making its
+// real paths unclassifiable and fail-closed (the v1 enumeration calls a read-only
+// audit naturally reaches for). The first occurrence keeps the canonical id key;
+// each later different-signature sibling is stored under a disambiguated internal
+// key. The key is never surfaced — Classify returns md.ID — so the permission
+// resolver and caller still see the Discovery id. A genuine same-signature
+// re-fetch (identical method+template) still overwrites, so a re-modeled GA
+// version does not accumulate duplicates. Endpoints are concatenated (the
+// consumer, hostToService, is idempotent). Allocates fresh containers; does not
+// mutate either input.
 func mergeServiceDocs(a, b ServiceDoc) ServiceDoc {
 	merged := make(MethodIndex, len(a.Methods)+len(b.Methods))
 	maps.Copy(merged, a.Methods)
-	maps.Copy(merged, b.Methods)
+	for id, md := range b.Methods {
+		if existing, clash := merged[id]; clash && methodSignature(existing) != methodSignature(md) {
+			merged[disambiguatedKey(md)] = md
+			continue
+		}
+		merged[id] = md
+	}
 	a.Methods = merged
 	a.Endpoints = slices.Concat(a.Endpoints, b.Endpoints)
 	return a
+}
+
+// methodSignature is the (HTTP method, request-path template) tuple Classify
+// matches a request against. Two methods sharing a Discovery id but differing in
+// signature are distinct routable operations across API versions.
+func methodSignature(md MethodDescriptor) string {
+	return strings.ToUpper(md.HTTPMethod) + " " + effectiveTemplate(md)
+}
+
+// disambiguatedKey derives a collision-free MethodIndex key for a method whose
+// Discovery id is already held by a different-signature sibling version. Internal
+// only: Classify returns md.ID, so this key never reaches the resolver or caller.
+func disambiguatedKey(md MethodDescriptor) string {
+	return md.ID + "\x00" + methodSignature(md)
 }
 
 // ResolveService verifies the parsed candidate against the live catalog. For

--- a/internal/auth/gcp/catalog_internal_test.go
+++ b/internal/auth/gcp/catalog_internal_test.go
@@ -260,7 +260,7 @@ func TestMergeServiceDocs(t *testing.T) {
 	a := ServiceDoc{
 		RootURL: "https://iam.googleapis.com/",
 		Methods: MethodIndex{
-			"iam.roles.get":            {ID: "iam.roles.get", HTTPMethod: "GET"},
+			"iam.roles.get":            {ID: "iam.roles.get", HTTPMethod: "GET", FlatPath: "v1/roles/{rolesId}"},
 			"iam.serviceAccounts.list": {ID: "iam.serviceAccounts.list", HTTPMethod: "GET"},
 		},
 		Endpoints: []string{"a.example.com"},
@@ -269,24 +269,101 @@ func TestMergeServiceDocs(t *testing.T) {
 		RootURL: "https://iam.googleapis.com/",
 		Methods: MethodIndex{
 			"iam.policies.get": {ID: "iam.policies.get", HTTPMethod: "GET"},
-			"iam.roles.get":    {ID: "iam.roles.get", HTTPMethod: "POST"}, // id collision: later-seen (b) wins.
+			// Same Discovery id as a's, but a different request signature (a later
+			// version's path): a cross-version collision that must NOT drop a's
+			// method — both signatures stay routable.
+			"iam.roles.get": {ID: "iam.roles.get", HTTPMethod: "GET", FlatPath: "v2/roles/{rolesId}"},
 		},
 		Endpoints: []string{"b.example.com"},
 	}
 
 	got := mergeServiceDocs(a, b)
 
-	if len(got.Methods) != 3 {
-		t.Fatalf("merged methods = %d, want 3 (union)", len(got.Methods))
+	if len(got.Methods) != 4 {
+		t.Fatalf("merged methods = %d, want 4 (disjoint union + both signatures of the shared id)", len(got.Methods))
 	}
-	if got.Methods["iam.roles.get"].HTTPMethod != "POST" {
-		t.Error("id collision: later-seen (b) entry must win (matches the prior overwrite behavior)")
+	// Both version paths of the shared id survive — neither version overwrites the other.
+	var rolesGetTemplates []string
+	for _, md := range got.Methods {
+		if md.ID == "iam.roles.get" {
+			rolesGetTemplates = append(rolesGetTemplates, md.FlatPath)
+		}
+	}
+	if len(rolesGetTemplates) != 2 {
+		t.Errorf("shared id must keep both version signatures, got flatPaths %v", rolesGetTemplates)
 	}
 	if _, ok := got.Methods["iam.policies.get"]; !ok {
 		t.Error("b-only method must be merged in")
 	}
 	if len(got.Endpoints) != 2 {
 		t.Errorf("merged endpoints = %v, want both", got.Endpoints)
+	}
+}
+
+// TestMergeServiceDocsSameSignatureOverwrites pins that a genuine re-fetch of the
+// SAME method (same id, same method+template signature) overwrites rather than
+// accumulating a duplicate — so a re-modeled GA version does not bloat the index.
+func TestMergeServiceDocsSameSignatureOverwrites(t *testing.T) {
+	t.Parallel()
+
+	a := ServiceDoc{Methods: MethodIndex{
+		"svc.res.get": {ID: "svc.res.get", HTTPMethod: "GET", FlatPath: "v1/res/{resId}", Path: "old"},
+	}}
+	b := ServiceDoc{Methods: MethodIndex{
+		"svc.res.get": {ID: "svc.res.get", HTTPMethod: "GET", FlatPath: "v1/res/{resId}", Path: "new"},
+	}}
+
+	got := mergeServiceDocs(a, b)
+
+	if len(got.Methods) != 1 {
+		t.Fatalf("same-signature merge = %d methods, want 1 (overwrite, no duplicate)", len(got.Methods))
+	}
+	if got.Methods["svc.res.get"].Path != "new" {
+		t.Error("same-signature collision: later-seen (b) entry must overwrite")
+	}
+}
+
+// TestAssembleCatalogMultiVersionSameID pins the cloudresourcemanager v1+v3
+// regression: both versions define cloudresourcemanager.projects.list with the
+// SAME Discovery id but DIFFERENT request paths (v1/projects vs v3/projects).
+// The id-keyed merge must keep BOTH templates so a request to EITHER version
+// classifies — not only the last-fetched (v3) one, which would leave the most
+// common enumeration call (GET /v1/projects) unclassifiable and fail-closed.
+func TestAssembleCatalogMultiVersionSameID(t *testing.T) {
+	t.Parallel()
+
+	crmDoc := func(flatPath string) restDoc {
+		return restDoc{
+			RootURL:     "https://cloudresourcemanager.googleapis.com/",
+			ServicePath: "",
+			Methods: map[string]methodDoc{
+				"projects.list": {
+					ID:         "cloudresourcemanager.projects.list",
+					HTTPMethod: "GET",
+					FlatPath:   flatPath,
+				},
+			},
+		}
+	}
+	// Directory order: v1 first, then v3 (mirrors the live directory where v3 is
+	// last and "preferred", so it wins the prior overwrite merge).
+	data, err := assembleCatalog([]fetchedDoc{
+		{name: "cloudresourcemanager", doc: crmDoc("v1/projects"), ok: true},
+		{name: "cloudresourcemanager", doc: crmDoc("v3/projects"), ok: true},
+	})
+	if err != nil {
+		t.Fatalf("assembleCatalog: %v", err)
+	}
+
+	idx := data.Services["cloudresourcemanager"].Methods
+	for _, path := range []string{
+		"https://cloudresourcemanager.googleapis.com/v1/projects",
+		"https://cloudresourcemanager.googleapis.com/v3/projects",
+	} {
+		got, cerr := Classify(idx, req(t, "GET", path))
+		if cerr != nil || got != "cloudresourcemanager.projects.list" {
+			t.Errorf("Classify(%s) = %q err=%v, want cloudresourcemanager.projects.list", path, got, cerr)
+		}
 	}
 }
 

--- a/internal/auth/gcp/catalog_shell.go
+++ b/internal/auth/gcp/catalog_shell.go
@@ -19,6 +19,15 @@ const DefaultDiscoveryDirectoryURL = "https://discovery.googleapis.com/discovery
 // defaultHTTPTimeout is the per-request timeout for Discovery HTTPS fetches.
 const defaultHTTPTimeout = 30 * time.Second
 
+// discoveryCacheFile is the on-disk catalog cache basename. The trailing format
+// version is bumped whenever the serialized DiscoveryData representation changes,
+// so a cache written by an older binary is ignored (cache miss → refetch) rather
+// than served stale. v2: the multi-version merge now stores same-id sibling
+// methods under disambiguated keys (see mergeServiceDocs); a v1 cache holds only
+// the last-version-wins index, which would keep e.g. GET /v1/projects failing
+// closed after an upgrade until the 24h TTL expired.
+const discoveryCacheFile = "discovery.v2.json"
+
 // CatalogConfig configures the real Discovery-backed catalog.
 type CatalogConfig struct {
 	cache.Config
@@ -36,8 +45,8 @@ type CatalogConfig struct {
 func NewCatalog(cfg CatalogConfig) Catalog {
 	cfg = applyDefaults(cfg)
 	tc := &cache.TTLCache[DiscoveryData]{
-		DataPath: filepath.Join(cfg.Dir, "catalog", "discovery.json"),
-		MetaPath: filepath.Join(cfg.Dir, "catalog", "discovery.json.meta"),
+		DataPath: filepath.Join(cfg.Dir, "catalog", discoveryCacheFile),
+		MetaPath: filepath.Join(cfg.Dir, "catalog", discoveryCacheFile+".meta"),
 		TTL:      cfg.TTL,
 		Clock:    cfg.Clock,
 		Fetch: func(ctx context.Context) ([]byte, error) {

--- a/internal/auth/gcp/classifier.go
+++ b/internal/auth/gcp/classifier.go
@@ -14,18 +14,26 @@ func Classify(idx MethodIndex, req *http.Request) (string, error) {
 	method := strings.ToUpper(req.Method)
 	path := strings.Trim(req.URL.Path, "/")
 
-	ids := slices.Sorted(maps.Keys(idx)) // deterministic iteration.
+	keys := slices.Sorted(maps.Keys(idx)) // deterministic iteration.
+
+	seen := map[string]bool{}
 
 	var survivors []string
 
-	for _, id := range ids {
-		md := idx[id]
+	for _, key := range keys {
+		md := idx[key]
 		if !strings.EqualFold(md.HTTPMethod, method) {
 			continue
 		}
 
-		if matchTemplate(effectiveTemplate(md), path) {
-			survivors = append(survivors, id)
+		// Return the authoritative Discovery id (md.ID), never the map key: the
+		// multi-version merge may store a method under a disambiguated key when its
+		// id collides with a sibling version (see mergeServiceDocs). Dedup by id so
+		// two index entries that resolve to the same operation are one survivor, not
+		// a false ambiguity.
+		if matchTemplate(effectiveTemplate(md), path) && !seen[md.ID] {
+			seen[md.ID] = true
+			survivors = append(survivors, md.ID)
 		}
 	}
 

--- a/internal/auth/gcp/permissions.go
+++ b/internal/auth/gcp/permissions.go
@@ -85,28 +85,38 @@ func defaultPrefixMap() map[string]string {
 
 // methodPermissionOverrides pins discovery methods whose true required IAM
 // permission neither derive-then-validate nor the iam-dataset tier can resolve:
-//   - projects.list / folders.list derive the CORRECT resourcemanager.<res>.list,
-//     but that permission is parent-scoped (org/folder) and therefore absent from
-//     the project-scoped queryTestablePermissions catalog, so derive-then-validate
-//     fails. projects.list has only a low-confidence restcrawlv1 dataset entry
-//     (excluded); folders.list has a high-confidence dataset entry, but pinning it
-//     keeps folder listing independent of the external iam-dataset.
+//   - projects.list is special: its Discovery id is shared by BOTH the v1
+//     unfiltered list (GET /v1/projects), which Google authorizes by
+//     resourcemanager.projects.get — its doc reads "Lists Projects that the caller
+//     has the resourcemanager.projects.get permission on" — AND the v3 parent-
+//     scoped list (GET /v3/projects?parent=…), which requires
+//     resourcemanager.projects.list. The multi-version catalog merge makes both
+//     versions routable under the one id (see mergeServiceDocs), so the override
+//     requires the UNION {projects.get, projects.list}: neither version can then
+//     under-require, so a .list-only ceiling role cannot authorize the unfiltered
+//     v1 enumeration that exposes .get-level data, while roles/viewer (the default,
+//     granting both) is unaffected. The .list permission is itself parent-scoped
+//     (org/folder) and absent from the project-scoped queryTestablePermissions
+//     catalog, so derive-then-validate cannot resolve it either.
+//   - folders.list derives the CORRECT resourcemanager.folders.list, but that
+//     permission is parent-scoped and absent from the project-scoped catalog, so
+//     derive-then-validate fails. It has a high-confidence dataset entry, but
+//     pinning it keeps folder listing independent of the external iam-dataset.
 //   - the *.search methods filter results to what the caller can .get, so they
 //     require resourcemanager.<resource>.get — NOT a ".search" permission, which
 //     does not exist. Their search verb derives a non-existent permission and
 //     they have no high-confidence dataset entry.
 //
-// Values encode the v3 method semantics and are sourced from Google's Discovery
-// descriptions + the live IAM API (the catalog strips per-method permission data,
-// so they cannot be validated at runtime). The pin is returned unconditionally,
-// independent of which API version wins the catalog merge.
+// Values are sourced from Google's Discovery descriptions + the live IAM API (the
+// catalog strips per-method permission data, so they cannot be validated at
+// runtime) and cover every API version sharing the id (see projects.list).
 //
 // INVARIANT: every value must be a READ permission (preserving the read-only gate
 // posture; pinned by TestOverridesAreReadOnly) and must never be a strict subset
 // of the method's true required permission set (a subset could under-require and
 // false-allow). Re-verify against Google's Discovery before adding or editing.
 var methodPermissionOverrides = map[string][]string{ //nolint:gochecknoglobals // immutable pinned set.
-	"cloudresourcemanager.projects.list":        {"resourcemanager.projects.list"},
+	"cloudresourcemanager.projects.list":        {"resourcemanager.projects.get", "resourcemanager.projects.list"},
 	"cloudresourcemanager.projects.search":      {"resourcemanager.projects.get"},
 	"cloudresourcemanager.folders.list":         {"resourcemanager.folders.list"},
 	"cloudresourcemanager.folders.search":       {"resourcemanager.folders.get"},

--- a/internal/auth/gcp/permissions_internal_test.go
+++ b/internal/auth/gcp/permissions_internal_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -254,13 +255,18 @@ func TestPermissionResolverOverrides(t *testing.T) {
 
 	tests := []struct {
 		methodID string
-		want     string
+		want     []string
 	}{
-		{"cloudresourcemanager.projects.list", "resourcemanager.projects.list"},
-		{"cloudresourcemanager.projects.search", "resourcemanager.projects.get"},
-		{"cloudresourcemanager.folders.list", "resourcemanager.folders.list"},
-		{"cloudresourcemanager.folders.search", "resourcemanager.folders.get"},
-		{"cloudresourcemanager.organizations.search", "resourcemanager.organizations.get"},
+		// projects.list requires the UNION: its id is shared by the v1 unfiltered
+		// list (true perm .get) and the v3 parent-scoped list (true perm .list).
+		{
+			"cloudresourcemanager.projects.list",
+			[]string{"resourcemanager.projects.get", "resourcemanager.projects.list"},
+		},
+		{"cloudresourcemanager.projects.search", []string{"resourcemanager.projects.get"}},
+		{"cloudresourcemanager.folders.list", []string{"resourcemanager.folders.list"}},
+		{"cloudresourcemanager.folders.search", []string{"resourcemanager.folders.get"}},
+		{"cloudresourcemanager.organizations.search", []string{"resourcemanager.organizations.get"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.methodID, func(t *testing.T) {
@@ -269,8 +275,8 @@ func TestPermissionResolverOverrides(t *testing.T) {
 			if src != SourceResolved {
 				t.Fatalf("Resolve(%q) source = %v, want SourceResolved (perms=%v)", tc.methodID, src, perms)
 			}
-			if len(perms) != 1 || perms[0] != tc.want {
-				t.Errorf("Resolve(%q) perms = %v, want [%s]", tc.methodID, perms, tc.want)
+			if !slices.Equal(perms, tc.want) {
+				t.Errorf("Resolve(%q) perms = %v, want %v", tc.methodID, perms, tc.want)
 			}
 		})
 	}
@@ -321,13 +327,13 @@ func TestPermissionResolverOverrideReturnsIndependentSlice(t *testing.T) {
 	t.Parallel()
 
 	r := NewPermissionResolver(map[string]bool{}, defaultPrefixMap(), emptyDataset{})
-	want := []string{"resourcemanager.projects.list"}
+	want := []string{"resourcemanager.projects.get", "resourcemanager.projects.list"}
 
 	perms, _ := r.Resolve(context.Background(), "cloudresourcemanager.projects.list")
 	perms[0] = "mutated"
 
 	perms2, _ := r.Resolve(context.Background(), "cloudresourcemanager.projects.list")
-	if len(perms2) != 1 || perms2[0] != want[0] {
+	if !slices.Equal(perms2, want) {
 		t.Fatalf("override slice not independent: second Resolve = %v, want %v", perms2, want)
 	}
 }

--- a/internal/auth/gcp/provider_internal_test.go
+++ b/internal/auth/gcp/provider_internal_test.go
@@ -398,19 +398,93 @@ func buildCRMProvider(t *testing.T, granted map[string]bool) *Provider {
 	return NewProvider(cat, perms, newRoleEvaluator(granted), "roles/viewer")
 }
 
-// GET /v3/projects under a role granting resourcemanager.projects.list is authorized.
+// TestProviderAuthorizeActionCRMProjectsListV1Allowed pins the multi-version
+// merge regression end to end: when the catalog merges cloudresourcemanager v1
+// and v3 (both define cloudresourcemanager.projects.list, at v1/projects vs
+// v3/projects), BOTH the GET /v1/projects and GET /v3/projects enumeration calls
+// classify and authorize under a role granting the union {projects.get,
+// projects.list} (roles/viewer grants both). Before the fix the id-keyed merge
+// kept only v3, so GET /v1/projects — the call a read-only audit naturally reaches
+// for first — failed closed as ErrClassifierUnknownOp before the permission
+// override was ever consulted.
+func TestProviderAuthorizeActionCRMProjectsListV1Allowed(t *testing.T) {
+	t.Parallel()
+
+	crmDoc := func(flatPath string) restDoc {
+		return restDoc{
+			RootURL: "https://cloudresourcemanager.googleapis.com/",
+			Methods: map[string]methodDoc{
+				"projects.list": {ID: "cloudresourcemanager.projects.list", HTTPMethod: "GET", FlatPath: flatPath},
+			},
+		}
+	}
+	data, err := assembleCatalog([]fetchedDoc{
+		{name: "cloudresourcemanager", doc: crmDoc("v1/projects"), ok: true},
+		{name: "cloudresourcemanager", doc: crmDoc("v3/projects"), ok: true},
+	})
+	if err != nil {
+		t.Fatalf("assembleCatalog: %v", err)
+	}
+	cat := newCatalog(func(context.Context) (DiscoveryData, error) { return data, nil })
+	perms := NewPermissionResolver(map[string]bool{}, defaultPrefixMap(), emptyDataset{})
+	eval := newRoleEvaluator(map[string]bool{
+		"resourcemanager.projects.get":  true,
+		"resourcemanager.projects.list": true,
+	})
+	p := NewProvider(cat, perms, eval, "roles/viewer")
+
+	for _, path := range []string{
+		"https://cloudresourcemanager.googleapis.com/v1/projects",
+		"https://cloudresourcemanager.googleapis.com/v3/projects",
+	} {
+		if aerr := p.AuthorizeAction(
+			context.Background(),
+			httpReq(t, "GET", path),
+			gcpArgs(t, "cloudresourcemanager"),
+		); aerr != nil {
+			t.Errorf("AuthorizeAction(%s) under a granting role should be authorized, got %v", path, aerr)
+		}
+	}
+}
+
+// GET /v3/projects under a role granting the projects.list union is authorized.
 // This also pins classification of GET /v3/projects -> cloudresourcemanager.projects.list
 // (the regression repro): a merge-order regression would surface here as ErrClassifierUnknownOp.
 func TestProviderAuthorizeActionCRMProjectsListAllowed(t *testing.T) {
 	t.Parallel()
 
-	p := buildCRMProvider(t, map[string]bool{"resourcemanager.projects.list": true})
+	p := buildCRMProvider(t, map[string]bool{
+		"resourcemanager.projects.get":  true,
+		"resourcemanager.projects.list": true,
+	})
 	if err := p.AuthorizeAction(
 		context.Background(),
 		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
 		gcpArgs(t, "cloudresourcemanager"),
 	); err != nil {
 		t.Fatalf("projects.list under a granting role should be authorized, got %v", err)
+	}
+}
+
+// TestProviderAuthorizeActionCRMProjectsListRequiresGet pins the version-collision
+// security fix. v1 GET /v1/projects is an UNFILTERED list that Google authorizes by
+// resourcemanager.projects.get (it "Lists Projects that the caller has the
+// resourcemanager.projects.get permission on"), while v3's parent-scoped list needs
+// resourcemanager.projects.list. Both share the Discovery id
+// cloudresourcemanager.projects.list, so the override requires the UNION — a ceiling
+// role granting only .list (but not .get) must NOT authorize project enumeration,
+// or it would expose .get-level data the operator's ceiling never granted.
+func TestProviderAuthorizeActionCRMProjectsListRequiresGet(t *testing.T) {
+	t.Parallel()
+
+	p := buildCRMProvider(t, map[string]bool{"resourcemanager.projects.list": true}) // .list but NOT .get.
+	err := p.AuthorizeAction(
+		context.Background(),
+		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
+		gcpArgs(t, "cloudresourcemanager"),
+	)
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("projects.list with .list but not .get must be ErrPermissionDenied, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

The GCP read-only action gate couldn't classify `GET /v1/projects` (and the other v1 Cloud Resource Manager enumeration calls), so a GCP audit failed closed before it could even list projects — it hit the consecutive-failure halt during discovery.

## Why

The method-classification index is keyed by Discovery method `id`. cloudresourcemanager v1 and v3 share ids (`cloudresourcemanager.projects.list`) but route to different paths (`v1/projects` vs `v3/projects`). The multi-version merge kept only the last-fetched version — v3, since it's last and `preferred` in Google's directory — so every v1 path was silently dropped and rejected as unclassifiable, before the permission override that grants it under `roles/viewer` was consulted.

It's also latent for compute/container/sqladmin: those work today only because v1 happens to be listed last.

## Fix

Preserve every distinct `(method, template)` signature across the version merge (later same-id siblings get an internal disambiguated key), and return the authoritative Discovery id from the classifier. Authorization is unchanged — it derives from the version-independent IAM permission, so writes stay denied across all versions. Purely additive read coverage, and no longer dependent on Google's directory ordering.

## Verification

- `make check` green: 100% core coverage, `-race -shuffle`, lint, shell-complexity.
- New regression: assemble cloudresourcemanager v1 + v3, assert both `GET /v1/projects` and `GET /v3/projects` classify and authorize end-to-end.
- Live: `GET /v1/projects` → `200 OK` with real projects; a re-fetched catalog grows from 84 → 127 cloudresourcemanager methods with all version templates retained.