### PR TITLE
refactor: make InvokableTool.Info and ReflectParams infallible

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -128,7 +128,7 @@ type Agent struct {
 // New builds the agent: it assembles the system prompt, registers the host
 // orchestration tools (write_todos, task, and verify_findings) alongside the
 // approval-wrapped I/O tools, and binds the tool schemas the model will see.
-func New(_ context.Context, cfg Config, opts ...Option) (*Agent, error) {
+func New(_ context.Context, cfg Config, opts ...Option) *Agent {
 	a := &Agent{ //nolint:exhaustruct // tools/history/sessionID set below or per Run
 		model:                  cfg.Model,
 		renderer:               cfg.Renderer,
@@ -156,11 +156,7 @@ func New(_ context.Context, cfg Config, opts ...Option) (*Agent, error) {
 	all = append(all, cfg.Tools...)
 	all = append(all, newWriteTodosTool(a), newTaskTool(a), newVerifyFindingsTool(a))
 
-	ts, err := buildToolset(all)
-	if err != nil {
-		return nil, err
-	}
-	a.tools = ts
+	a.tools = buildToolset(all)
 
 	for _, o := range opts {
 		o(a)
@@ -168,25 +164,22 @@ func New(_ context.Context, cfg Config, opts ...Option) (*Agent, error) {
 
 	a.sessionID = a.newID()
 
-	return a, nil
+	return a
 }
 
 // buildToolset indexes tools by name and collects their schemas.
-func buildToolset(ts []schema.InvokableTool) (toolset, error) {
+func buildToolset(ts []schema.InvokableTool) toolset {
 	out := toolset{
 		tools: make(map[string]schema.InvokableTool, len(ts)),
 		infos: make([]*schema.ToolInfo, 0, len(ts)),
 	}
 	for _, t := range ts {
-		info, err := t.Info(context.Background())
-		if err != nil {
-			return toolset{}, fmt.Errorf("agent: read tool info: %w", err)
-		}
+		info := t.Info()
 		out.tools[info.Name] = t
 		out.infos = append(out.infos, info)
 	}
 
-	return out, nil
+	return out
 }
 
 // Run executes one research turn: it seeds the working transcript from the Q&A

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -86,8 +86,8 @@ type echoTool struct {
 
 var _ schema.InvokableTool = (*echoTool)(nil)
 
-func (*echoTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "echo", Desc: "echo tool", Params: nil}, nil
+func (*echoTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "echo", Desc: "echo tool", Params: nil}
 }
 
 func (t *echoTool) Run(context.Context, string) (string, error) {
@@ -103,25 +103,12 @@ type errTool struct{}
 
 var _ schema.InvokableTool = (*errTool)(nil)
 
-func (*errTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "boom", Desc: "boom tool", Params: nil}, nil
+func (*errTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "boom", Desc: "boom tool", Params: nil}
 }
 
 func (*errTool) Run(context.Context, string) (string, error) {
 	return "", errors.New("tool boom")
-}
-
-// infoErrTool fails on Info, exercising the buildToolset error path.
-type infoErrTool struct{}
-
-var _ schema.InvokableTool = (*infoErrTool)(nil)
-
-func (*infoErrTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return nil, errors.New("info boom")
-}
-
-func (*infoErrTool) Run(context.Context, string) (string, error) {
-	return "", nil
 }
 
 // toolCall builds an assistant message carrying a single tool call.
@@ -331,10 +318,7 @@ func TestNew_Success(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = &scriptedModel{}
 
-	a, err := New(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	a := New(context.Background(), cfg)
 	if a.maxIter != 5 || a.maxSubagentIter != 3 {
 		t.Errorf("budgets = (%d,%d), want (5,3)", a.maxIter, a.maxSubagentIter)
 	}
@@ -353,25 +337,9 @@ func TestNew_AppliesOptions(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = &scriptedModel{}
 
-	a, err := New(context.Background(), cfg, withSystemPrompt("OVERRIDDEN"))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	a := New(context.Background(), cfg, withSystemPrompt("OVERRIDDEN"))
 	if a.systemPrompt != "OVERRIDDEN" {
 		t.Errorf("systemPrompt = %q, want option-applied value", a.systemPrompt)
-	}
-}
-
-func TestNew_ToolInfoError(t *testing.T) {
-	t.Parallel()
-
-	cfg := baseConfig()
-	cfg.Model = &scriptedModel{}
-	cfg.Tools = []schema.InvokableTool{&infoErrTool{}}
-
-	_, err := New(context.Background(), cfg)
-	if err == nil || !strings.Contains(err.Error(), "read tool info") {
-		t.Fatalf("expected tool-info error, got: %v", err)
 	}
 }
 
@@ -381,7 +349,7 @@ func TestNew_RegistersOrchestrationToolsUnwrapped(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = &scriptedModel{}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	// The concrete types prove New registers them bare: surfaced, not gated.
 	if _, ok := a.tools.tools["write_todos"].(*writeTodosTool); !ok {
@@ -398,7 +366,7 @@ func TestNew_RegistersVerifierAlways(t *testing.T) {
 	cfg := baseConfig() // No panel size to set: verification is unconditional.
 	cfg.Model = &scriptedModel{}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 	if _, ok := a.tools.tools["verify_findings"].(*verifyFindingsTool); !ok {
 		t.Errorf("verify_findings registered as %T, want *verifyFindingsTool", a.tools.tools["verify_findings"])
 	}
@@ -413,7 +381,7 @@ func TestRun_RecordsQAHistory(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = &scriptedModel{msgs: []*schema.Message{schema.AssistantMessage("the answer", nil)}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "the question", &buf); err != nil {
@@ -444,7 +412,7 @@ func TestRun_SeedsSystemThenHistoryThenQuestion(t *testing.T) {
 	cfg.Model = model
 	cfg.Providers = []auth.Provider{}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	if err := a.Run(context.Background(), "q1", io.Discard); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -472,7 +440,7 @@ func TestRun_SecondTurnReplaysHistory(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = model
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	if err := a.Run(context.Background(), "q1", io.Discard); err != nil {
 		t.Fatalf("Run #1: %v", err)
@@ -502,7 +470,7 @@ func TestRun_IterationLimitNotice(t *testing.T) {
 	cfg.Model = &scriptedModel{msgs: []*schema.Message{toolCall("c1", "echo", "{}")}}
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: nil}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "q", &buf); err != nil {
@@ -523,7 +491,7 @@ func TestRun_PropagatesModelError(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Model = &errModel{}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	if err := a.Run(context.Background(), "q", io.Discard); err == nil {
 		t.Fatal("expected error from Run")
@@ -844,7 +812,7 @@ func TestRun_CountersAccumulateAcrossTurns(t *testing.T) {
 	cfg.Model = model
 	cfg.Metrics = metrics.NewAccumulator("p", "m")
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	if err := a.Run(context.Background(), "q1", io.Discard); err != nil {
 		t.Fatalf("Run #1: %v", err)
@@ -882,7 +850,7 @@ func TestRun_ClosesTurnForActiveTime(t *testing.T) {
 	cfg.Model = model
 	cfg.Metrics = metrics.NewAccumulator("p", "m", metrics.WithClock(advancing))
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 	if err := a.Run(context.Background(), "q1", io.Discard); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -927,7 +895,7 @@ func TestRun_BudgetHaltsTurnWithNotice(t *testing.T) {
 	cfg.Metrics = acc
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: nil}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "q", &buf); err != nil {
@@ -979,7 +947,7 @@ func TestRun_BudgetHaltsOnOverBudgetFinalAnswer(t *testing.T) {
 	cfg.Model = model
 	cfg.Metrics = acc
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "q", &buf); err != nil {
@@ -1041,7 +1009,7 @@ func TestRun_BudgetHaltsBeforeRemainingToolCalls(t *testing.T) {
 	cfg.Metrics = acc
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: &ran}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 	a.maxSubagentIter = 3
 
 	var buf bytes.Buffer
@@ -1111,7 +1079,7 @@ func TestAgent_Run_BracketsInterrupterTurn(t *testing.T) {
 	cfg.Interrupter = fi
 	cfg.Metrics = metrics.NewAccumulator("p", "m")
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	if err := a.Run(context.Background(), "q", io.Discard); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -1154,7 +1122,7 @@ func TestRun_InterruptAtTopOfLoop(t *testing.T) {
 	cfg.Model = &scriptedModel{msgs: []*schema.Message{schema.AssistantMessage("should not appear", nil)}}
 	cfg.Interrupter = fi
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1189,7 +1157,7 @@ func TestRun_InterruptAfterGenerate(t *testing.T) {
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: &ran}}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1220,7 +1188,7 @@ func TestRun_InterruptDuringGenerateWinsOverModelError(t *testing.T) {
 	cfg.Model = &errModel{} // Generate always errors.
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1248,7 +1216,7 @@ func TestRun_InterruptDuringFinalAnswerRenderDenies(t *testing.T) {
 	cfg.Model = &scriptedModel{msgs: []*schema.Message{schema.AssistantMessage("the final answer", nil)}}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1282,7 +1250,7 @@ func TestRun_InterruptPostDispatch(t *testing.T) {
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: &ran}}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1323,7 +1291,7 @@ func TestRun_InvokeIOGuard(t *testing.T) {
 	cfg.Tools = []schema.InvokableTool{&echoTool{ran: &ran}}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1341,8 +1309,8 @@ type ctxWaitTool struct{ canceled *bool }
 
 var _ schema.InvokableTool = ctxWaitTool{}
 
-func (ctxWaitTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "waiter", Desc: "", Params: nil}, nil
+func (ctxWaitTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "waiter", Desc: "", Params: nil}
 }
 
 func (w ctxWaitTool) Run(ctx context.Context, _ string) (string, error) {
@@ -1407,7 +1375,7 @@ func TestRun_CancelsHungModelCallOnInterrupt(t *testing.T) {
 	cfg.Model = ctxWaitModel{}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "q", &buf)
@@ -1427,8 +1395,8 @@ type failingTool struct{ name string }
 
 var _ schema.InvokableTool = (*failingTool)(nil)
 
-func (f *failingTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}, nil
+func (f *failingTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}
 }
 
 func (f *failingTool) Run(ctx context.Context, _ string) (string, error) {
@@ -1442,8 +1410,8 @@ type succeedingTool struct{ name string }
 
 var _ schema.InvokableTool = (*succeedingTool)(nil)
 
-func (s *succeedingTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: s.name, Desc: "", Params: nil}, nil
+func (s *succeedingTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: s.name, Desc: "", Params: nil}
 }
 
 func (s *succeedingTool) Run(context.Context, string) (string, error) {
@@ -1481,7 +1449,7 @@ func TestRun_HaltsAfterNConsecutiveFailures(t *testing.T) {
 	cfg.Cfg.MaxConsecutiveFailures = 3
 	cfg.Tools = []schema.InvokableTool{&failingTool{name: "fail_tool"}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "scan", &buf); err != nil {
@@ -1522,7 +1490,7 @@ func TestRun_SuccessResetsFailureStreak(t *testing.T) {
 		&succeedingTool{name: "good_tool"},
 	}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "scan", &buf); err != nil {
@@ -1553,7 +1521,7 @@ func TestRun_MaxConsecutiveFailuresZeroDisables(t *testing.T) {
 	cfg.Cfg.MaxIterations = 2 // exhaust after 2 iterations.
 	cfg.Tools = []schema.InvokableTool{&failingTool{name: "fail_tool"}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "scan", &buf); err != nil {
@@ -1593,7 +1561,7 @@ func TestRun_DenialCountsAsFailure(t *testing.T) {
 	cfg.DeniedToolResult = denyMsg
 	cfg.Tools = []schema.InvokableTool{denyingTool}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	if err := a.Run(context.Background(), "scan", &buf); err != nil {
@@ -1656,7 +1624,7 @@ func TestRun_FailureSummaryInterruptPropagates(t *testing.T) {
 	cfg.Tools = []schema.InvokableTool{&failingTool{name: "fail_tool"}}
 	cfg.Interrupter = ci
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
 	err := a.Run(context.Background(), "scan", &buf)
@@ -1694,8 +1662,8 @@ func TestCreditedFailures(t *testing.T) {
 // script whose n inner http_request calls each returned >=400.
 type multiFailTool struct{ n int }
 
-func (multiFailTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "multifail", Desc: "", Params: nil}, nil
+func (multiFailTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "multifail", Desc: "", Params: nil}
 }
 
 func (m multiFailTool) Run(ctx context.Context, _ string) (string, error) {
@@ -1731,8 +1699,8 @@ func TestDispatch_CountsEachInnerFailure(t *testing.T) {
 // fan-out that got some 4xx responses and some useful 2xx ones.
 type mixedOutcomeTool struct{}
 
-func (mixedOutcomeTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "mixed", Desc: "", Params: nil}, nil
+func (mixedOutcomeTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "mixed", Desc: "", Params: nil}
 }
 
 func (mixedOutcomeTool) Run(ctx context.Context, _ string) (string, error) {
@@ -1771,10 +1739,7 @@ func TestNew_WiresAbout(t *testing.T) {
 	cfg.Model = &scriptedModel{}
 	cfg.About = "PRODUCT BLURB"
 
-	a, err := New(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	a := New(context.Background(), cfg)
 	if !strings.Contains(a.systemPrompt, "About cynative:") || !strings.Contains(a.systemPrompt, "PRODUCT BLURB") {
 		t.Errorf("New did not weave Config.About into the system prompt: %q", a.systemPrompt)
 	}
@@ -1792,7 +1757,7 @@ func TestNew_WiresOnFirstResponse(t *testing.T) {
 	cfg.Model = &scriptedModel{}
 	cfg.OnFirstResponse = hook
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 
 	// The field must be set to the same func value (pointer equality).
 	if a.onFirstResponse == nil {

--- a/internal/agent/audit_state_internal_test.go
+++ b/internal/agent/audit_state_internal_test.go
@@ -12,10 +12,7 @@ import (
 func TestNew_MintsSessionIDViaInjectedGenerator(t *testing.T) {
 	t.Parallel()
 
-	a, err := New(context.Background(), config0Cfg(), WithNewID(seqIDs("S1", "ignored")))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	a := New(context.Background(), config0Cfg(), WithNewID(seqIDs("S1", "ignored")))
 	if a.sessionID != "S1" {
 		t.Errorf("sessionID: got %q want S1", a.sessionID)
 	}

--- a/internal/agent/dispatch_internal_test.go
+++ b/internal/agent/dispatch_internal_test.go
@@ -34,15 +34,15 @@ type stubTool struct {
 	err  error
 }
 
-func (s stubTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: s.name, Desc: "", Params: nil}, nil
+func (s stubTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: s.name, Desc: "", Params: nil}
 }
 func (s stubTool) Run(context.Context, string) (string, error) { return s.out, s.err }
 
 func auditAgent(sink audit.Sink, tools map[string]schema.InvokableTool) *Agent {
 	infos := make([]*schema.ToolInfo, 0, len(tools))
 	for _, tl := range tools {
-		info, _ := tl.Info(context.Background())
+		info := tl.Info()
 		infos = append(infos, info)
 	}
 
@@ -187,8 +187,8 @@ type funcTool struct {
 	run  func(context.Context, string) (string, error)
 }
 
-func (f funcTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}, nil
+func (f funcTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}
 }
 func (f funcTool) Run(ctx context.Context, args string) (string, error) { return f.run(ctx, args) }
 
@@ -207,7 +207,7 @@ func approvalFn(inner schema.InvokableTool, approve bool) schema.InvokableTool {
 }
 
 func mustName(t schema.InvokableTool) string {
-	info, _ := t.Info(context.Background())
+	info := t.Info()
 
 	return info.Name
 }
@@ -219,8 +219,8 @@ type fakeScoped struct {
 	err  error
 }
 
-func (f fakeScoped) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}, nil
+func (f fakeScoped) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}
 }
 func (fakeScoped) Run(context.Context, string) (string, error) { return "", nil }
 func (f fakeScoped) runScoped(context.Context, *runState, string) (string, error) {

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -1,25 +1,10 @@
 package agent
 
 import (
-	"context"
 	"io"
-	"testing"
 
 	"github.com/cynative/cynative/internal/schema"
 )
-
-// newAgent builds an Agent via New, failing the test on a construction error, so
-// callers keep no outer err in scope (avoiding shadowing of Run's error).
-func newAgent(t *testing.T, cfg Config) *Agent {
-	t.Helper()
-
-	a, err := New(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	return a
-}
 
 // withSystemPrompt overrides the assembled system prompt; a test-only Option
 // proving New applies its options after construction.
@@ -32,7 +17,7 @@ func withSystemPrompt(s string) Option {
 func newTestAgent(model schema.ChatModel, byName map[string]schema.InvokableTool) *Agent {
 	infos := make([]*schema.ToolInfo, 0, len(byName))
 	for _, t := range byName {
-		info, _ := t.Info(context.Background())
+		info := t.Info()
 		infos = append(infos, info)
 	}
 

--- a/internal/agent/framing_internal_test.go
+++ b/internal/agent/framing_internal_test.go
@@ -13,8 +13,8 @@ import (
 // fakeIOTool is a plain (non-runScoped) tool whose Run returns fixed content.
 type fakeIOTool struct{ out string }
 
-func (f fakeIOTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "http_request"}, nil
+func (f fakeIOTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "http_request"}
 }
 func (f fakeIOTool) Run(context.Context, string) (string, error) { return f.out, nil }
 
@@ -24,8 +24,8 @@ type errScopedTool struct{}
 
 var _ runScopedTool = errScopedTool{}
 
-func (errScopedTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "write_todos"}, nil
+func (errScopedTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "write_todos"}
 }
 
 func (errScopedTool) Run(context.Context, string) (string, error) {
@@ -103,8 +103,8 @@ func TestDispatch_OrchestrationError(t *testing.T) {
 // fakeDenyTool is a plain (non-runScoped) tool that returns a fixed denial string.
 type fakeDenyTool struct{ msg string }
 
-func (f fakeDenyTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "http_request"}, nil
+func (f fakeDenyTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "http_request"}
 }
 func (f fakeDenyTool) Run(context.Context, string) (string, error) { return f.msg, nil }
 

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -84,8 +84,8 @@ type echoInnerTool struct {
 
 var _ schema.InvokableTool = (*echoInnerTool)(nil)
 
-func (*echoInnerTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "echo", Desc: "echo", Params: nil}, nil
+func (*echoInnerTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "echo", Desc: "echo", Params: nil}
 }
 
 func (t *echoInnerTool) Run(context.Context, string) (string, error) {
@@ -150,7 +150,7 @@ func runWithModel(
 	ctx := context.Background()
 	echo := tools.NewApprovalTool(&echoInnerTool{ran: ran}, prompter.prompt, "notty")
 
-	a, err := agent.New(ctx, agent.Config{ //nolint:exhaustruct // VerboseWriter/Metrics omitted
+	a := agent.New(ctx, agent.Config{ //nolint:exhaustruct // VerboseWriter/Metrics omitted
 		Model: model,
 		Cfg: config.Config{ //nolint:exhaustruct // only loop/render knobs matter
 			MaxIterations:         10,
@@ -161,9 +161,6 @@ func runWithModel(
 		Providers: nil,
 		Renderer:  capturingRenderer,
 	})
-	if err != nil {
-		t.Fatalf("agent.New: %v", err)
-	}
 
 	var buf bytes.Buffer
 	runErr := a.Run(ctx, "do it", &buf)
@@ -351,7 +348,7 @@ func runWithVerifier(
 	var ran bool
 	echo := tools.NewApprovalTool(&echoInnerTool{ran: &ran}, prompter.prompt, "notty")
 
-	a, err := agent.New(ctx, agent.Config{ //nolint:exhaustruct // VerboseWriter/Metrics omitted
+	a := agent.New(ctx, agent.Config{ //nolint:exhaustruct // VerboseWriter/Metrics omitted
 		Model: model,
 		Cfg: config.Config{ //nolint:exhaustruct // only loop/render knobs matter
 			MaxIterations:         10,
@@ -362,9 +359,6 @@ func runWithVerifier(
 		Providers: nil,
 		Renderer:  capturingRenderer,
 	})
-	if err != nil {
-		t.Fatalf("agent.New: %v", err)
-	}
 
 	var buf bytes.Buffer
 	runErr := a.Run(ctx, "audit it", &buf)

--- a/internal/agent/schema_invariant_internal_test.go
+++ b/internal/agent/schema_invariant_internal_test.go
@@ -18,10 +18,7 @@ func TestBoundToolSchemas_ContainNoSecretShapedContent(t *testing.T) {
 
 	// A zero Config suffices: verify_findings is always bound and New reads only Cfg
 	// here, so the other Config fields can stay zero.
-	a, err := New(context.Background(), Config{}) //nolint:exhaustruct // only Cfg matters; defaults zero.
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	a := New(context.Background(), Config{}) //nolint:exhaustruct // only Cfg matters; defaults zero.
 
 	r := redact.New()
 	for _, info := range a.tools.infos {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -52,8 +52,8 @@ func newTaskTool(a *Agent) *taskTool {
 }
 
 // Info returns the tool's static schema.
-func (t *taskTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return t.info, nil
+func (t *taskTool) Info() *schema.ToolInfo {
+	return t.info
 }
 
 // Run satisfies schema.InvokableTool; dispatch never calls it (runScoped is

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -43,11 +43,9 @@ const subagentDelegationGuidance = "Sub-agents cannot themselves delegate with t
 
 // newTaskTool builds the task tool bound to a.
 func newTaskTool(a *Agent) *taskTool {
-	params, _ := schema.ReflectParams[taskArgs]()
-
 	return &taskTool{
 		agent: a,
-		info:  &schema.ToolInfo{Name: "task", Desc: taskDesc, Params: params},
+		info:  &schema.ToolInfo{Name: "task", Desc: taskDesc, Params: schema.ReflectParams[taskArgs]()},
 	}
 }
 

--- a/internal/agent/task_internal_test.go
+++ b/internal/agent/task_internal_test.go
@@ -20,10 +20,7 @@ func TestNewTaskTool_Info(t *testing.T) {
 
 	tool := newTaskTool(newTestAgent(&scriptedModel{}, map[string]schema.InvokableTool{}))
 
-	info, err := tool.Info(context.Background())
-	if err != nil {
-		t.Fatalf("Info: %v", err)
-	}
+	info := tool.Info()
 	if info.Name != "task" {
 		t.Errorf("name = %q, want task", info.Name)
 	}

--- a/internal/agent/todos.go
+++ b/internal/agent/todos.go
@@ -36,11 +36,13 @@ const writeTodosDesc = "Record or update your investigation plan as a todo list 
 
 // newWriteTodosTool builds the write_todos tool bound to a.
 func newWriteTodosTool(a *Agent) *writeTodosTool {
-	params, _ := schema.ReflectParams[writeTodosArgs]()
-
 	return &writeTodosTool{
 		agent: a,
-		info:  &schema.ToolInfo{Name: "write_todos", Desc: writeTodosDesc, Params: params},
+		info: &schema.ToolInfo{
+			Name:   "write_todos",
+			Desc:   writeTodosDesc,
+			Params: schema.ReflectParams[writeTodosArgs](),
+		},
 	}
 }
 

--- a/internal/agent/todos.go
+++ b/internal/agent/todos.go
@@ -45,8 +45,8 @@ func newWriteTodosTool(a *Agent) *writeTodosTool {
 }
 
 // Info returns the tool's static schema.
-func (t *writeTodosTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return t.info, nil
+func (t *writeTodosTool) Info() *schema.ToolInfo {
+	return t.info
 }
 
 // Run satisfies schema.InvokableTool; dispatch never calls it (runScoped is

--- a/internal/agent/todos_internal_test.go
+++ b/internal/agent/todos_internal_test.go
@@ -15,10 +15,7 @@ func TestNewWriteTodosTool_Info(t *testing.T) {
 
 	tool := newWriteTodosTool(newTestAgent(&scriptedModel{}, map[string]schema.InvokableTool{}))
 
-	info, err := tool.Info(context.Background())
-	if err != nil {
-		t.Fatalf("Info: %v", err)
-	}
+	info := tool.Info()
 	if info.Name != "write_todos" {
 		t.Errorf("name = %q, want write_todos", info.Name)
 	}

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -235,8 +235,8 @@ func newVerifyFindingsTool(a *Agent) *verifyFindingsTool {
 }
 
 // Info returns the tool's static schema.
-func (t *verifyFindingsTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return t.info, nil
+func (t *verifyFindingsTool) Info() *schema.ToolInfo {
+	return t.info
 }
 
 // Run satisfies schema.InvokableTool; dispatch never calls it (runScoped is

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -225,11 +225,13 @@ const verifierSystemPrompt = "You are an adversarial reviewer of cloud-security 
 
 // newVerifyFindingsTool builds the verify_findings tool bound to a.
 func newVerifyFindingsTool(a *Agent) *verifyFindingsTool {
-	params, _ := schema.ReflectParams[verifyFindingsArgs]()
-
 	return &verifyFindingsTool{
-		agent:   a,
-		info:    &schema.ToolInfo{Name: "verify_findings", Desc: verifyFindingsDesc, Params: params},
+		agent: a,
+		info: &schema.ToolInfo{
+			Name:   "verify_findings",
+			Desc:   verifyFindingsDesc,
+			Params: schema.ReflectParams[verifyFindingsArgs](),
+		},
 		timeout: passTimeout,
 	}
 }

--- a/internal/agent/verify_internal_test.go
+++ b/internal/agent/verify_internal_test.go
@@ -824,10 +824,7 @@ func TestVerifyFindings_Info(t *testing.T) {
 	t.Parallel()
 
 	a := newVerifierAgent(batchModel{verdict: verdictConfirmed})
-	info, err := newVerifyFindingsTool(a).Info(context.Background())
-	if err != nil {
-		t.Fatalf("Info: %v", err)
-	}
+	info := newVerifyFindingsTool(a).Info()
 	if info.Name != "verify_findings" || info.Params == nil {
 		t.Errorf("info = %+v, want named tool with params schema", info)
 	}

--- a/internal/agent/welcome_internal_test.go
+++ b/internal/agent/welcome_internal_test.go
@@ -21,7 +21,7 @@ func welcomeAgent(t *testing.T, model schema.ChatModel) (*Agent, *metrics.Accumu
 	cfg.Model = model
 	cfg.Connectors = map[string]ConnectorMeta{"eks": {Identity: "cluster/prod", Posture: "view"}}
 
-	a := newAgent(t, cfg)
+	a := New(context.Background(), cfg)
 	a.renderer = echoRenderer
 	acc := metrics.NewAccumulator("p", "m")
 	a.metrics = acc
@@ -137,20 +137,14 @@ func TestConfigWelcomeTimeout_SetsField(t *testing.T) {
 
 	// Positive duration: field must be set.
 	cfg.WelcomeTimeout = 5 * time.Millisecond
-	a, err := New(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	a := New(context.Background(), cfg)
 	if a.welcomeTimeoutD != 5*time.Millisecond {
 		t.Errorf("welcomeTimeoutD = %v, want 5ms", a.welcomeTimeoutD)
 	}
 
 	// Zero duration: field stays zero (the const default is used).
 	cfg.WelcomeTimeout = 0
-	a2, err := New(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	a2 := New(context.Background(), cfg)
 	if a2.welcomeTimeoutD != 0 {
 		t.Errorf("zero duration must leave welcomeTimeoutD zero, got %v", a2.welcomeTimeoutD)
 	}

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -146,7 +146,7 @@ type deps struct {
 	run                  func(ctx context.Context, task string, cfg config.Config, flags researchFlags) error
 	getProviders         getProvidersFunc
 	newChatModel         func(ctx context.Context, cfg config.Config, recordUsage func(schema.Usage)) (chatModel, error)
-	newHTTPRequestTool   func(providers []auth.Provider) (schema.InvokableTool, error)
+	newHTTPRequestTool   func(providers []auth.Provider) schema.InvokableTool
 	newCodeExecutionTool func(primitives []schema.InvokableTool, verbose io.Writer, maxConcurrency int, sink audit.Sink) (schema.InvokableTool, error)
 	newAuditSink         func(cfg config.Config) (audit.Sink, func() error, error)
 	newAgent             func(ctx context.Context, cfg agent.Config, opts ...agent.Option) *agent.Agent
@@ -527,13 +527,8 @@ func (d *deps) buildToolSet(
 	verboseWriter io.Writer,
 	sink audit.Sink,
 ) ([]schema.InvokableTool, error) {
-	httpTool, err := d.newHTTPRequestTool(providers)
-	if err != nil {
-		return nil, fmt.Errorf("build http_request tool: %w", err)
-	}
-
 	// Primitives are exposed (raw) inside the sandbox; the code tool wraps them.
-	primitives := []schema.InvokableTool{httpTool}
+	primitives := []schema.InvokableTool{d.newHTTPRequestTool(providers)}
 
 	codeTool, err := d.newCodeExecutionTool(primitives, verboseWriter, cfg.SandboxMaxConcurrency, sink)
 	if err != nil {

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -149,7 +149,7 @@ type deps struct {
 	newHTTPRequestTool   func(providers []auth.Provider) (schema.InvokableTool, error)
 	newCodeExecutionTool func(primitives []schema.InvokableTool, verbose io.Writer, maxConcurrency int, sink audit.Sink) (schema.InvokableTool, error)
 	newAuditSink         func(cfg config.Config) (audit.Sink, func() error, error)
-	newAgent             func(ctx context.Context, cfg agent.Config, opts ...agent.Option) (*agent.Agent, error)
+	newAgent             func(ctx context.Context, cfg agent.Config, opts ...agent.Option) *agent.Agent
 	ui                   researchUI
 	out                  io.Writer
 	errOut               io.Writer
@@ -271,7 +271,7 @@ func (d *deps) runResearch(ctx context.Context, task string, cfg config.Config, 
 		"gke": cfg.Connectors.GKE.ClusterRole,
 		"aks": cfg.Connectors.AKS.ClusterRole,
 	}
-	a, err := d.newAgent(ctx, agent.Config{
+	a := d.newAgent(ctx, agent.Config{
 		Model:            llm.NewRedactingChatModel(cm, redact.New()),
 		Cfg:              cfg,
 		Tools:            toolSet,
@@ -286,9 +286,6 @@ func (d *deps) runResearch(ctx context.Context, task string, cfg config.Config, 
 		Interrupter:      d.interrupter,
 		OnFirstResponse:  d.showLLMOnce(cfg, &llmShown),
 	})
-	if err != nil {
-		return fmt.Errorf("initialize agent: %w", err)
-	}
 
 	// Detect the terminal background once, before runInitialPhase / the interactive
 	// loop start any turn's keystroke watcher — so the OSC 11/DA1 probe reply cannot

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -692,7 +692,7 @@ func TestInteractiveLoop_ContextCancelled(t *testing.T) {
 func newTestAgent(t *testing.T, m schema.ChatModel) *agent.Agent {
 	t.Helper()
 
-	a, err := agent.New(context.Background(), agent.Config{
+	a := agent.New(context.Background(), agent.Config{
 		Model:         m,
 		Cfg:           validCfg(),
 		Tools:         nil,
@@ -700,9 +700,6 @@ func newTestAgent(t *testing.T, m schema.ChatModel) *agent.Agent {
 		Renderer:      (&fakeUI{}).RenderMessage, //nolint:exhaustruct // no-op renderer
 		VerboseWriter: nil,
 	})
-	if err != nil {
-		t.Fatalf("agent.New: %v", err)
-	}
 
 	return a
 }
@@ -718,29 +715,6 @@ func TestNewChatModel(t *testing.T) {
 	}
 
 	t.Cleanup(cm.Shutdown)
-}
-
-func TestRunResearch_AgentInitError(t *testing.T) {
-	t.Parallel()
-
-	d := testDeps()
-	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
-		return &fakeChatModel{ //nolint:exhaustruct // only the success path is needed here
-			responses: []*schema.Message{assistantMsg("x")},
-		}, nil
-	}
-	d.newAgent = func(context.Context, agent.Config, ...agent.Option) (*agent.Agent, error) {
-		return nil, errors.New("agent boom")
-	}
-
-	err := d.runResearch(context.Background(), "task", validCfg(), researchFlags{}) //nolint:exhaustruct // defaults
-	if err == nil {
-		t.Fatal("expected error from agent init")
-	}
-
-	if !strings.Contains(err.Error(), "initialize agent") {
-		t.Errorf("expected 'initialize agent' in error, got: %v", err)
-	}
 }
 
 func TestRunResearch_CodeToolError(t *testing.T) {
@@ -1198,7 +1172,7 @@ func TestInteractiveLoop_CancelledWithActivity_RendersSessionFooter(t *testing.T
 func newTestAgentWithMetrics(t *testing.T, m schema.ChatModel, acc *metrics.Accumulator) *agent.Agent {
 	t.Helper()
 
-	a, err := agent.New(context.Background(), agent.Config{
+	a := agent.New(context.Background(), agent.Config{
 		Model:         m,
 		Cfg:           validCfg(),
 		Tools:         nil,
@@ -1207,9 +1181,6 @@ func newTestAgentWithMetrics(t *testing.T, m schema.ChatModel, acc *metrics.Accu
 		VerboseWriter: nil,
 		Metrics:       acc,
 	})
-	if err != nil {
-		t.Fatalf("agent.New: %v", err)
-	}
 
 	return a
 }
@@ -1367,7 +1338,7 @@ func (trippedInterrupter) EndTurn()          {}
 func newInterruptedAgent(t *testing.T) *agent.Agent {
 	t.Helper()
 
-	a, err := agent.New(context.Background(), agent.Config{
+	a := agent.New(context.Background(), agent.Config{
 		Model:         &fakeChatModel{}, //nolint:exhaustruct // model never called
 		Cfg:           validCfg(),
 		Tools:         nil,
@@ -1376,9 +1347,6 @@ func newInterruptedAgent(t *testing.T) *agent.Agent {
 		VerboseWriter: nil,
 		Interrupter:   trippedInterrupter{},
 	})
-	if err != nil {
-		t.Fatalf("agent.New: %v", err)
-	}
 
 	return a
 }
@@ -1484,7 +1452,7 @@ func TestRunResearch_PassesInterrupterToAgent(t *testing.T) {
 
 	d := testDeps()
 	d.interrupter = &interrupt.State{}
-	d.newAgent = func(_ context.Context, cfg agent.Config, _ ...agent.Option) (*agent.Agent, error) {
+	d.newAgent = func(_ context.Context, cfg agent.Config, _ ...agent.Option) *agent.Agent {
 		gotCfg = cfg
 
 		return agent.New(context.Background(), cfg)
@@ -1535,7 +1503,7 @@ func TestRunResearch_PassesAboutToAgent(t *testing.T) {
 
 	var gotCfg agent.Config
 	d := testDeps()
-	d.newAgent = func(_ context.Context, cfg agent.Config, _ ...agent.Option) (*agent.Agent, error) {
+	d.newAgent = func(_ context.Context, cfg agent.Config, _ ...agent.Option) *agent.Agent {
 		gotCfg = cfg
 
 		return agent.New(context.Background(), cfg)
@@ -1993,7 +1961,7 @@ func TestRunResearch_WelcomeTimedOut_Proceeds(t *testing.T) {
 		return &seqBlockThenAnswerModel{answer: "here are your repos"}, nil
 	}
 	// Inject a very short welcome timeout via the Config.WelcomeTimeout field.
-	d.newAgent = func(ctx context.Context, cfg agent.Config, opts ...agent.Option) (*agent.Agent, error) {
+	d.newAgent = func(ctx context.Context, cfg agent.Config, opts ...agent.Option) *agent.Agent {
 		cfg.WelcomeTimeout = 1 * time.Millisecond
 
 		return agent.New(ctx, cfg, opts...)

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -204,9 +204,7 @@ func testDeps() *deps {
 		newChatModel: func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
 			return &fakeChatModel{}, nil //nolint:exhaustruct // benign default; tests override per case
 		},
-		newHTTPRequestTool: func(providers []auth.Provider) (schema.InvokableTool, error) {
-			return tools.NewHTTPRequestTool(providers)
-		},
+		newHTTPRequestTool:   tools.NewHTTPRequestTool,
 		newCodeExecutionTool: tools.NewCodeExecutionTool,
 		newAuditSink: func(config.Config) (audit.Sink, func() error, error) {
 			return nil, func() error { return nil }, nil
@@ -450,24 +448,6 @@ func TestRunResearch_VerboseFlag(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "Verbose") {
 		t.Errorf("expected 'Verbose' in output, got: %q", buf.String())
-	}
-}
-
-func TestRunResearch_HTTPToolError(t *testing.T) {
-	t.Parallel()
-
-	d := testDeps()
-	d.newHTTPRequestTool = func([]auth.Provider) (schema.InvokableTool, error) {
-		return nil, errors.New("schema boom")
-	}
-
-	err := d.runResearch(context.Background(), "task", validCfg(), researchFlags{}) //nolint:exhaustruct // defaults
-	if err == nil {
-		t.Fatal("expected error from http_request tool build")
-	}
-
-	if !strings.Contains(err.Error(), "build http_request tool") {
-		t.Errorf("expected 'build http_request tool' in error, got: %v", err)
 	}
 }
 

--- a/internal/cli/wire_shell.go
+++ b/internal/cli/wire_shell.go
@@ -115,9 +115,7 @@ func newDeps() *deps {
 				llm.WithUsageRecorder(recordUsage),
 			)
 		},
-		newHTTPRequestTool: func(providers []auth.Provider) (schema.InvokableTool, error) {
-			return tools.NewHTTPRequestTool(providers)
-		},
+		newHTTPRequestTool:   tools.NewHTTPRequestTool,
 		newCodeExecutionTool: tools.NewCodeExecutionTool,
 		newAuditSink: func(cfg config.Config) (audit.Sink, func() error, error) {
 			if !cfg.Audit.Enabled {

--- a/internal/llm/convert_internal_test.go
+++ b/internal/llm/convert_internal_test.go
@@ -431,12 +431,9 @@ func TestSchemaToToolParameters_NilSchema(t *testing.T) {
 func TestSchemaToolsToParams_BuildsFunctionTool(t *testing.T) {
 	t.Parallel()
 
-	s, err := schema.ReflectParams[struct {
+	s := schema.ReflectParams[struct {
 		URL string `json:"url" jsonschema:"description=the url,required"`
 	}]()
-	if err != nil {
-		t.Fatalf("ReflectParams: %v", err)
-	}
 
 	infos := []*schema.ToolInfo{{
 		Name:   "http_request",

--- a/internal/schema/reflect.go
+++ b/internal/schema/reflect.go
@@ -11,14 +11,13 @@ import "github.com/invopop/jsonschema"
 //   - Anonymous:true omits the auto-generated $id.
 //
 // Descriptions are read from `jsonschema_description:"..."` struct tags; required
-// fields are derived from json tags (an omitempty field is optional). It returns
-// an error to satisfy the builder seam, though invopop's Reflect never fails.
-func ReflectParams[T any]() (*jsonschema.Schema, error) {
+// fields are derived from json tags (an omitempty field is optional).
+func ReflectParams[T any]() *jsonschema.Schema {
 	r := jsonschema.Reflector{
 		Anonymous:                 true,
 		AllowAdditionalProperties: false,
 		DoNotReference:            true,
 	}
 
-	return r.Reflect(*new(T)), nil
+	return r.Reflect(*new(T))
 }

--- a/internal/schema/reflect_test.go
+++ b/internal/schema/reflect_test.go
@@ -17,10 +17,7 @@ type reflectArgs struct {
 func TestReflectParams_Shape(t *testing.T) {
 	t.Parallel()
 
-	s, err := schema.ReflectParams[reflectArgs]()
-	if err != nil {
-		t.Fatalf("ReflectParams: %v", err)
-	}
+	s := schema.ReflectParams[reflectArgs]()
 	if s.Type != "object" {
 		t.Errorf("type = %q, want object", s.Type)
 	}

--- a/internal/schema/tool.go
+++ b/internal/schema/tool.go
@@ -14,12 +14,12 @@ type ToolInfo struct {
 	Params *jsonschema.Schema
 }
 
-// InvokableTool is a host capability the model can invoke. Run receives the
-// model's raw JSON argument string and returns the result string; an execution
-// failure is returned as the result (not a Go error) so the loop can hand it to
-// the model.
+// InvokableTool is a host capability the model can invoke. Info returns the
+// tool's static schema. Run receives the model's raw JSON argument string and
+// returns the result string; an execution failure is returned as the result
+// (not a Go error) so the loop can hand it to the model.
 type InvokableTool interface {
-	Info(ctx context.Context) (*ToolInfo, error)
+	Info() *ToolInfo
 	Run(ctx context.Context, argumentsInJSON string) (string, error)
 }
 

--- a/internal/tools/approval.go
+++ b/internal/tools/approval.go
@@ -39,6 +39,7 @@ type Prompter func(name, arguments, style string, alreadyGranted bool) Decision
 // later call to this tool is auto-approved (still displayed, never paused).
 type approvalTool struct {
 	inner    schema.InvokableTool
+	name     string
 	prompter Prompter
 	style    string
 	granted  atomic.Bool
@@ -49,24 +50,19 @@ var _ schema.InvokableTool = (*approvalTool)(nil)
 // NewApprovalTool wraps inner so each Run is gated by prompter. style is the
 // render style passed through to the prompter for formatting.
 func NewApprovalTool(inner schema.InvokableTool, prompter Prompter, style string) schema.InvokableTool {
-	return &approvalTool{inner: inner, prompter: prompter, style: style}
+	return &approvalTool{inner: inner, name: inner.Info().Name, prompter: prompter, style: style}
 }
 
 // Info delegates to the inner tool so the model sees the real schema.
-func (a *approvalTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
-	return a.inner.Info(ctx)
+func (a *approvalTool) Info() *schema.ToolInfo {
+	return a.inner.Info()
 }
 
 // Run prompts for approval (or honors a standing session grant), records the
 // decision on the context for the audit log, then runs or denies the inner tool.
 func (a *approvalTool) Run(ctx context.Context, argumentsInJSON string) (string, error) {
-	info, err := a.inner.Info(ctx)
-	if err != nil {
-		return "", err
-	}
-
 	granted := a.granted.Load()
-	d := a.prompter(info.Name, argumentsInJSON, a.style, granted)
+	d := a.prompter(a.name, argumentsInJSON, a.style, granted)
 	if d == ApproveSession {
 		a.granted.Store(true)
 	}

--- a/internal/tools/approval_test.go
+++ b/internal/tools/approval_test.go
@@ -2,7 +2,6 @@ package tools_test
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,27 +11,19 @@ import (
 	"github.com/cynative/cynative/internal/tools"
 )
 
-// errFakeInfo is returned by fakeTool.Info when infoErr is set.
-var errFakeInfo = errors.New("info boom")
-
 // fakeTool is a configurable schema.InvokableTool used to drive every branch of
 // the approval decorator and to observe whether the inner tool ran.
 type fakeTool struct {
-	name    string
-	ret     string
-	infoErr error
+	name string
+	ret  string
 
 	ran     bool
 	gotArgs string
 }
 
-// Info reports the configured name, or infoErr when set.
-func (f *fakeTool) Info(context.Context) (*schema.ToolInfo, error) {
-	if f.infoErr != nil {
-		return nil, f.infoErr
-	}
-
-	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}, nil
+// Info reports the configured name.
+func (f *fakeTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: f.name, Desc: "", Params: nil}
 }
 
 // Run records that it ran and the arguments it received.
@@ -46,8 +37,8 @@ func (f *fakeTool) Run(_ context.Context, argumentsInJSON string) (string, error
 // countingTool counts how many times it ran; safe for concurrent Run.
 type countingTool struct{ calls *atomic.Int64 }
 
-func (countingTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "code_execution", Desc: "", Params: nil}, nil
+func (countingTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "code_execution", Desc: "", Params: nil}
 }
 
 func (c countingTool) Run(context.Context, string) (string, error) {
@@ -59,7 +50,7 @@ func (c countingTool) Run(context.Context, string) (string, error) {
 func TestApprovalToolApproveRunsInner(t *testing.T) {
 	t.Parallel()
 
-	inner := &fakeTool{name: "echo", ret: "echoed", infoErr: nil, ran: false, gotArgs: ""}
+	inner := &fakeTool{name: "echo", ret: "echoed", ran: false, gotArgs: ""}
 
 	var gotName, gotArgs, gotStyle string
 
@@ -96,7 +87,7 @@ func TestApprovalToolApproveRunsInner(t *testing.T) {
 func TestApprovalToolDenyReturnsDeniedMessage(t *testing.T) {
 	t.Parallel()
 
-	inner := &fakeTool{name: "echo", ret: "echoed", infoErr: nil, ran: false, gotArgs: ""}
+	inner := &fakeTool{name: "echo", ret: "echoed", ran: false, gotArgs: ""}
 	at := tools.NewApprovalTool(inner, func(string, string, string, bool) tools.Decision { return tools.Deny }, "dark")
 
 	out, err := at.Run(context.Background(), "{}")
@@ -113,35 +104,17 @@ func TestApprovalToolDenyReturnsDeniedMessage(t *testing.T) {
 	}
 }
 
-func TestApprovalToolInfoError(t *testing.T) {
-	t.Parallel()
-
-	inner := &fakeTool{name: "x", ret: "", infoErr: errFakeInfo, ran: false, gotArgs: ""}
-	at := tools.NewApprovalTool(inner, func(string, string, string, bool) tools.Decision {
-		return tools.ApproveOnce
-	}, "dark")
-
-	_, err := at.Run(context.Background(), "{}")
-	if !errors.Is(err, errFakeInfo) {
-		t.Errorf("err=%v want %v", err, errFakeInfo)
-	}
-
-	if inner.ran {
-		t.Error("inner ran despite Info error")
-	}
-}
-
 func TestApprovalToolInfoDelegates(t *testing.T) {
 	t.Parallel()
 
-	inner := &fakeTool{name: "echo", ret: "", infoErr: nil, ran: false, gotArgs: ""}
+	inner := &fakeTool{name: "echo", ret: "", ran: false, gotArgs: ""}
 	at := tools.NewApprovalTool(inner, func(string, string, string, bool) tools.Decision {
 		return tools.ApproveOnce
 	}, "dark")
 
-	info, err := at.Info(context.Background())
-	if err != nil || info.Name != "echo" {
-		t.Errorf("info=%+v err=%v", info, err)
+	info := at.Info()
+	if info.Name != "echo" {
+		t.Errorf("info=%+v", info)
 	}
 }
 
@@ -161,7 +134,7 @@ func TestApprovalTool_RecordsDecisionOnContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			inner := &fakeTool{name: "http_request", ret: "ok", infoErr: nil, ran: false, gotArgs: ""}
+			inner := &fakeTool{name: "http_request", ret: "ok", ran: false, gotArgs: ""}
 			at := tools.NewApprovalTool(inner, func(string, string, string, bool) tools.Decision {
 				return tc.decision
 			}, "notty")
@@ -183,7 +156,7 @@ func TestApprovalTool_RecordsDecisionOnContext(t *testing.T) {
 func TestApprovalTool_SessionGrant_RecordsProvenance(t *testing.T) {
 	t.Parallel()
 
-	inner := &fakeTool{name: "code_execution", ret: "ok", infoErr: nil, ran: false, gotArgs: ""}
+	inner := &fakeTool{name: "code_execution", ret: "ok", ran: false, gotArgs: ""}
 	at := tools.NewApprovalTool(inner, func(string, string, string, bool) tools.Decision {
 		return tools.ApproveSession
 	}, "notty")
@@ -209,7 +182,7 @@ func TestApprovalTool_GrantIsPerToolInstance(t *testing.T) {
 	t.Parallel()
 
 	mk := func(name string, seen *[]bool) schema.InvokableTool {
-		inner := &fakeTool{name: name, ret: "ok", infoErr: nil, ran: false, gotArgs: ""}
+		inner := &fakeTool{name: name, ret: "ok", ran: false, gotArgs: ""}
 
 		return tools.NewApprovalTool(inner, func(_, _, _ string, granted bool) tools.Decision {
 			*seen = append(*seen, granted)

--- a/internal/tools/codeexec.go
+++ b/internal/tools/codeexec.go
@@ -110,10 +110,7 @@ func newCodeExecutionToolWithOpts(
 		opt(o)
 	}
 
-	funcs, descs, err := buildToolFuncs(inner, sink, o.newID)
-	if err != nil {
-		return nil, err
-	}
+	funcs, descs := buildToolFuncs(inner, sink, o.newID)
 
 	params, err := o.codeArgsSchema()
 	if err != nil {
@@ -136,8 +133,8 @@ func newCodeExecutionToolWithOpts(
 }
 
 // Info returns the tool's schema.
-func (t *codeExecutionTool) Info(_ context.Context) (*schema.ToolInfo, error) {
-	return t.info, nil
+func (t *codeExecutionTool) Info() *schema.ToolInfo {
+	return t.info
 }
 
 // Run runs the script. Execution failures are returned as the tool result (not a
@@ -185,16 +182,12 @@ func buildToolFuncs(
 	inner []schema.InvokableTool,
 	sink audit.Sink,
 	newID func() string,
-) (map[string]sandbox.ToolFunc, []toolDesc, error) {
-	ctx := context.Background()
+) (map[string]sandbox.ToolFunc, []toolDesc) {
 	funcs := make(map[string]sandbox.ToolFunc, len(inner))
 	descs := make([]toolDesc, 0, len(inner))
 
 	for _, it := range inner {
-		info, err := it.Info(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("tools: read inner tool info: %w", err)
-		}
+		info := it.Info()
 
 		if info.Name == codeExecutionName {
 			continue
@@ -204,7 +197,7 @@ func buildToolFuncs(
 		descs = append(descs, toolDesc{name: info.Name, desc: info.Desc, params: info.Params})
 	}
 
-	return funcs, descs, nil
+	return funcs, descs
 }
 
 // innerResultDecision returns the audit decision to stamp on an inner result

--- a/internal/tools/codeexec.go
+++ b/internal/tools/codeexec.go
@@ -55,9 +55,8 @@ type toolDesc struct {
 
 // codeExecOptions holds the configurable seams for NewCodeExecutionTool.
 type codeExecOptions struct {
-	codeArgsSchema schemaBuilderFunc
-	newSandbox     func(map[string]sandbox.ToolFunc, io.Writer, int) (codeRunner, error)
-	newID          func() string
+	newSandbox func(map[string]sandbox.ToolFunc, io.Writer, int) (codeRunner, error)
+	newID      func() string
 }
 
 // codeExecOption is a functional option for NewCodeExecutionTool.
@@ -95,9 +94,6 @@ func newCodeExecutionToolWithOpts(
 	opts ...codeExecOption,
 ) (schema.InvokableTool, error) {
 	o := &codeExecOptions{
-		codeArgsSchema: func() (*jsonschema.Schema, error) {
-			return schema.ReflectParams[codeArgs]()
-		},
 		newSandbox: func(funcs map[string]sandbox.ToolFunc, w io.Writer, mc int) (codeRunner, error) {
 			// RedactPreservingLocation (not Redact): sandbox tool results are HTTP
 			// responses whose signed Location URL must survive for redirect-following.
@@ -112,11 +108,6 @@ func newCodeExecutionToolWithOpts(
 
 	funcs, descs := buildToolFuncs(inner, sink, o.newID)
 
-	params, err := o.codeArgsSchema()
-	if err != nil {
-		return nil, fmt.Errorf("tools: build code_execution schema: %w", err)
-	}
-
 	sb, err := o.newSandbox(funcs, verbose, maxConcurrency)
 	if err != nil {
 		return nil, fmt.Errorf("tools: build sandbox: %w", err)
@@ -126,7 +117,7 @@ func newCodeExecutionToolWithOpts(
 		info: &schema.ToolInfo{
 			Name:   codeExecutionName,
 			Desc:   codeDescription(descs, json.Marshal),
-			Params: params,
+			Params: schema.ReflectParams[codeArgs](),
 		},
 		sandbox: sb,
 	}, nil

--- a/internal/tools/codeexec_audit_test.go
+++ b/internal/tools/codeexec_audit_test.go
@@ -35,8 +35,8 @@ type echoTool struct {
 	err error
 }
 
-func (echoTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "http_request", Desc: "echo", Params: nil}, nil
+func (echoTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "http_request", Desc: "echo", Params: nil}
 }
 
 func (e echoTool) Run(_ context.Context, args string) (string, error) {
@@ -269,8 +269,8 @@ func TestCodeExec_ScriptFailure_ReturnsOutputAndMarksFailed(t *testing.T) {
 // on the context but returns the response body with no Go error.
 type markFailTool struct{}
 
-func (markFailTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "http_request", Desc: "", Params: nil}, nil
+func (markFailTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "http_request", Desc: "", Params: nil}
 }
 
 func (markFailTool) Run(ctx context.Context, _ string) (string, error) {
@@ -309,8 +309,8 @@ func TestCodeExec_InnerMarkedFailure_RecordsErrorAndPropagates(t *testing.T) {
 // markProgressTool simulates an inner http_request that gets a sub-4xx response.
 type markProgressTool struct{}
 
-func (markProgressTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "http_request", Desc: "", Params: nil}, nil
+func (markProgressTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "http_request", Desc: "", Params: nil}
 }
 
 func (markProgressTool) Run(ctx context.Context, _ string) (string, error) {

--- a/internal/tools/codeexec_internal_test.go
+++ b/internal/tools/codeexec_internal_test.go
@@ -25,27 +25,19 @@ type probeArgs struct {
 
 // fakeInnerTool is a stand-in InvokableTool.
 type fakeInnerTool struct {
-	name    string
-	desc    string
-	infoErr error
-	runOut  string
+	name   string
+	desc   string
+	runOut string
 }
 
-func (f *fakeInnerTool) Info(_ context.Context) (*schema.ToolInfo, error) {
-	if f.infoErr != nil {
-		return nil, f.infoErr
-	}
-
-	params, err := schema.ReflectParams[probeArgs]()
-	if err != nil {
-		return nil, err
-	}
+func (f *fakeInnerTool) Info() *schema.ToolInfo {
+	params, _ := schema.ReflectParams[probeArgs]()
 
 	return &schema.ToolInfo{
 		Name:   f.name,
 		Desc:   f.desc,
 		Params: params,
-	}, nil
+	}
 }
 
 func (f *fakeInnerTool) Run(_ context.Context, _ string) (string, error) {
@@ -56,8 +48,8 @@ func (f *fakeInnerTool) Run(_ context.Context, _ string) (string, error) {
 // invokerToToolFunc should prefer StructuredRun over Run.
 type structuredFake struct{}
 
-func (structuredFake) Info(_ context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "fake"}, nil //nolint:exhaustruct // minimal
+func (structuredFake) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "fake"} //nolint:exhaustruct // minimal
 }
 
 func (structuredFake) Run(_ context.Context, _ string) (string, error) {
@@ -104,10 +96,7 @@ func TestNewCodeExecutionTool_Info(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 
-	info, err := tl.Info(context.Background())
-	if err != nil {
-		t.Fatalf("info: %v", err)
-	}
+	info := tl.Info()
 
 	if info.Name != codeExecutionName {
 		t.Errorf("name = %q", info.Name)
@@ -156,32 +145,9 @@ func TestNewCodeExecutionTool_SelfExclusion(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 
-	info, _ := tl.Info(context.Background())
+	info := tl.Info()
 	if strings.Contains(info.Desc, codeExecutionName+"(args)") {
 		t.Errorf("code_execution should not be exposed inside itself: %s", info.Desc)
-	}
-}
-
-func TestNewCodeExecutionTool_InfoError(t *testing.T) {
-	t.Parallel()
-
-	mock := &codeRunnerMock{ //nolint:exhaustruct // only RunFunc matters
-		RunFunc: func(_ context.Context, _ string, _ time.Duration) (string, error) { return "", nil },
-	}
-
-	//nolint:exhaustruct // only infoErr matters
-	inner := []schema.InvokableTool{&fakeInnerTool{infoErr: errors.New("boom")}}
-
-	_, err := NewCodeExecutionToolWithOpts(
-		inner,
-		nil,
-		sandbox.DefaultMaxConcurrency,
-		WithCodeSandboxFactory(func(_ map[string]sandbox.ToolFunc, _ io.Writer, _ int) (codeRunner, error) {
-			return mock, nil
-		}),
-	)
-	if err == nil {
-		t.Fatal("expected inner Info error")
 	}
 }
 
@@ -425,8 +391,8 @@ func TestNewCodeExecutionTool_ThreadsMaxConcurrency(t *testing.T) {
 // secretTool returns a github-token-shaped value the production redactor catches.
 type secretTool struct{}
 
-func (secretTool) Info(context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{Name: "leak", Desc: "returns a secret", Params: nil}, nil
+func (secretTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "leak", Desc: "returns a secret", Params: nil}
 }
 
 func (secretTool) Run(context.Context, string) (string, error) {
@@ -501,10 +467,7 @@ func TestNewCodeExecutionTool_OptionalTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	info, err := tl.Info(context.Background())
-	if err != nil {
-		t.Fatalf("info: %v", err)
-	}
+	info := tl.Info()
 
 	// Only `code` is required; `timeout_seconds` has a runtime default and must be optional.
 	if got := info.Params.Required; len(got) != 1 || got[0] != "code" {

--- a/internal/tools/codeexec_internal_test.go
+++ b/internal/tools/codeexec_internal_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/invopop/jsonschema"
-
 	"github.com/cynative/cynative/internal/audit"
 	"github.com/cynative/cynative/internal/sandbox"
 	"github.com/cynative/cynative/internal/schema"
@@ -31,7 +29,7 @@ type fakeInnerTool struct {
 }
 
 func (f *fakeInnerTool) Info() *schema.ToolInfo {
-	params, _ := schema.ReflectParams[probeArgs]()
+	params := schema.ReflectParams[probeArgs]()
 
 	return &schema.ToolInfo{
 		Name:   f.name,
@@ -148,20 +146,6 @@ func TestNewCodeExecutionTool_SelfExclusion(t *testing.T) {
 	info := tl.Info()
 	if strings.Contains(info.Desc, codeExecutionName+"(args)") {
 		t.Errorf("code_execution should not be exposed inside itself: %s", info.Desc)
-	}
-}
-
-func TestNewCodeExecutionTool_SchemaError(t *testing.T) {
-	t.Parallel()
-
-	_, err := NewCodeExecutionToolWithOpts(
-		nil,
-		nil,
-		sandbox.DefaultMaxConcurrency,
-		WithCodeArgsSchema(func() (*jsonschema.Schema, error) { return nil, errors.New("schema boom") }),
-	)
-	if err == nil {
-		t.Fatal("expected schema error")
 	}
 }
 
@@ -327,7 +311,7 @@ func TestSchemaJSON_Nil(t *testing.T) {
 func TestSchemaJSON_MarshalError(t *testing.T) {
 	t.Parallel()
 
-	params, _ := schema.ReflectParams[probeArgs]()
+	params := schema.ReflectParams[probeArgs]()
 
 	errMarshal := func(any) ([]byte, error) { return nil, errors.New("boom") }
 

--- a/internal/tools/export_test.go
+++ b/internal/tools/export_test.go
@@ -10,23 +10,11 @@ import (
 	"github.com/cynative/cynative/internal/schema"
 )
 
-// Seam rule: construction-time seams (read once while building, e.g. schema
-// builder, sandbox factory) are injected as functional options.
-
-// WithHTTPSchemaBuilder returns a functional option that replaces the
-// http_request parameter-schema builder. Used in tests to force the error path.
-func WithHTTPSchemaBuilder(fn schemaBuilderFunc) httpRequestOption {
-	return func(o *httpRequestOptions) { o.schemaBuilder = fn }
-}
-
-// WithHTTPMarshalJSON returns a functional option that replaces the JSON
-// marshaller used by StructuredRun. Used in tests to force the marshal error path.
-func WithHTTPMarshalJSON(fn marshalFunc) httpRequestOption {
-	return func(o *httpRequestOptions) { o.marshalJSON = fn }
-}
+// Seam rule: construction-time seams (read once while building, e.g. the
+// sandbox factory) are injected as functional options.
 
 // NewCodeExecutionToolWithOpts exposes the variadic-options constructor for
-// package-internal tests that need to inject seams (schema builder, sandbox factory).
+// package-internal tests that need to inject seams (sandbox factory, ID func).
 // It forwards a nil sink so all 10 existing callers compile unchanged.
 func NewCodeExecutionToolWithOpts(
 	inner []schema.InvokableTool,
@@ -58,11 +46,6 @@ type RunnerFunc func(ctx context.Context, code string, timeout time.Duration) (s
 // Run satisfies codeRunner.
 func (f RunnerFunc) Run(ctx context.Context, code string, timeout time.Duration) (string, error) {
 	return f(ctx, code, timeout)
-}
-
-// WithCodeArgsSchema injects a replacement schema builder for codeArgs.
-func WithCodeArgsSchema(fn schemaBuilderFunc) codeExecOption {
-	return func(o *codeExecOptions) { o.codeArgsSchema = fn }
 }
 
 // WithCodeSandboxFactory injects a replacement sandbox factory.

--- a/internal/tools/httptool.go
+++ b/internal/tools/httptool.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/invopop/jsonschema"
-
 	"github.com/cynative/cynative/internal/audit"
 	"github.com/cynative/cynative/internal/auth"
 	"github.com/cynative/cynative/internal/schema"
@@ -27,60 +25,27 @@ const httpRequestDescription = "Make a generic HTTP request. Redirects are NOT f
 // statusFloor is the lowest HTTP status treated as a failed request outcome.
 const statusFloor = 400
 
-// schemaBuilderFunc is the type of a function that builds a *jsonschema.Schema.
-type schemaBuilderFunc func() (*jsonschema.Schema, error)
-
-// marshalFunc is the type of a function that marshals a value to JSON bytes.
-type marshalFunc func(any) ([]byte, error)
-
-// httpRequestOptions holds the configurable seams for NewHTTPRequestTool.
-type httpRequestOptions struct {
-	schemaBuilder schemaBuilderFunc
-	marshalJSON   marshalFunc
-}
-
-// httpRequestOption is a functional option for NewHTTPRequestTool.
-type httpRequestOption func(*httpRequestOptions)
-
 // httpRequestTool is the schema tool that executes HTTP requests via transport.
 // It forwards the model's raw JSON arguments to the transport Client unchanged
 // so the auth layer receives the exact bytes it expects.
 type httpRequestTool struct {
-	info        *schema.ToolInfo
-	providers   []auth.Provider
-	marshalJSON marshalFunc
-	client      *transport.Client
+	info      *schema.ToolInfo
+	providers []auth.Provider
+	client    *transport.Client
 }
 
 // NewHTTPRequestTool builds the http_request tool, capturing the auth providers
 // for use during execution.
-func NewHTTPRequestTool(providers []auth.Provider, opts ...httpRequestOption) (schema.InvokableTool, error) {
-	o := &httpRequestOptions{
-		schemaBuilder: func() (*jsonschema.Schema, error) {
-			return schema.ReflectParams[transport.RequestArgs]()
-		},
-		marshalJSON: json.Marshal,
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
-
-	params, err := o.schemaBuilder()
-	if err != nil {
-		return nil, fmt.Errorf("tools: build http_request schema: %w", err)
-	}
-
+func NewHTTPRequestTool(providers []auth.Provider) schema.InvokableTool {
 	return &httpRequestTool{
 		info: &schema.ToolInfo{
 			Name:   "http_request",
 			Desc:   httpRequestDescription,
-			Params: params,
+			Params: schema.ReflectParams[transport.RequestArgs](),
 		},
-		providers:   providers,
-		marshalJSON: o.marshalJSON,
-		client:      transport.NewClient(),
-	}, nil
+		providers: providers,
+		client:    transport.NewClient(),
+	}
 }
 
 // Info returns the tool's schema.
@@ -132,10 +97,9 @@ func (t *httpRequestTool) StructuredRun(ctx context.Context, argumentsInJSON str
 		audit.MarkProgress(ctx)
 	}
 
-	b, err := t.marshalJSON(resp)
-	if err != nil {
-		return "", fmt.Errorf("tools: marshal structured response: %w", err)
-	}
+	// transport.Response is a fixed plain-data struct (ints, strings, bools, a
+	// string-keyed header map), so json.Marshal cannot fail on it.
+	b, _ := json.Marshal(resp)
 
 	return string(b), nil
 }

--- a/internal/tools/httptool.go
+++ b/internal/tools/httptool.go
@@ -84,8 +84,8 @@ func NewHTTPRequestTool(providers []auth.Provider, opts ...httpRequestOption) (s
 }
 
 // Info returns the tool's schema.
-func (t *httpRequestTool) Info(_ context.Context) (*schema.ToolInfo, error) {
-	return t.info, nil
+func (t *httpRequestTool) Info() *schema.ToolInfo {
+	return t.info
 }
 
 // Run executes the HTTP request described by argumentsInJSON. Execution failures

--- a/internal/tools/httptool_test.go
+++ b/internal/tools/httptool_test.go
@@ -41,10 +41,7 @@ func TestNewHTTPRequestTool_Info(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 
-	info, err := tl.Info(context.Background())
-	if err != nil {
-		t.Fatalf("info: %v", err)
-	}
+	info := tl.Info()
 	if info.Name != "http_request" {
 		t.Errorf("name = %q", info.Name)
 	}
@@ -347,10 +344,7 @@ func TestNewHTTPRequestTool_RequiredFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	info, err := tl.Info(context.Background())
-	if err != nil {
-		t.Fatalf("info: %v", err)
-	}
+	info := tl.Info()
 
 	// Top level: only method, url, auth_provider are required.
 	assertRequiredSet(t, "<root>", info.Params.Required, []string{"method", "url", "auth_provider"})

--- a/internal/tools/httptool_test.go
+++ b/internal/tools/httptool_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,8 +12,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/invopop/jsonschema"
 
 	"github.com/cynative/cynative/internal/audit"
 	"github.com/cynative/cynative/internal/auth"
@@ -36,10 +33,7 @@ func tlsCertBase64(t *testing.T, srv *httptest.Server) string {
 func TestNewHTTPRequestTool_Info(t *testing.T) {
 	t.Parallel()
 
-	tl, err := tools.NewHTTPRequestTool(nil)
-	if err != nil {
-		t.Fatalf("new: %v", err)
-	}
+	tl := tools.NewHTTPRequestTool(nil)
 
 	info := tl.Info()
 	if info.Name != "http_request" {
@@ -65,19 +59,6 @@ func TestNewHTTPRequestTool_Info(t *testing.T) {
 	}
 }
 
-func TestNewHTTPRequestTool_SchemaError(t *testing.T) {
-	t.Parallel()
-
-	_, err := tools.NewHTTPRequestTool(nil,
-		tools.WithHTTPSchemaBuilder(func() (*jsonschema.Schema, error) {
-			return nil, errors.New("schema build failed")
-		}),
-	)
-	if err == nil {
-		t.Fatal("expected error when schema generation fails")
-	}
-}
-
 func TestHTTPRequestTool_InvokableRun_Success(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +70,7 @@ func TestHTTPRequestTool_InvokableRun_Success(t *testing.T) {
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
 
-	tl, _ := tools.NewHTTPRequestTool(providers)
+	tl := tools.NewHTTPRequestTool(providers)
 	args, _ := json.Marshal(map[string]any{"method": "GET", "url": srv.URL, "auth_provider": "loopback"})
 
 	out, err := tl.Run(context.Background(), string(args))
@@ -104,7 +85,7 @@ func TestHTTPRequestTool_InvokableRun_Success(t *testing.T) {
 func TestHTTPRequestTool_InvokableRun_BadJSON(t *testing.T) {
 	t.Parallel()
 
-	tl, _ := tools.NewHTTPRequestTool(nil)
+	tl := tools.NewHTTPRequestTool(nil)
 
 	out, err := tl.Run(context.Background(), "not-json")
 	if err != nil {
@@ -127,10 +108,7 @@ func TestHTTPRequestTool_StructuredRun(t *testing.T) {
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
 
-	tl, err := tools.NewHTTPRequestTool(providers)
-	if err != nil {
-		t.Fatalf("NewHTTPRequestTool: %v", err)
-	}
+	tl := tools.NewHTTPRequestTool(providers)
 
 	sr, ok := tl.(schema.StructuredRunner)
 	if !ok {
@@ -157,10 +135,7 @@ func TestHTTPRequestTool_StructuredRun(t *testing.T) {
 func TestHTTPRequestTool_StructuredRun_TransportError(t *testing.T) {
 	t.Parallel()
 
-	tl, err := tools.NewHTTPRequestTool(nil)
-	if err != nil {
-		t.Fatalf("NewHTTPRequestTool: %v", err)
-	}
+	tl := tools.NewHTTPRequestTool(nil)
 
 	sr, ok := tl.(schema.StructuredRunner)
 	if !ok {
@@ -168,45 +143,9 @@ func TestHTTPRequestTool_StructuredRun_TransportError(t *testing.T) {
 	}
 
 	// Bad JSON arguments cause transport.ExecuteStructured to return an error.
-	_, err = sr.StructuredRun(context.Background(), "not-json")
+	_, err := sr.StructuredRun(context.Background(), "not-json")
 	if err == nil {
 		t.Fatal("expected error for bad JSON arguments")
-	}
-}
-
-func TestHTTPRequestTool_StructuredRun_MarshalError(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-
-	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
-
-	tl, err := tools.NewHTTPRequestTool(providers,
-		tools.WithHTTPMarshalJSON(func(any) ([]byte, error) {
-			return nil, errors.New("marshal failed")
-		}),
-	)
-	if err != nil {
-		t.Fatalf("NewHTTPRequestTool: %v", err)
-	}
-
-	sr, ok := tl.(schema.StructuredRunner)
-	if !ok {
-		t.Fatalf("http_request does not implement StructuredRunner")
-	}
-
-	_, err = sr.StructuredRun(
-		context.Background(),
-		fmt.Sprintf(`{"method":"GET","url":%q,"auth_provider":"loopback"}`, srv.URL),
-	)
-	if err == nil {
-		t.Fatal("expected error when marshalJSON fails")
-	}
-	if !strings.Contains(err.Error(), "marshal structured response") {
-		t.Errorf("error message = %q, want to contain %q", err.Error(), "marshal structured response")
 	}
 }
 
@@ -219,7 +158,7 @@ func TestHTTPRequestTool_Run_MarksFailedOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
-	tl, _ := tools.NewHTTPRequestTool(providers)
+	tl := tools.NewHTTPRequestTool(providers)
 	args, _ := json.Marshal(map[string]any{"method": "GET", "url": srv.URL, "auth_provider": "loopback"})
 
 	ctx, fail := audit.WithFailure(context.Background())
@@ -240,7 +179,7 @@ func TestHTTPRequestTool_Run_DoesNotMarkFailedOn2xx(t *testing.T) {
 	defer srv.Close()
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
-	tl, _ := tools.NewHTTPRequestTool(providers)
+	tl := tools.NewHTTPRequestTool(providers)
 	args, _ := json.Marshal(map[string]any{"method": "GET", "url": srv.URL, "auth_provider": "loopback"})
 
 	ctx, fail := audit.WithFailure(context.Background())
@@ -264,7 +203,7 @@ func TestHTTPRequestTool_StructuredRun_MarksFailedOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
-	tl, _ := tools.NewHTTPRequestTool(providers)
+	tl := tools.NewHTTPRequestTool(providers)
 	sr, ok := tl.(schema.StructuredRunner)
 	if !ok {
 		t.Fatalf("http_request does not implement StructuredRunner")
@@ -289,7 +228,7 @@ func TestHTTPRequestTool_StructuredRun_DoesNotMarkFailedOn2xx(t *testing.T) {
 	defer srv.Close()
 
 	providers := []auth.Provider{&authtest.LoopbackProvider{CACert: tlsCertBase64(t, srv)}}
-	tl, _ := tools.NewHTTPRequestTool(providers)
+	tl := tools.NewHTTPRequestTool(providers)
 	sr, ok := tl.(schema.StructuredRunner)
 	if !ok {
 		t.Fatalf("http_request does not implement StructuredRunner")
@@ -308,10 +247,7 @@ func TestHTTPRequestTool_StructuredRun_DoesNotMarkFailedOn2xx(t *testing.T) {
 func TestHTTPRequestTool_StructuredRun_MarksFailedOnTransportError(t *testing.T) {
 	t.Parallel()
 
-	tl, err := tools.NewHTTPRequestTool(nil)
-	if err != nil {
-		t.Fatalf("NewHTTPRequestTool: %v", err)
-	}
+	tl := tools.NewHTTPRequestTool(nil)
 	sr, ok := tl.(schema.StructuredRunner)
 	if !ok {
 		t.Fatalf("http_request does not implement StructuredRunner")
@@ -340,10 +276,7 @@ func assertRequiredSet(t *testing.T, where string, got, want []string) {
 func TestNewHTTPRequestTool_RequiredFields(t *testing.T) {
 	t.Parallel()
 
-	tl, err := tools.NewHTTPRequestTool(nil)
-	if err != nil {
-		t.Fatalf("new: %v", err)
-	}
+	tl := tools.NewHTTPRequestTool(nil)
 	info := tl.Info()
 
 	// Top level: only method, url, auth_provider are required.

--- a/internal/tools/schema_invariant_test.go
+++ b/internal/tools/schema_invariant_test.go
@@ -1,7 +1,6 @@
 package tools_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -29,10 +28,7 @@ func TestToolSchemas_ContainNoSecretShapedContent(t *testing.T) {
 
 	r := redact.New()
 	for _, tool := range []schema.InvokableTool{httpTool, codeTool} {
-		info, infoErr := tool.Info(context.Background())
-		if infoErr != nil {
-			t.Fatalf("Info: %v", infoErr)
-		}
+		info := tool.Info()
 
 		rendered := info.Desc
 		if info.Params != nil {

--- a/internal/tools/schema_invariant_test.go
+++ b/internal/tools/schema_invariant_test.go
@@ -17,10 +17,7 @@ import (
 func TestToolSchemas_ContainNoSecretShapedContent(t *testing.T) {
 	t.Parallel()
 
-	httpTool, err := tools.NewHTTPRequestTool(nil)
-	if err != nil {
-		t.Fatalf("NewHTTPRequestTool: %v", err)
-	}
+	httpTool := tools.NewHTTPRequestTool(nil)
 	codeTool, err := tools.NewCodeExecutionTool([]schema.InvokableTool{httpTool}, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("NewCodeExecutionTool: %v", err)


### PR DESCRIPTION
Closes #69.

Both signatures carried the previous agent framework's fallible shape even though their error paths could never fire. Making them infallible rides the cascade the issue laid out, in two commits:

**`Info() *ToolInfo`** - all six implementations returned a static `(t.info, nil)`. `buildToolset`, `buildToolFuncs`, and `agent.New` lose their only error paths, the CLI drops its agent-init error branch, and the approval decorator captures the tool name once at construction instead of re-fetching Info on every Run.

**`ReflectParams[T]() *jsonschema.Schema`** - the error existed only to satisfy the builder seam. Dropping it deletes the fake-fallible schema-builder and marshal seams in `internal/tools` with their three forced-error tests, makes `NewHTTPRequestTool` infallible up through the CLI wiring, and removes the `params, _ :=` discards in the agent. `StructuredRun`'s marshal-error branch becomes a commented discard: `transport.Response` is a fixed plain-data struct that `json.Marshal` cannot fail on.

Deliberately kept: `NewCodeExecutionTool` stays fallible (the sandbox constructor has a real error path) and the code-exec test constructors are unchanged.

-384 net lines. Each commit passes `make check` on its own; no behavior changes.
