### PR TITLE
ci: gate release-please PRs with a local Linux install e2e

### DIFF
--- a/.github/workflows/install-e2e.yaml
+++ b/.github/workflows/install-e2e.yaml
@@ -1,0 +1,57 @@
+name: Install e2e
+
+# Runs on EVERY pull request (no paths filter) so this job's status check is
+# always reported. A paths-filtered/skipped workflow leaves a *required* status
+# check stuck pending and blocks unrelated PRs from merging - so to gate ONLY
+# release-please PRs, the job must always report: the heavy build+install runs
+# only for release-please PRs (or a manual dispatch); every other PR passes
+# trivially. Mirrors .github/workflows/pkg-tools.yaml.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install-e2e:
+    name: Linux install e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # fetch-depth: 0 gets full history + tags so goreleaser can derive the
+      # snapshot version from the latest release tag.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Detect release-please PR
+        id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          relevant=false
+          # Manual dispatch is an intentional run on any branch.
+          [ "${EVENT}" = "workflow_dispatch" ] && relevant=true
+          # release-please's branch name is deterministic and present from PR
+          # creation (verified on PRs #31/#29) - the primary, reliable signal.
+          [ "${HEAD_REF}" = "release-please--branches--main" ] && relevant=true
+          # The autorelease label is a secondary fallback (it can lag creation).
+          case ",${LABELS}," in *",autorelease: pending,"*) relevant=true ;; esac
+          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
+          if [ "${relevant}" = "true" ]; then
+            echo "Release-please PR or manual dispatch - running the install e2e."
+          else
+            echo "Not a release-please PR - skipping the heavy e2e (check passes trivially)."
+          fi
+      - name: Report tested head SHA
+        if: steps.detect.outputs.relevant == 'true'
+        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        if: steps.detect.outputs.relevant == 'true'
+        with:
+          go-version-file: go.mod
+      - name: Build snapshot and run the install e2e
+        if: steps.detect.outputs.relevant == 'true'
+        run: make install-e2e

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: scripts/release/sign-darwin-binary.sh "{{ .Path }}" "{{ .Target }}"
+        - cmd: scripts/release/sign-darwin-binary.sh "{{ .Path }}" "{{ .Target }}" "{{ .IsSnapshot }}"
 
 archives:
   - formats: [tar.gz]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: check check-go check-scripts lint format test generate shell-complexity \
-	windows-build shellcheck pwsh-lint pwsh-test sh-test
+	windows-build shellcheck pwsh-lint pwsh-test sh-test install-e2e
 
 # Pinned external (non-Go) tool versions for check-scripts. Unlike the Go tools
 # (pinned via go.mod / `go tool`), these are NOT Dependabot-managed — Dependabot has
@@ -109,3 +109,15 @@ shell-complexity:
 # here instead of duplicating them). Example: `make -s print-SHELLCHECK_VERSION`.
 print-%:
 	@echo '$($*)'
+
+# install-e2e: real-artifact install e2e for release confidence (issue #41).
+# Standalone (NOT part of `make check`): builds a real Linux archive via a
+# goreleaser snapshot, serves it from a loopback fixture server, runs the real
+# install.sh, verifies `cynative --version`, uninstalls, and proves a checksum
+# failure fails closed. Presence-checks python3 (fixture server) with an install
+# hint, mirroring the sh-test/shellcheck install-free pattern.
+install-e2e:
+	@command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 not found, needed by the install e2e loopback fixture server (test/install.e2e.test.sh)."; exit 1; }
+	go tool goreleaser release --snapshot --clean
+	sh test/install.e2e.test.sh ./dist
+	@echo "OK: install-e2e (real archive install + version + uninstall + checksum-failure)"

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,6 @@ print-%:
 # hint, mirroring the sh-test/shellcheck install-free pattern.
 install-e2e:
 	@command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 not found, needed by the install e2e loopback fixture server (test/install.e2e.test.sh)."; exit 1; }
-	go tool goreleaser release --snapshot --clean
+	go tool goreleaser release --snapshot --clean --skip=before
 	sh test/install.e2e.test.sh ./dist
 	@echo "OK: install-e2e (real archive install + version + uninstall + checksum-failure)"

--- a/scripts/release/sign-darwin-binary.sh
+++ b/scripts/release/sign-darwin-binary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # GoReleaser post-build hook: sign a darwin Mach-O with Developer ID Application.
-# Usage: sign-darwin-binary.sh <binary-path> <target e.g. darwin_arm64>
+# Usage: sign-darwin-binary.sh <binary-path> <target e.g. darwin_arm64> [isSnapshot=false]
 set -euo pipefail
 
 binary="$1"; target="${2:-}"; snapshot="${3:-false}"

--- a/scripts/release/sign-darwin-binary.sh
+++ b/scripts/release/sign-darwin-binary.sh
@@ -3,11 +3,19 @@
 # Usage: sign-darwin-binary.sh <binary-path> <target e.g. darwin_arm64>
 set -euo pipefail
 
-binary="$1"; target="${2:-}"
+binary="$1"; target="${2:-}"; snapshot="${3:-false}"
 case "${target}" in
   darwin_*) ;;
   *) exit 0 ;;   # non-darwin target: nothing to sign
 esac
+
+# Snapshot builds (goreleaser --snapshot, e.g. the install e2e) are never releases,
+# so there is nothing to sign. Default is "false" (fail-closed): a real release or a
+# dropped 3rd arg still attempts signing and fails loudly on missing material.
+if [ "${snapshot}" = "true" ]; then
+  echo "snapshot build: skipping darwin signing (${target})" >&2
+  exit 0
+fi
 
 : "${MACOS_SIGN_P12_FILE:?MACOS_SIGN_P12_FILE unset}"
 : "${MACOS_SIGN_PASSWORD_FILE:?MACOS_SIGN_PASSWORD_FILE unset}"

--- a/test/install.e2e.test.sh
+++ b/test/install.e2e.test.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Real-artifact install e2e for release confidence (issue #41).
+# Serves a goreleaser-built Linux archive from a loopback fixture server, runs the
+# real install.sh, verifies `cynative --version`, uninstalls, and proves a checksum
+# failure is fail-closed. Hermetic: no public releases, Homebrew, Scoop, LLM, or
+# cloud access (CYNATIVE_VERSION is pinned and gh is stubbed to keep attestation
+# offline; the server is loopback-only).
+# Usage: test/install.e2e.test.sh [DIST_DIR]   (default: <repo>/dist)
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+installer="$root/install.sh"
+dist=${1:-"$root/dist"}
+
+server_pid=''
+workdir=''
+cleanup() {
+  [ -z "${server_pid:-}" ] || kill "$server_pid" 2>/dev/null || true
+  [ -z "${workdir:-}" ] || rm -rf "$workdir"
+}
+trap cleanup EXIT INT TERM
+
+command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found (fixture server)\n' >&2; exit 1; }
+
+case "$(uname -s)" in
+  Linux) os=Linux ;;
+  Darwin) os=Darwin ;;
+  *) printf 'skip: unsupported OS %s\n' "$(uname -s)" >&2; exit 0 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=x86_64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) printf 'skip: unsupported arch %s\n' "$(uname -m)" >&2; exit 0 ;;
+esac
+archive="cynative_${os}_${arch}.tar.gz"
+
+[ -f "$dist/$archive" ] || { printf 'FAIL: %s not found (run goreleaser snapshot first)\n' "$dist/$archive" >&2; exit 1; }
+[ -f "$dist/checksums.txt" ] || { printf 'FAIL: %s/checksums.txt not found\n' "$dist" >&2; exit 1; }
+[ -f "$dist/metadata.json" ] || { printf 'FAIL: %s/metadata.json not found\n' "$dist" >&2; exit 1; }
+
+# Expected `cynative --version` string: the version goreleaser stamped, v-normalized.
+want=$(python3 -c 'import json,sys; v=json.load(open(sys.argv[1]))["version"]; print(v[1:] if v.startswith("v") else v)' "$dist/metadata.json")
+[ -n "$want" ] || { printf 'FAIL: could not read version from metadata.json\n' >&2; exit 1; }
+
+workdir=$(mktemp -d)
+srv="$workdir/srv"; bin="$workdir/bin"; bad="$workdir/bad"; stub="$workdir/stub"
+mkdir -p "$srv" "$bin" "$bad" "$stub"
+
+# Serve a COPY of dist so the checksum-failure phase can tamper without touching dist.
+cp "$dist/$archive" "$dist/checksums.txt" "$srv/"
+
+# Offline attestation: a gh stub whose verify-asset always fails (keeps gh offline).
+printf '#!/bin/sh\nexit 1\n' > "$stub/gh"
+chmod +x "$stub/gh"
+
+portfile="$workdir/port"
+python3 "$root/test/serve-fixture.py" "$srv" "$portfile" &
+server_pid=$!
+
+i=0
+while [ ! -s "$portfile" ]; do
+  i=$((i + 1))
+  [ "$i" -lt 100 ] || { printf 'FAIL: fixture server did not start\n' >&2; exit 1; }
+  sleep 0.1
+done
+base="http://127.0.0.1:$(cat "$portfile")"
+
+run_install() { # install_dir : run the real installer against the loopback base
+  CYNATIVE_BASE_URL="$base" \
+  CYNATIVE_VERSION="v0.0.0-e2e" \
+  CYNATIVE_REQUIRE_ATTESTATION=0 \
+  CYNATIVE_INSTALL_DIR="$1" \
+  PATH="$stub:$PATH" \
+    sh "$installer"
+}
+
+printf '== INSTALL ==\n' >&2
+run_install "$bin"
+[ -x "$bin/cynative" ] || { printf 'FAIL: binary not installed\n' >&2; exit 1; }
+
+printf '== VERSION ==\n' >&2
+got=$("$bin/cynative" --version | head -n1)
+case "$got" in
+  "cynative $want") : ;;
+  *) printf 'FAIL: version mismatch: want "cynative %s" got "%s"\n' "$want" "$got" >&2; exit 1 ;;
+esac
+
+printf '== UNINSTALL ==\n' >&2
+CYNATIVE_INSTALL_DIR="$bin" sh "$installer" --uninstall
+[ ! -e "$bin/cynative" ] || { printf 'FAIL: uninstall left the binary in place\n' >&2; exit 1; }
+
+printf '== CHECKSUM-FAILURE ==\n' >&2
+# Tamper the served archive so its sha no longer matches the unchanged checksums.txt.
+printf 'tamper' >> "$srv/$archive"
+set +e
+out=$(run_install "$bad" 2>&1); rc=$?
+set -e
+[ "$rc" -ne 0 ] || { printf 'FAIL: tampered archive did not fail install\n' >&2; exit 1; }
+case "$out" in
+  *"checksum mismatch"*) : ;;
+  *) printf 'FAIL: expected "checksum mismatch", got: %s\n' "$out" >&2; exit 1 ;;
+esac
+[ ! -e "$bad/cynative" ] || { printf 'FAIL: tampered install wrote a binary\n' >&2; exit 1; }
+
+printf 'install.e2e: OK (install + version %s + uninstall + checksum-failure)\n' "$want" >&2

--- a/test/install.smoke.test.sh
+++ b/test/install.smoke.test.sh
@@ -51,25 +51,8 @@ exit 1
 EOF
 chmod +x "$stub/gh"
 
-cat > "$workdir/serve.py" <<'PY'
-import sys, functools, http.server
-srv_dir, portfile = sys.argv[1], sys.argv[2]
-
-
-class Quiet(http.server.SimpleHTTPRequestHandler):
-    def log_message(self, *args):
-        pass
-
-
-handler = functools.partial(Quiet, directory=srv_dir)
-httpd = http.server.HTTPServer(("127.0.0.1", 0), handler)
-with open(portfile, "w") as f:
-    f.write(str(httpd.server_address[1]))
-httpd.serve_forever()
-PY
-
 portfile="$workdir/port"
-python3 "$workdir/serve.py" "$srv" "$portfile" &
+python3 "$root/test/serve-fixture.py" "$srv" "$portfile" &
 server_pid=$!
 
 i=0

--- a/test/serve-fixture.py
+++ b/test/serve-fixture.py
@@ -1,0 +1,20 @@
+"""Loopback HTTP fixture server for the install.sh test scripts.
+
+Usage: serve-fixture.py <serve_dir> <portfile>
+Binds 127.0.0.1 on an ephemeral port, writes the chosen port to <portfile>, then
+serves <serve_dir> forever with logging silenced. Loopback-only and hermetic.
+"""
+import sys, functools, http.server
+srv_dir, portfile = sys.argv[1], sys.argv[2]
+
+
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+handler = functools.partial(Quiet, directory=srv_dir)
+httpd = http.server.HTTPServer(("127.0.0.1", 0), handler)
+with open(portfile, "w") as f:
+    f.write(str(httpd.server_address[1]))
+httpd.serve_forever()


### PR DESCRIPTION
## What & why

Adds a hermetic, real-artifact Linux install e2e and gates release-please PRs with it, so a broken local install path blocks a release instead of reaching users. Closes #41. Part of the release-confidence epic (#36).

- `test/install.e2e.test.sh` + `make install-e2e`: builds the real Linux archive with a goreleaser snapshot, serves it from a loopback fixture server, runs the real `install.sh`, verifies `cynative --version`, uninstalls, and proves a checksum failure is fail-closed.
- `.github/workflows/install-e2e.yaml`: mirrors `pkg-tools.yaml`'s always-report pattern. One job (`Linux install e2e`) runs on every PR but does the heavy build only for release-please PRs (head ref `release-please--branches--main` or the `autorelease: pending` label) or a manual dispatch. Every other PR passes trivially, so it can be a required check without wedging normal PRs.
- `scripts/release/sign-darwin-binary.sh` + `.goreleaser.yaml`: the darwin sign hook now skips signing in snapshot mode (`{{ .IsSnapshot }}`), so a secretless `goreleaser release --snapshot` works. Real releases run `--clean` (never `--snapshot`), so signing is unchanged and still fail-closed.
- `test/serve-fixture.py`: the loopback fixture server, extracted from `install.smoke.test.sh` so both install tests share it.

Hermetic by construction: no public GitHub releases, Homebrew, Scoop, LLM providers, or cloud credentials. `CYNATIVE_VERSION` is pinned (skips the latest-release lookup), `gh` is stubbed (attestation stays offline), the server is loopback-only, and `--skip=before` avoids the goreleaser `go mod tidy` hook.

`make install-e2e` is standalone (not part of `make check`), so the normal PR gate stays fast; the existing fast fake-binary smoke test still runs on every PR.

After merge: add the `Linux install e2e` check to the `default` ruleset's required status checks (once it has run here so it is selectable), so release-please PRs cannot merge unless the local install path works.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [ ] Docs updated if behavior changed (dev tooling only, no product behavior change)
