### PR TITLE
feat(install): add CYNATIVE_BASE_URL test seam to install.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ All targets are wired through `make`. Lint and test rely on `go tool golangci-li
 
 - `make check` — the full gate CI runs: `check-go` + `check-scripts`.
 - `make check-go` — generate + lint + shell-complexity + format-diff + test + `windows-build` (GOOS=windows amd64/arm64 cross-compile); 100% `go.mod`-pinned/hermetic; **the pre-commit hook runs this**.
-- `make check-scripts` — `shellcheck` (all tracked `*.sh`, pinned `v0.11.0`) + PSScriptAnalyzer on `install.ps1` + Pester unit tests (pinned `1.25.0`/`5.7.1`). Install-free: asserts each pinned tool/module is present and fails with an install hint otherwise (needs `shellcheck` + PowerShell 7). These external tool versions are pinned in the `Makefile` and bumped by hand — Dependabot has no PowerShell Gallery or raw-binary ecosystem.
+- `make check-scripts` — `shellcheck` (all tracked `*.sh`, pinned `v0.11.0`) + PSScriptAnalyzer on `install.ps1` + Pester unit tests (pinned `1.25.0`/`5.7.1`) + `sh-test` (the POSIX `install.sh` unit tests plus a `python3`-backed loopback fixture-server smoke test that exercises the `CYNATIVE_BASE_URL` download-base seam end-to-end and its non-loopback-HTTP reject). Install-free: asserts each pinned tool/module is present and fails with an install hint otherwise (needs `shellcheck` + PowerShell 7 + `python3`). The pinned PowerShell/shellcheck versions are set in the `Makefile` and bumped by hand — Dependabot has no PowerShell Gallery or raw-binary ecosystem.
 - `make generate` — `go generate ./...` (regenerates the `moq` mocks).
 - `make lint` — `go tool golangci-lint run`.
 - `make format` — `go tool golangci-lint fmt --diff` (prints diffs; does not write).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ board.
 - `make` and a POSIX shell.
 - Go tooling (`golangci-lint`, `moq`, complexity checkers) is pinned via `go.mod`
   and invoked through `make` — no separate installs. The shell/PowerShell gate
-  (`make check-scripts`) additionally needs `shellcheck` and PowerShell 7 with
-  Pester/PSScriptAnalyzer; those versions are pinned in the `Makefile` and installed
+  (`make check-scripts`) additionally needs `shellcheck`, PowerShell 7 with
+  Pester/PSScriptAnalyzer, and `python3` (the `install.sh` loopback smoke test's
+  fixture server); those versions are pinned in the `Makefile` and installed
   separately (`make check-scripts` prints an install hint if one is missing).
 
 On a fresh checkout, generate the gitignored mocks before running package tests:
@@ -28,7 +29,8 @@ Every PR must pass `make check`, which runs two halves:
   format-diff + the full race-enabled test suite + a `GOOS=windows` cross-build);
   100% `go.mod`-pinned. **The pre-commit hook runs this.**
 - `make check-scripts` — `shellcheck` over every tracked `*.sh`, PSScriptAnalyzer on
-  `install.ps1`, and the Pester unit tests, each at a version pinned in the `Makefile`.
+  `install.ps1`, the Pester unit tests, and the POSIX `install.sh` unit + loopback smoke
+  tests (`sh-test`, which needs `python3`), each at a version pinned in the `Makefile`.
 
 ```bash
 make check

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: check check-go check-scripts lint format test generate shell-complexity \
-	windows-build shellcheck pwsh-lint pwsh-test
+	windows-build shellcheck pwsh-lint pwsh-test sh-test
 
 # Pinned external (non-Go) tool versions for check-scripts. Unlike the Go tools
 # (pinned via go.mod / `go tool`), these are NOT Dependabot-managed — Dependabot has
@@ -19,7 +19,7 @@ check-go: generate lint shell-complexity format test windows-build
 
 # Non-Go, system-tool checks. Install-free: each target asserts its pinned tool /
 # module version is present and fails with an install hint otherwise.
-check-scripts: shellcheck pwsh-lint pwsh-test
+check-scripts: shellcheck pwsh-lint pwsh-test sh-test
 
 generate:
 	go generate ./...
@@ -69,6 +69,15 @@ pwsh-lint:
 pwsh-test:
 	@command -v pwsh >/dev/null 2>&1 || { echo "FAIL: pwsh not found — install PowerShell 7 + Pester $(PESTER_VERSION)."; exit 1; }
 	pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester | Where-Object Version -eq "$(PESTER_VERSION)")) { Write-Host "FAIL: Pester $(PESTER_VERSION) not installed — run: Install-Module Pester -RequiredVersion $(PESTER_VERSION) -Scope CurrentUser -SkipPublisherCheck"; exit 1 }; Import-Module -Name Pester -RequiredVersion $(PESTER_VERSION) -Force -ErrorAction Stop; $$r = Invoke-Pester -Path test/install.unit.Tests.ps1 -Output Detailed -PassThru; if ($$r.FailedCount -gt 0) { exit 1 }'
+
+# sh-test: POSIX install.sh unit + loopback smoke tests. Presence-check python3
+# (the smoke test's loopback fixture server) with an install hint, mirroring the
+# shellcheck/pwsh install-free pattern.
+sh-test:
+	@command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 not found — needed by the install.sh loopback smoke test (test/install.smoke.test.sh)."; exit 1; }
+	@sh test/install.unit.test.sh
+	@sh test/install.smoke.test.sh
+	@echo "OK: sh-test (install.sh unit + loopback smoke)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/install.sh
+++ b/install.sh
@@ -2,24 +2,15 @@
 # cynative installer.
 #   curl -fsSL https://raw.githubusercontent.com/cynative/cynative/main/install.sh | sh
 # Env: CYNATIVE_VERSION (default: latest), CYNATIVE_INSTALL_DIR (default: ~/.local/bin),
-#      CYNATIVE_REQUIRE_ATTESTATION=1 (make a failed release-attestation check fatal).
+#      CYNATIVE_REQUIRE_ATTESTATION=1 (make a failed release-attestation check fatal),
+#      CYNATIVE_BASE_URL (download base override; https required unless loopback - for testing).
 # For high-integrity installs, fetch this script from an immutable ref instead of `main`:
 #   curl -fsSL https://raw.githubusercontent.com/cynative/cynative/<tag-or-sha>/install.sh | sh
-set -eu
 
 REPO="cynative/cynative"
 BINARY="cynative"
-INSTALL_DIR="${CYNATIVE_INSTALL_DIR:-${HOME}/.local/bin}"
 
 err() { printf 'cynative-install: %s\n' "$*" >&2; exit 1; }
-
-# Paired uninstall: `curl -fsSL .../install.sh | sh -s -- --uninstall`
-if [ "${1:-}" = "--uninstall" ]; then
-  target="$INSTALL_DIR/$BINARY"
-  if [ -e "$target" ]; then rm -f "$target" && printf 'removed %s\n' "$target" >&2
-  else printf '%s not found (nothing to remove)\n' "$target" >&2; fi
-  exit 0
-fi
 
 download() { # url -> stdout
   if command -v curl >/dev/null 2>&1; then curl -fsSL "$1"
@@ -37,67 +28,145 @@ sha256() { # file -> "<hex>  <file>"
   else err "need sha256sum or shasum"; fi
 }
 
-command -v uname >/dev/null 2>&1 || err "uname not found"
-command -v tar >/dev/null 2>&1 || err "tar not found"
-command -v mktemp >/dev/null 2>&1 || err "mktemp not found"
-
-case "$(uname -s)" in
-  Linux) OS=Linux ;;
-  Darwin) OS=Darwin ;;
-  *) err "unsupported OS '$(uname -s)' — see https://github.com/${REPO}/releases" ;;
-esac
-case "$(uname -m)" in
-  x86_64|amd64) ARCH=x86_64 ;;
-  arm64|aarch64) ARCH=arm64 ;;
-  *) err "unsupported arch '$(uname -m)' — see https://github.com/${REPO}/releases" ;;
-esac
-
-VERSION="${CYNATIVE_VERSION:-}"
-if [ -z "$VERSION" ]; then
-  VERSION=$(download "https://api.github.com/repos/${REPO}/releases/latest" \
-    | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
-  [ -n "$VERSION" ] || err "could not resolve latest release tag"
-fi
-
-ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
-BASE="https://github.com/${REPO}/releases/download/${VERSION}"
-
-tmp=$(mktemp -d) || err "mktemp failed"
-trap 'rm -rf "$tmp"' EXIT INT TERM
-
-printf 'downloading %s @ %s\n' "$ARCHIVE" "$VERSION" >&2
-download_to "${BASE}/${ARCHIVE}" "$tmp/$ARCHIVE" || err "download failed: ${BASE}/${ARCHIVE}"
-download_to "${BASE}/checksums.txt" "$tmp/checksums.txt" || err "download failed: ${BASE}/checksums.txt"
-
-matches=$(awk -v f="$ARCHIVE" '$2==f {print $1}' "$tmp/checksums.txt")
-count=$(printf '%s' "$matches" | grep -c . || true)
-[ "$count" = "1" ] || err "expected exactly one checksum entry for ${ARCHIVE}, found ${count}"
-got=$(cd "$tmp" && sha256 "$ARCHIVE" | awk '{print $1}')
-[ "$matches" = "$got" ] || err "checksum mismatch: want ${matches} got ${got}"
-
-if command -v gh >/dev/null 2>&1; then
-  if gh release verify-asset "$VERSION" "$tmp/$ARCHIVE" --repo "$REPO" >/dev/null 2>&1; then
-    printf 'attestation verified\n' >&2
-  elif [ "${CYNATIVE_REQUIRE_ATTESTATION:-0}" = "1" ]; then
-    err "attestation verification failed (CYNATIVE_REQUIRE_ATTESTATION=1)"
-  else
-    printf 'warning: attestation not verified (continuing)\n' >&2
+# --- Download-base test seam (mirrors install.ps1). ---
+url_scheme() { # url -> lowercased scheme (the whole string when there is no scheme).
+  printf '%s' "${1%%://*}" | tr '[:upper:]' '[:lower:]'
+}
+url_host() { # url -> lowercased bare host, or the raw authority when malformed (fail-closed).
+  rest=${1#*://}    # strip scheme.
+  rest=${rest%%/*}  # strip path.
+  rest=${rest##*@}  # strip userinfo.
+  case "$rest" in
+    '['*)           # IPv6 literal: require a closing ']' with only an optional :port after it.
+      inner=${rest#'['}
+      case "$inner" in
+        *']'*)
+          host=${inner%%']'*}
+          after=${inner#*']'}
+          case "$after" in ''|:*) : ;; *) host=$rest ;; esac
+          ;;
+        *) host=$rest ;;
+      esac
+      ;;
+    *) host=${rest%%:*} ;;   # strip :port.
+  esac
+  printf '%s' "$host" | tr '[:upper:]' '[:lower:]'
+}
+is_loopback_host() { # host -> 0 for localhost, ::1, or a canonical 127.0.0.0/8 address.
+  case "$1" in
+    localhost|::1) return 0 ;;
+    127.*) ;;
+    *) return 1 ;;
+  esac
+  IFS=. read -r o1 o2 o3 o4 o5 <<EOF
+$1
+EOF
+  [ -z "$o5" ] || return 1               # more than four octets.
+  for o in "$o1" "$o2" "$o3" "$o4"; do
+    case "$o" in
+      ''|*[!0-9]*) return 1 ;;           # empty or non-digit.
+      0[0-9]*) return 1 ;;               # leading zero (non-canonical).
+    esac
+    [ "$o" -le 255 ] || return 1
+  done
+  return 0
+}
+url_allowed() { # url -> 0 when https, or http on a loopback host.
+  scheme=$(url_scheme "$1")
+  if [ "$scheme" = https ]; then return 0; fi
+  if [ "$scheme" = http ] && is_loopback_host "$(url_host "$1")"; then return 0; fi
+  return 1
+}
+resolve_base_url() { # override repo version -> base url (stdout) | err
+  override=$1; repo=$2; version=$3
+  if [ -n "$override" ]; then
+    url_allowed "$override" ||
+      err "CYNATIVE_BASE_URL must be https:// (or http:// on loopback for tests): '$override'"
+    while :; do case "$override" in */) override=${override%/} ;; *) break ;; esac; done
+    printf '%s' "$override"
+    return 0
   fi
-fi
+  printf 'https://github.com/%s/releases/download/%s' "$repo" "$version"
+}
 
-tar -xzf "$tmp/$ARCHIVE" -C "$tmp" "$BINARY" || err "failed to extract ${BINARY}"
-[ -f "$tmp/$BINARY" ] || err "${BINARY} not found in archive"
-chmod +x "$tmp/$BINARY"
+main() {
+  set -eu
 
-mkdir -p "$INSTALL_DIR" || err "cannot create ${INSTALL_DIR}"
-mv "$tmp/$BINARY" "$INSTALL_DIR/.${BINARY}.tmp.$$" || err "install write failed"
-mv "$INSTALL_DIR/.${BINARY}.tmp.$$" "$INSTALL_DIR/$BINARY" || err "install move failed"
+  INSTALL_DIR="${CYNATIVE_INSTALL_DIR:-${HOME}/.local/bin}"
 
-printf 'installed %s %s to %s/%s\n' "$BINARY" "$VERSION" "$INSTALL_DIR" "$BINARY" >&2
-case ":${PATH}:" in
-  *":${INSTALL_DIR}:"*) ;;
-  *)
-    # shellcheck disable=SC2016  # the printed $PATH is intentionally literal (a copy-paste hint).
-    printf 'note: %s is not on PATH — add: export PATH="%s:$PATH"\n' "$INSTALL_DIR" "$INSTALL_DIR" >&2
-    ;;
-esac
+  # Paired uninstall: `curl -fsSL .../install.sh | sh -s -- --uninstall`
+  if [ "${1:-}" = "--uninstall" ]; then
+    target="$INSTALL_DIR/$BINARY"
+    if [ -e "$target" ]; then rm -f "$target" && printf 'removed %s\n' "$target" >&2
+    else printf '%s not found (nothing to remove)\n' "$target" >&2; fi
+    exit 0
+  fi
+
+  command -v uname >/dev/null 2>&1 || err "uname not found"
+  command -v tar >/dev/null 2>&1 || err "tar not found"
+  command -v mktemp >/dev/null 2>&1 || err "mktemp not found"
+
+  case "$(uname -s)" in
+    Linux) OS=Linux ;;
+    Darwin) OS=Darwin ;;
+    *) err "unsupported OS '$(uname -s)' — see https://github.com/${REPO}/releases" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64) ARCH=x86_64 ;;
+    arm64|aarch64) ARCH=arm64 ;;
+    *) err "unsupported arch '$(uname -m)' — see https://github.com/${REPO}/releases" ;;
+  esac
+
+  VERSION="${CYNATIVE_VERSION:-}"
+  if [ -z "$VERSION" ]; then
+    VERSION=$(download "https://api.github.com/repos/${REPO}/releases/latest" \
+      | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+    [ -n "$VERSION" ] || err "could not resolve latest release tag"
+  fi
+
+  ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
+  BASE=$(resolve_base_url "${CYNATIVE_BASE_URL:-}" "$REPO" "$VERSION")
+
+  tmp=$(mktemp -d) || err "mktemp failed"
+  trap 'rm -rf "$tmp"' EXIT INT TERM
+
+  printf 'downloading %s @ %s\n' "$ARCHIVE" "$VERSION" >&2
+  download_to "${BASE}/${ARCHIVE}" "$tmp/$ARCHIVE" || err "download failed: ${BASE}/${ARCHIVE}"
+  download_to "${BASE}/checksums.txt" "$tmp/checksums.txt" || err "download failed: ${BASE}/checksums.txt"
+
+  matches=$(awk -v f="$ARCHIVE" '$2==f {print $1}' "$tmp/checksums.txt")
+  count=$(printf '%s' "$matches" | grep -c . || true)
+  [ "$count" = "1" ] || err "expected exactly one checksum entry for ${ARCHIVE}, found ${count}"
+  got=$(cd "$tmp" && sha256 "$ARCHIVE" | awk '{print $1}')
+  [ "$matches" = "$got" ] || err "checksum mismatch: want ${matches} got ${got}"
+
+  if command -v gh >/dev/null 2>&1; then
+    if gh release verify-asset "$VERSION" "$tmp/$ARCHIVE" --repo "$REPO" >/dev/null 2>&1; then
+      printf 'attestation verified\n' >&2
+    elif [ "${CYNATIVE_REQUIRE_ATTESTATION:-0}" = "1" ]; then
+      err "attestation verification failed (CYNATIVE_REQUIRE_ATTESTATION=1)"
+    else
+      printf 'warning: attestation not verified (continuing)\n' >&2
+    fi
+  fi
+
+  tar -xzf "$tmp/$ARCHIVE" -C "$tmp" "$BINARY" || err "failed to extract ${BINARY}"
+  [ -f "$tmp/$BINARY" ] || err "${BINARY} not found in archive"
+  chmod +x "$tmp/$BINARY"
+
+  mkdir -p "$INSTALL_DIR" || err "cannot create ${INSTALL_DIR}"
+  mv "$tmp/$BINARY" "$INSTALL_DIR/.${BINARY}.tmp.$$" || err "install write failed"
+  mv "$INSTALL_DIR/.${BINARY}.tmp.$$" "$INSTALL_DIR/$BINARY" || err "install move failed"
+
+  printf 'installed %s %s to %s/%s\n' "$BINARY" "$VERSION" "$INSTALL_DIR" "$BINARY" >&2
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+      # shellcheck disable=SC2016  # the printed $PATH is intentionally literal (a copy-paste hint).
+      printf 'note: %s is not on PATH — add: export PATH="%s:$PATH"\n' "$INSTALL_DIR" "$INSTALL_DIR" >&2
+      ;;
+  esac
+}
+
+# Run main unless sourced for unit testing (CYNATIVE_TEST_SOURCE=1).
+[ -n "${CYNATIVE_TEST_SOURCE:-}" ] || main "$@"

--- a/test/install.smoke.test.sh
+++ b/test/install.smoke.test.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# End-to-end smoke: run the real install.sh against a loopback fixture server.
+# Proves both issue #40 clauses - install from http://127.0.0.1, and reject a
+# non-loopback http override. Hermetic (no network): CYNATIVE_VERSION is pinned,
+# the server is loopback-only, and a gh stub keeps attestation offline.
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+installer="$root/install.sh"
+
+server_pid=''
+workdir=''
+cleanup() {
+  [ -z "${server_pid:-}" ] || kill "$server_pid" 2>/dev/null || true
+  [ -z "${workdir:-}" ] || rm -rf "$workdir"
+}
+trap cleanup EXIT INT TERM
+
+command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found (fixture server)\n' >&2; exit 1; }
+
+workdir=$(mktemp -d)
+srv="$workdir/srv"
+bin="$workdir/bin"
+stub="$workdir/stub"
+mkdir -p "$srv" "$bin" "$stub"
+
+case "$(uname -s)" in
+  Linux) os=Linux ;;
+  Darwin) os=Darwin ;;
+  *) printf 'skip: unsupported OS %s\n' "$(uname -s)" >&2; exit 0 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=x86_64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) printf 'skip: unsupported arch %s\n' "$(uname -m)" >&2; exit 0 ;;
+esac
+archive="cynative_${os}_${arch}.tar.gz"
+
+marker='fake-cynative-ok'
+cat > "$srv/cynative" <<EOF
+#!/bin/sh
+echo $marker
+EOF
+chmod +x "$srv/cynative"
+( cd "$srv" && tar -czf "$archive" cynative && rm -f cynative )
+( cd "$srv" && { sha256sum "$archive" 2>/dev/null || shasum -a 256 "$archive"; } > checksums.txt )
+
+cat > "$stub/gh" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$stub/gh"
+
+cat > "$workdir/serve.py" <<'PY'
+import sys, functools, http.server
+srv_dir, portfile = sys.argv[1], sys.argv[2]
+
+
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+handler = functools.partial(Quiet, directory=srv_dir)
+httpd = http.server.HTTPServer(("127.0.0.1", 0), handler)
+with open(portfile, "w") as f:
+    f.write(str(httpd.server_address[1]))
+httpd.serve_forever()
+PY
+
+portfile="$workdir/port"
+python3 "$workdir/serve.py" "$srv" "$portfile" &
+server_pid=$!
+
+i=0
+while [ ! -s "$portfile" ]; do
+  i=$((i + 1))
+  [ "$i" -lt 100 ] || { printf 'FAIL: fixture server did not start\n' >&2; exit 1; }
+  sleep 0.1
+done
+port=$(cat "$portfile")
+
+# Accept path: the real installer against a loopback http base.
+CYNATIVE_BASE_URL="http://127.0.0.1:$port" \
+CYNATIVE_VERSION="v0.0.0-test" \
+CYNATIVE_REQUIRE_ATTESTATION=0 \
+CYNATIVE_INSTALL_DIR="$bin" \
+PATH="$stub:$PATH" \
+  sh "$installer"
+
+[ -x "$bin/cynative" ] || { printf 'FAIL: binary not installed\n' >&2; exit 1; }
+out=$("$bin/cynative")
+[ "$out" = "$marker" ] || { printf 'FAIL: installed binary marker mismatch: %s\n' "$out" >&2; exit 1; }
+
+# Reject path: a non-loopback http override must fail closed before any download.
+set +e
+reject=$(CYNATIVE_BASE_URL="http://evil.example" CYNATIVE_VERSION="v0.0.0-test" sh "$installer" 2>&1)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || { printf 'FAIL: non-loopback http override was not rejected\n' >&2; exit 1; }
+case "$reject" in
+  *cynative-install:*"must be https"*) : ;;
+  *) printf 'FAIL: reject message shape: %s\n' "$reject" >&2; exit 1 ;;
+esac
+
+printf 'install.smoke: OK (accept http://127.0.0.1 + reject non-loopback http)\n' >&2

--- a/test/install.unit.test.sh
+++ b/test/install.unit.test.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Unit tests for the install.sh URL-safety seam. Sources install.sh via the
+# CYNATIVE_TEST_SOURCE guard (no install runs, no network) and checks the pure
+# helpers. Mirrors the Pester Test-CynUrlAllowed / Resolve-CynBaseUrl blocks and
+# adds the IPv6 / 127.0.0.0/8 / spoof cases the POSIX parser must prove itself.
+set -u
+
+CYNATIVE_TEST_SOURCE=1
+export CYNATIVE_TEST_SOURCE
+# shellcheck disable=SC1091  # install.sh is sourced at runtime via a $0-relative path.
+. "$(dirname "$0")/../install.sh"
+
+pass=0
+fail=0
+allow() { # label url : url_allowed should accept.
+  if url_allowed "$2"; then pass=$((pass + 1))
+  else fail=$((fail + 1)); printf 'FAIL expected-allow: %s (%s)\n' "$1" "$2" >&2; fi
+}
+reject() { # label url : url_allowed should refuse.
+  if url_allowed "$2"; then fail=$((fail + 1)); printf 'FAIL expected-reject: %s (%s)\n' "$1" "$2" >&2
+  else pass=$((pass + 1)); fi
+}
+eq() { # label want got.
+  if [ "$2" = "$3" ]; then pass=$((pass + 1))
+  else fail=$((fail + 1)); printf 'FAIL %s:\n  want: %s\n  got:  %s\n' "$1" "$2" "$3" >&2; fi
+}
+
+allow 'https public'          'https://example.com/x'
+allow 'https bare host'       'https://mirror.example'
+allow 'http 127.0.0.1:port'   'http://127.0.0.1:8000/x'
+allow 'http localhost'        'http://localhost:8000/x'
+allow 'http [::1]:port'       'http://[::1]:8000/x'
+allow 'http [::1]'            'http://[::1]'
+allow 'http 127.5.6.7'        'http://127.5.6.7'
+allow 'http 127.255.255.255'  'http://127.255.255.255'
+
+reject 'http public'          'http://evil.example/x'
+reject 'http 127-spoof'       'http://127.0.0.1.evil.com'
+reject 'http localhost-spoof' 'http://localhost.evil.com'
+reject 'http octet over 255'  'http://127.256.0.1'
+reject 'http leading zero'    'http://0127.0.0.1'
+reject 'http [::1]evil'       'http://[::1]evil.com'
+reject 'http [::1 unclosed'   'http://[::1'
+reject 'ftp'                  'ftp://example.com/x'
+reject 'file'                 'file:///tmp/x'
+reject 'no scheme'            'not-a-url'
+
+eq 'default base url' \
+  'https://github.com/cynative/cynative/releases/download/v1.0.0' \
+  "$(resolve_base_url '' 'cynative/cynative' 'v1.0.0')"
+eq 'https override trims one slash' \
+  'https://mirror.example/dl' "$(resolve_base_url 'https://mirror.example/dl/' 'r' 'v')"
+eq 'https override trims all slashes' \
+  'https://mirror.example/dl' "$(resolve_base_url 'https://mirror.example/dl///' 'r' 'v')"
+eq 'loopback http override kept' \
+  'http://127.0.0.1:8000' "$(resolve_base_url 'http://127.0.0.1:8000' 'r' 'v')"
+
+# Reject override: err prints the cynative-install: message and exits; run in a
+# subshell so its exit does not kill the harness, and capture stderr.
+msg=$(resolve_base_url 'http://evil.example' 'r' 'v' 2>&1 >/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ]; then pass=$((pass + 1))
+else fail=$((fail + 1)); printf 'FAIL reject should exit non-zero\n' >&2; fi
+case "$msg" in
+  *cynative-install:*"must be https"*) pass=$((pass + 1)) ;;
+  *) fail=$((fail + 1)); printf 'FAIL reject message shape: %s\n' "$msg" >&2 ;;
+esac
+
+printf 'install.unit: %d passed, %d failed\n' "$pass" "$fail" >&2
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #40. Part of the release-confidence epic (#36).

## What

Gives `install.sh` the same `CYNATIVE_BASE_URL` download-base override that `install.ps1`
already has, so release-confidence tests can build local artifacts, serve them from
loopback, and run the real installer without depending on a published GitHub release.

Safety rule (identical to `install.ps1`):

- default still uses GitHub releases,
- `https://` overrides are allowed,
- `http://` is allowed only for loopback (localhost, `127.0.0.0/8`, `::1`),
- anything else fails closed.

## How

- New pure helpers in `install.sh` (`url_scheme`, `url_host`, `is_loopback_host`,
  `url_allowed`, `resolve_base_url`). The IPv6 and `127.0.0.0/8` handling fails closed on
  spoof shapes like `http://[::1]evil.com`, `http://127.0.0.1.evil.com`, and
  `http://0127.0.0.1`.
- The installer flow moves into `main()` behind a source guard
  (`[ -n "${CYNATIVE_TEST_SOURCE:-}" ] || main "$@"`), so unit tests can source the helpers
  without running the installer. Behavior when run normally or via `curl | sh` is unchanged;
  version resolution still uses `api.github.com` regardless of the override.

## Tests

- `test/install.unit.test.sh` - POSIX unit tests for the URL-safety logic (mirrors the
  Pester `Test-CynUrlAllowed` / `Resolve-CynBaseUrl` blocks and adds IPv6 / `127.0.0.0/8` /
  spoof cases). Passes under dash, busybox ash, and bash --posix.
- `test/install.smoke.test.sh` - end-to-end: builds a fake artifact, serves it from a
  loopback fixture server, runs the real installer over `http://127.0.0.1`, and asserts a
  non-loopback `http://` override is rejected. Hermetic (no network).
- New `make sh-test` target, gated in `make check-scripts`. It presence-checks `python3`
  (the smoke test's fixture server) with an install hint, matching the existing
  `shellcheck`/`pwsh` install-free pattern.
