### PR TITLE
refactor: share one TLS-config builder between transport and auth bootstrap

### DIFF
--- a/internal/auth/k8s_fetch_internal_test.go
+++ b/internal/auth/k8s_fetch_internal_test.go
@@ -94,9 +94,9 @@ func TestClusterHTTPClient_PropagatesBuildError(t *testing.T) {
 	t.Parallel()
 
 	// pinnedHTTPClient is shell (gate-exempt); this guards that it hands its
-	// args to buildClusterTLSConfig and passes the helper's error through.
+	// args to BuildTLSConfig and passes the helper's error through.
 	_, err := pinnedHTTPClient("not-base64-!!", "", "", "", nil)
-	if err == nil || !strings.Contains(err.Error(), "k8s_hardening: decode cluster CA:") {
+	if err == nil || !strings.Contains(err.Error(), "failed to decode CA certificate") {
 		t.Fatalf("want decode cluster CA error, got %v", err)
 	}
 }

--- a/internal/auth/k8s_fetch_shell.go
+++ b/internal/auth/k8s_fetch_shell.go
@@ -17,19 +17,14 @@ const maxViewRoleBytes = 1 << 20 // 1 MiB.
 
 // pinnedHTTPClient builds an [http.Client] trusting the system roots plus caData
 // (base64 PEM), optionally presenting a client certificate (base64 PEM cert+key)
-// for mTLS clusters. It mirrors transport.tlsTransport but lives here because
-// auth must not import transport. control, when non-nil, is installed as the
-// [net.Dialer] ControlContext hook so the bootstrap fetch runs through the dial guard.
+// for mTLS clusters, via [BuildTLSConfig] (the same builder the transport
+// request path uses). control, when non-nil, is installed as the [net.Dialer]
+// ControlContext hook so the bootstrap fetch runs through the dial guard.
 func pinnedHTTPClient(
 	caData, clientCert, clientKey, serverName string,
 	control func(ctx context.Context, network, address string, c syscall.RawConn) error,
 ) (*http.Client, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		pool = x509.NewCertPool()
-	}
-
-	tlsCfg, err := buildClusterTLSConfig(pool, caData, clientCert, clientKey, serverName)
+	tlsCfg, err := BuildTLSConfig(x509.SystemCertPool, caData, clientCert, clientKey, serverName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/k8s_tls.go
+++ b/internal/auth/k8s_tls.go
@@ -1,55 +1,8 @@
 package auth
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
-	"errors"
-	"fmt"
 	"net/http"
 )
-
-// buildClusterTLSConfig assembles the cluster TLS config from base64-PEM material:
-// it appends caData to pool, optionally loads a base64-PEM client cert+key for
-// mTLS, and sets ServerName when non-empty. Pure; the system-root pool load and
-// the HTTP transport/client build stay in the shell (pinnedHTTPClient).
-func buildClusterTLSConfig(
-	pool *x509.CertPool, caData, clientCert, clientKey, serverName string,
-) (*tls.Config, error) {
-	if caData != "" {
-		rawCA, decErr := base64.StdEncoding.DecodeString(caData)
-		if decErr != nil {
-			return nil, fmt.Errorf("k8s_hardening: decode cluster CA: %w", decErr)
-		}
-		if !pool.AppendCertsFromPEM(rawCA) {
-			return nil, errors.New("k8s_hardening: parse cluster CA")
-		}
-	}
-
-	tlsCfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12} //nolint:exhaustruct // defaults are fine.
-
-	if serverName != "" {
-		tlsCfg.ServerName = serverName
-	}
-
-	if clientCert != "" && clientKey != "" {
-		rawCert, certErr := base64.StdEncoding.DecodeString(clientCert)
-		if certErr != nil {
-			return nil, fmt.Errorf("k8s_hardening: decode client cert: %w", certErr)
-		}
-		rawKey, keyErr := base64.StdEncoding.DecodeString(clientKey)
-		if keyErr != nil {
-			return nil, fmt.Errorf("k8s_hardening: decode client key: %w", keyErr)
-		}
-		pair, pairErr := tls.X509KeyPair(rawCert, rawKey)
-		if pairErr != nil {
-			return nil, fmt.Errorf("k8s_hardening: client key pair: %w", pairErr)
-		}
-		tlsCfg.Certificates = []tls.Certificate{pair}
-	}
-
-	return tlsCfg, nil
-}
 
 // clusterConn is the pure, assembled description of how to reach a cluster's API
 // server for the bootstrap view fetch: the endpoint URL and the base64-PEM TLS

--- a/internal/auth/k8s_tls_internal_test.go
+++ b/internal/auth/k8s_tls_internal_test.go
@@ -1,115 +1,13 @@
 package auth
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"k8s.io/client-go/rest"
-
-	"github.com/cynative/cynative/internal/auth/authtest"
 )
-
-func TestBuildClusterTLSConfig(t *testing.T) {
-	t.Parallel()
-
-	caPEM, _, err := authtest.GenerateCA()
-	if err != nil {
-		t.Fatalf("GenerateCA: %v", err)
-	}
-	validCA := base64.StdEncoding.EncodeToString(caPEM)
-
-	// A self-signed cert with its matching key — tls.X509KeyPair succeeds.
-	clientCertPEM, clientKeyPEM, err := authtest.GenerateCA()
-	if err != nil {
-		t.Fatalf("GenerateCA (client): %v", err)
-	}
-	validCert := base64.StdEncoding.EncodeToString(clientCertPEM)
-	validKey := base64.StdEncoding.EncodeToString(clientKeyPEM)
-
-	// A different key, so cert/key do not match.
-	_, otherKeyPEM, err := authtest.GenerateCA()
-	if err != nil {
-		t.Fatalf("GenerateCA (mismatch): %v", err)
-	}
-	mismatchKey := base64.StdEncoding.EncodeToString(otherKeyPEM)
-
-	// Valid base64 of non-PEM bytes — AppendCertsFromPEM returns false.
-	nonPEM := base64.StdEncoding.EncodeToString([]byte("not a pem block"))
-
-	tests := []struct {
-		name       string
-		caData     string
-		clientCert string
-		clientKey  string
-		serverName string
-		wantErr    string // substring; "" means success.
-		wantCert   bool   // expect exactly one tls.Certificate.
-		wantServer string // expected ServerName.
-	}{
-		{name: "valid CA only", caData: validCA},
-		{name: "bad base64 CA", caData: "not-base64-!!", wantErr: "k8s_hardening: decode cluster CA:"},
-		{name: "non-PEM CA", caData: nonPEM, wantErr: "k8s_hardening: parse cluster CA"},
-		{name: "server name set", caData: validCA, serverName: "api.example.com", wantServer: "api.example.com"},
-		{name: "valid client cert+key", caData: validCA, clientCert: validCert, clientKey: validKey, wantCert: true},
-		{
-			name: "bad base64 client cert", caData: validCA, clientCert: "not-base64-!!", clientKey: validKey,
-			wantErr: "k8s_hardening: decode client cert:",
-		},
-		{
-			name: "bad base64 client key", caData: validCA, clientCert: validCert, clientKey: "not-base64-!!",
-			wantErr: "k8s_hardening: decode client key:",
-		},
-		{
-			name: "mismatched cert/key", caData: validCA, clientCert: validCert, clientKey: mismatchKey,
-			wantErr: "k8s_hardening: client key pair:",
-		},
-		{name: "client cert but empty key", caData: validCA, clientCert: validCert, clientKey: "", wantCert: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			pool := x509.NewCertPool()
-			cfg, cfgErr := buildClusterTLSConfig(pool, tt.caData, tt.clientCert, tt.clientKey, tt.serverName)
-
-			if tt.wantErr != "" {
-				if cfgErr == nil || !strings.Contains(cfgErr.Error(), tt.wantErr) {
-					t.Fatalf("want error containing %q, got %v", tt.wantErr, cfgErr)
-				}
-
-				return
-			}
-			if cfgErr != nil {
-				t.Fatalf("unexpected error: %v", cfgErr)
-			}
-			assertBuiltTLSConfig(t, cfg, pool, tt.wantServer, tt.wantCert)
-		})
-	}
-}
-
-// assertBuiltTLSConfig checks the success-path shape of a built cluster TLS config.
-func assertBuiltTLSConfig(t *testing.T, cfg *tls.Config, pool *x509.CertPool, wantServer string, wantCert bool) {
-	t.Helper()
-
-	if cfg.MinVersion != tls.VersionTLS12 {
-		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
-	}
-	if cfg.RootCAs != pool {
-		t.Error("RootCAs should be the passed-in pool")
-	}
-	if cfg.ServerName != wantServer {
-		t.Errorf("ServerName = %q, want %q", cfg.ServerName, wantServer)
-	}
-	if gotCert := len(cfg.Certificates) == 1; gotCert != wantCert {
-		t.Errorf("one client certificate present = %v, want %v", gotCert, wantCert)
-	}
-}
 
 func TestBearerInject(t *testing.T) {
 	t.Parallel()

--- a/internal/auth/tlsconfig.go
+++ b/internal/auth/tlsconfig.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+// BuildTLSConfig assembles a TLS client config from base64-PEM material. It is
+// shared by the transport request path (custom CA / mTLS providers) and the
+// auth bootstrap fetches (the K8s ClusterRole fetch and the GitLab probe).
+//
+// The config starts from systemPool's roots (falling back to an empty pool when
+// the system pool is unavailable), so endpoints using publicly-trusted
+// certificates (e.g. GKE DNS endpoints) keep working, while the appended custom
+// caData allows connections to private endpoints (e.g. EKS/GKE cluster IPs with
+// self-signed CAs). A clientCert+clientKey pair enables mTLS, serverName
+// overrides SNI/verification when non-empty, and MinVersion is pinned to TLS 1.2.
+func BuildTLSConfig(
+	systemPool func() (*x509.CertPool, error),
+	caData, clientCert, clientKey, serverName string,
+) (*tls.Config, error) {
+	pool, sysErr := systemPool()
+	if sysErr != nil {
+		pool = x509.NewCertPool()
+	}
+
+	if caData != "" {
+		rawCA, decErr := base64.StdEncoding.DecodeString(caData)
+		if decErr != nil {
+			return nil, fmt.Errorf("failed to decode CA certificate: %w", decErr)
+		}
+		if !pool.AppendCertsFromPEM(rawCA) {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+	}
+
+	tlsCfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12} //nolint:exhaustruct // defaults are fine.
+
+	if serverName != "" {
+		tlsCfg.ServerName = serverName
+	}
+
+	if clientCert != "" && clientKey != "" {
+		rawCert, certErr := base64.StdEncoding.DecodeString(clientCert)
+		if certErr != nil {
+			return nil, fmt.Errorf("failed to decode client certificate: %w", certErr)
+		}
+		rawKey, keyErr := base64.StdEncoding.DecodeString(clientKey)
+		if keyErr != nil {
+			return nil, fmt.Errorf("failed to decode client key: %w", keyErr)
+		}
+		pair, pairErr := tls.X509KeyPair(rawCert, rawKey)
+		if pairErr != nil {
+			return nil, fmt.Errorf("failed to parse client certificate key pair: %w", pairErr)
+		}
+		tlsCfg.Certificates = []tls.Certificate{pair}
+	}
+
+	return tlsCfg, nil
+}

--- a/internal/auth/tlsconfig_test.go
+++ b/internal/auth/tlsconfig_test.go
@@ -1,0 +1,129 @@
+package auth_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cynative/cynative/internal/auth"
+	"github.com/cynative/cynative/internal/auth/authtest"
+)
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	caPEM, _, err := authtest.GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+	validCA := base64.StdEncoding.EncodeToString(caPEM)
+
+	// A self-signed cert with its matching key, so tls.X509KeyPair succeeds.
+	clientCertPEM, clientKeyPEM, err := authtest.GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA (client): %v", err)
+	}
+	validCert := base64.StdEncoding.EncodeToString(clientCertPEM)
+	validKey := base64.StdEncoding.EncodeToString(clientKeyPEM)
+
+	// A different key, so cert/key do not match.
+	_, otherKeyPEM, err := authtest.GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA (mismatch): %v", err)
+	}
+	mismatchKey := base64.StdEncoding.EncodeToString(otherKeyPEM)
+
+	// Valid base64 of non-PEM bytes, so AppendCertsFromPEM returns false.
+	nonPEM := base64.StdEncoding.EncodeToString([]byte("not a pem block"))
+
+	tests := []buildTLSConfigCase{
+		{name: "valid CA only", caData: validCA},
+		{name: "system pool unavailable falls back to empty pool", poolErr: true, caData: validCA},
+		{name: "bad base64 CA", caData: "not-base64-!!", wantErr: "failed to decode CA certificate"},
+		{name: "non-PEM CA", caData: nonPEM, wantErr: "failed to parse CA certificate"},
+		{name: "server name set", caData: validCA, serverName: "api.example.com", wantServer: "api.example.com"},
+		{name: "valid client cert+key", caData: validCA, clientCert: validCert, clientKey: validKey, wantCert: true},
+		{
+			name: "bad base64 client cert", caData: validCA, clientCert: "not-base64-!!", clientKey: validKey,
+			wantErr: "failed to decode client certificate",
+		},
+		{
+			name: "bad base64 client key", caData: validCA, clientCert: validCert, clientKey: "not-base64-!!",
+			wantErr: "failed to decode client key",
+		},
+		{
+			name: "mismatched cert/key", caData: validCA, clientCert: validCert, clientKey: mismatchKey,
+			wantErr: "failed to parse client certificate key pair",
+		},
+		{name: "client cert but empty key", caData: validCA, clientCert: validCert, clientKey: "", wantCert: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runBuildTLSConfigCase(t, tt)
+		})
+	}
+}
+
+// buildTLSConfigCase is one row of the TestBuildTLSConfig table.
+type buildTLSConfigCase struct {
+	name       string
+	poolErr    bool // systemPool returns an error (empty-pool fallback).
+	caData     string
+	clientCert string
+	clientKey  string
+	serverName string
+	wantErr    string // substring; "" means success.
+	wantCert   bool   // expect exactly one tls.Certificate.
+	wantServer string // expected ServerName.
+}
+
+// runBuildTLSConfigCase executes one table row against auth.BuildTLSConfig.
+func runBuildTLSConfigCase(t *testing.T, tt buildTLSConfigCase) {
+	t.Helper()
+
+	pool := x509.NewCertPool()
+	systemPool := func() (*x509.CertPool, error) { return pool, nil }
+	if tt.poolErr {
+		systemPool = func() (*x509.CertPool, error) { return nil, errors.New("system pool unavailable") }
+	}
+
+	cfg, cfgErr := auth.BuildTLSConfig(systemPool, tt.caData, tt.clientCert, tt.clientKey, tt.serverName)
+
+	if tt.wantErr != "" {
+		if cfgErr == nil || !strings.Contains(cfgErr.Error(), tt.wantErr) {
+			t.Fatalf("want error containing %q, got %v", tt.wantErr, cfgErr)
+		}
+
+		return
+	}
+	if cfgErr != nil {
+		t.Fatalf("unexpected error: %v", cfgErr)
+	}
+	assertBuiltTLSConfig(t, cfg, tt.wantServer, tt.wantCert)
+	if !tt.poolErr && cfg.RootCAs != pool {
+		t.Error("RootCAs should be the system pool")
+	}
+}
+
+// assertBuiltTLSConfig checks the success-path shape of a built TLS config.
+func assertBuiltTLSConfig(t *testing.T, cfg *tls.Config, wantServer string, wantCert bool) {
+	t.Helper()
+
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if cfg.RootCAs == nil {
+		t.Error("RootCAs should be set")
+	}
+	if cfg.ServerName != wantServer {
+		t.Errorf("ServerName = %q, want %q", cfg.ServerName, wantServer)
+	}
+	if gotCert := len(cfg.Certificates) == 1; gotCert != wantCert {
+		t.Errorf("one client certificate present = %v, want %v", gotCert, wantCert)
+	}
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -3,11 +3,8 @@ package transport
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -381,12 +378,12 @@ func dialGuard(
 	}
 }
 
-// configureTransport always installs a per-request [*http.Transport] (a clone of
-// [http.DefaultTransport] — never the shared default) whose dialer runs the
+// configureTransport always installs a per-request [*http.Transport] built fresh
+// from scratch (never the shared [http.DefaultTransport]) whose dialer runs the
 // dial-time IP guard, even when no CA / client cert is supplied. When the active
-// provider supplies a CA and/or client cert, the TLS material is layered onto the
-// same clone. It returns a cleanup function that must be deferred by the caller
-// to release idle connections.
+// provider supplies a CA and/or client cert, the TLS material is set on that same
+// transport. It returns a cleanup function that must be deferred by the caller to
+// release idle connections.
 func (c *Client) configureTransport(
 	ctx context.Context,
 	client *http.Client,
@@ -439,78 +436,23 @@ func (c *Client) configureTransport(
 	return tr.CloseIdleConnections, nil
 }
 
-// tlsTransport returns an [*http.Transport] configured to trust both the system
-// root CAs and the given custom CA certificate, and additionally injects a client
-// certificate and key if provided. The data parameters must be base64-encoded PEM.
-//
-// Starting from the system pool ensures that endpoints using publicly-trusted
-// certificates (e.g. GKE DNS endpoints) continue to work, while the appended
-// custom CA allows connections to private endpoints (e.g. EKS/GKE cluster IPs
-// with self-signed CAs).
+// tlsTransport installs on base a TLS config built by [auth.BuildTLSConfig]:
+// system roots (via the injected systemCertPool seam) plus the given custom CA,
+// and optionally a client certificate/key pair for mTLS. The data parameters
+// must be base64-encoded PEM. configureTransport, the only caller, always passes
+// a fresh base with no TLSClientConfig, so the built config is set wholesale.
 func (c *Client) tlsTransport(
 	base *http.Transport,
 	caData, clientCertData, clientKeyData, serverName string,
 ) (*http.Transport, error) {
-	pool, sysErr := c.systemCertPool()
-	if sysErr != nil {
-		pool = x509.NewCertPool()
-	}
-
-	if caData != "" {
-		rawCA, err := base64.StdEncoding.DecodeString(caData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode CA certificate: %w", err)
-		}
-
-		if !pool.AppendCertsFromPEM(rawCA) {
-			return nil, errors.New("failed to parse CA certificate")
-		}
-	}
-
-	certs, err := parseClientCert(clientCertData, clientKeyData)
+	tlsCfg, err := auth.BuildTLSConfig(c.systemCertPool, caData, clientCertData, clientKeyData, serverName)
 	if err != nil {
 		return nil, err
 	}
 
-	t := base.Clone()
-	if t.TLSClientConfig == nil {
-		t.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-	}
-	t.TLSClientConfig.RootCAs = pool
-	if len(certs) > 0 {
-		t.TLSClientConfig.Certificates = certs
-	}
-	if serverName != "" {
-		t.TLSClientConfig.ServerName = serverName
-	}
+	base.TLSClientConfig = tlsCfg
 
-	return t, nil
-}
-
-// parseClientCert decodes a base64-encoded PEM client certificate/key pair into
-// a [tls.Certificate] slice for mTLS. It returns nil (no client cert) when
-// either input is empty, and an error when decoding or pairing fails.
-func parseClientCert(clientCertData, clientKeyData string) ([]tls.Certificate, error) {
-	if clientCertData == "" || clientKeyData == "" {
-		return nil, nil
-	}
-
-	rawCert, err := base64.StdEncoding.DecodeString(clientCertData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode client certificate: %w", err)
-	}
-
-	rawKey, err := base64.StdEncoding.DecodeString(clientKeyData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode client key: %w", err)
-	}
-
-	cert, err := tls.X509KeyPair(rawCert, rawKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse client certificate key pair: %w", err)
-	}
-
-	return []tls.Certificate{cert}, nil
+	return base, nil
 }
 
 // FormatResponse redacts, dumps, and truncates an HTTP response. The body is

--- a/internal/transport/transport_internal_test.go
+++ b/internal/transport/transport_internal_test.go
@@ -759,53 +759,22 @@ func TestExecute_CACert_BadPEM(t *testing.T) {
 	}
 }
 
-func TestCATransport_ExistingHTTPTransport(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprintf(w, "ok")
-	}))
-	t.Cleanup(srv.Close)
-
-	caBase64 := tlsCertBase64(t, srv)
-
-	base := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
-	}
-
-	tr, err := NewClient().tlsTransport(base, caBase64, "", "", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if tr.TLSClientConfig.RootCAs == nil {
-		t.Error("expected RootCAs to be set")
-	}
-}
-
 func TestCATransport_SystemCertPoolFailure(t *testing.T) {
 	t.Parallel()
 
+	// Pins that tlsTransport threads the injected systemCertPool seam into
+	// auth.BuildTLSConfig, whose empty-pool fallback keeps the custom CA usable
+	// even when the system pool is unavailable.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "ok")
 	}))
 	t.Cleanup(srv.Close)
-
-	caBase64 := tlsCertBase64(t, srv)
-
-	base := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
-	}
 
 	c := NewClient(WithSystemCertPool(func() (*x509.CertPool, error) {
 		return nil, errors.New("system pool unavailable")
 	}))
 
-	tr, err := c.tlsTransport(base, caBase64, "", "", "")
+	tr, err := c.tlsTransport(&http.Transport{}, tlsCertBase64(t, srv), "", "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1374,31 +1343,6 @@ func TestTLSTransport_BadClientKeyBase64(t *testing.T) {
 	_, err := NewClient().tlsTransport(&http.Transport{}, "", "dmFsaWQtYmFzZTY0", "bad!base64", "")
 	if err == nil || !strings.Contains(err.Error(), "failed to decode client key") {
 		t.Errorf("expected base64 decode error, got %v", err)
-	}
-}
-
-func TestTLSTransport_NilTLSClientConfigDoesNotPanic(t *testing.T) {
-	t.Parallel()
-
-	// http.DefaultTransport.Clone() can yield a nil TLSClientConfig (e.g. under
-	// GODEBUG=http2client=0). tlsTransport must allocate it rather than panic.
-	// ForceAttemptHTTP2 is false (zero value) and DialContext is non-nil, so
-	// Clone()'s onceSetNextProtoDefaults early-returns without allocating
-	// TLSClientConfig — reproducing the nil-config case deterministically.
-	base := &http.Transport{DialContext: (&net.Dialer{}).DialContext}
-
-	tr, err := NewClient().tlsTransport(base, "", "", "", "")
-	if err != nil {
-		t.Fatalf("tlsTransport returned error: %v", err)
-	}
-	if tr.TLSClientConfig == nil {
-		t.Fatal("tlsTransport must initialize TLSClientConfig when the base left it nil")
-	}
-	if tr.TLSClientConfig.RootCAs == nil {
-		t.Error("tlsTransport must set RootCAs on the TLS config")
-	}
-	if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
-		t.Errorf("MinVersion = %#x, want tls.VersionTLS12 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS12)
 	}
 }
 


### PR DESCRIPTION
## What & why

Closes #72.

The TLS client-config assembly (system-pool + custom-CA pinning, mTLS cert/key, TLS 1.2 floor, ServerName) lived in two places: `transport.tlsTransport` + `parseClientCert`, and `auth.buildClusterTLSConfig` serving the K8s and GitLab bootstrap fetches. The empty-pool `SystemCertPool` fallback was duplicated too. The old comment claimed auth must not import transport, but the import edge already runs the other way (transport imports auth), so one exported builder can live on the auth side with no new import edges.

This adds `auth.BuildTLSConfig(systemPool, caData, clientCert, clientKey, serverName)` and routes all three consumers through it:

- `transport.tlsTransport` shrinks to a 6-line adapter that threads its injected `systemCertPool` seam.
- `auth.pinnedHTTPClient` (K8s eks/gke/aks/kubernetes + GitLab bootstrap) passes `x509.SystemCertPool`.

Deleted: `parseClientCert`, the dead clone/preserve-existing-`TLSClientConfig` branch (the sole caller `configureTransport` always passes a fresh transport), and their two pinning tests. `TestCATransport_SystemCertPoolFailure` becomes a seam-wiring pin.

Error strings adopt transport's wording, so all transport assertions survive unchanged and the GitLab probe's CA errors stop being mislabeled with a `k8s_hardening:` prefix. A stale `configureTransport` doc comment (still describing a `http.DefaultTransport` clone) is corrected.

**Only externally-visible change:** the K8s/GitLab bootstrap CA/cert error prefixes now match transport's wording. Net -76 lines; the security-critical assembly now exists in exactly one place, used by the request path and both bootstrap paths.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed (n/a — no user-facing docs; only internal error-prefix wording)
