### PR TITLE
docs: condense AGENTS.md and fix claims that drifted from the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,632 @@
 # AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) and other coding agents when working with code in this repository. `CLAUDE.md` is a symlink to this file.
+This file provides guidance to Claude Code (claude.ai/code) and other coding agents when working
+with code in this repository. `CLAUDE.md` is a symlink to this file.
 
 ## Commands
 
-All targets are wired through `make`. Lint and test rely on `go tool golangci-lint` (pinned via `go.mod`), so no separate install is needed. `moq` is pinned the same way and `make generate` writes the gitignored `*_mock_test.go` mocks — **run `make generate` before `go test ./internal/<pkg>` on a fresh checkout**, or the tests won't compile.
+All targets are wired through `make`. Lint and test rely on `go tool golangci-lint` (pinned via
+`go.mod`), so no separate install is needed. `moq` is pinned the same way and `make generate`
+writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
+`go test ./internal/<pkg>` on a fresh checkout**, or the tests won't compile.
 
-- `make check` — the full gate CI runs: `check-go` + `check-scripts`.
-- `make check-go` — generate + lint + shell-complexity + format-diff + test + `windows-build` (GOOS=windows amd64/arm64 cross-compile); 100% `go.mod`-pinned/hermetic; **the pre-commit hook runs this**.
-- `make check-scripts` — `shellcheck` (all tracked `*.sh`, pinned `v0.11.0`) + PSScriptAnalyzer on `install.ps1` + Pester unit tests (pinned `1.25.0`/`5.7.1`) + `sh-test` (the POSIX `install.sh` unit tests plus a `python3`-backed loopback fixture-server smoke test that exercises the `CYNATIVE_BASE_URL` download-base seam end-to-end and its non-loopback-HTTP reject). Install-free: asserts each pinned tool/module is present and fails with an install hint otherwise (needs `shellcheck` + PowerShell 7 + `python3`). The pinned PowerShell/shellcheck versions are set in the `Makefile` and bumped by hand — Dependabot has no PowerShell Gallery or raw-binary ecosystem.
-- `make generate` — `go generate ./...` (regenerates the `moq` mocks).
-- `make lint` — `go tool golangci-lint run`.
-- `make format` — `go tool golangci-lint fmt --diff` (prints diffs; does not write).
-- `make test` — runs `CGO_ENABLED=1 go test -race -shuffle=on ./... -coverprofile=coverage.out -covermode=atomic`, then **fails unless every statement outside the imperative shell (`*_shell.go`) and the test-support package `internal/auth/authtest` is covered**. On failure it prints each uncovered `file:line`. The same target then runs an import guard, once per goreleaser-shipped platform (linux/windows/darwin x amd64/arm64 at `CGO_ENABLED=0`, since a build-tagged importer is invisible to the other build contexts): `go list` must show no non-test importer of `internal/auth/authtest`, so the coverage-exempt package can mechanically never reach a shipped binary.
-- `make shell-complexity` — runs `go tool gocyclo`/`gocognit` over every `*_shell.go` file and **fails CI if any function exceeds cyclomatic or cognitive complexity 6**. Shell files are exempt from the 100% coverage gate, so this keeps them thin: a violation means *extract the logic into gated (covered) core*, not raise the budget. AST-only (no `make generate` needed); fails closed on any non-zero exit. No per-function escape hatch — the gate also rejects the tools' native `//gocyclo:ignore`/`//gocognit:ignore` skip directives in shell files. The standalone tools are pinned `go tool` deps; non-shell (core) files remain governed by `.golangci.yaml` (`cyclop` 30 / `gocognit` 20).
-- Run a single test: `go test ./internal/agent -run TestName` (add `-v` for output, `-count=1` to skip cache).
+- `make check`: the full gate CI runs, `check-go` + `check-scripts`.
+- `make check-go`: generate + lint + shell-complexity + format-diff + test + `windows-build`
+  (GOOS=windows amd64/arm64 cross-compile). 100% `go.mod`-pinned and hermetic; **the pre-commit
+  hook runs this**.
+- `make check-scripts`: `shellcheck` (all tracked `*.sh`) + PSScriptAnalyzer on `install.ps1` +
+  Pester unit tests + `sh-test` (the POSIX `install.sh` unit tests plus a `python3`-backed
+  loopback smoke test of the `CYNATIVE_BASE_URL` download-base seam and its non-loopback-HTTP
+  reject). Install-free: asserts each pinned tool or module is present and fails with an install
+  hint otherwise (needs `shellcheck`, PowerShell 7, `python3`). The pinned shellcheck/Pester/
+  PSScriptAnalyzer versions live in the `Makefile` and are bumped by hand; Dependabot has no
+  PowerShell Gallery or raw-binary ecosystem.
+- `make generate`: `go generate ./...` (regenerates the `moq` mocks).
+- `make lint`: `go tool golangci-lint run`.
+- `make format`: `go tool golangci-lint fmt --diff` (prints diffs; does not write).
+- `make test`: runs `CGO_ENABLED=1 go test -race -shuffle=on ./...` with atomic coverage, then
+  **fails unless every statement outside the imperative shell (`*_shell.go`) and the
+  test-support package `internal/auth/authtest` is covered**, printing each uncovered
+  `file:line`. Add tests alongside new code or the gate fails. The authtest exemption carries a
+  companion import guard, run once per goreleaser-shipped platform (linux/windows/darwin x
+  amd64/arm64 at `CGO_ENABLED=0`, since a build-tagged importer is invisible to other build
+  contexts): `go list` must show no non-test importer of `internal/auth/authtest`, so
+  coverage-exempt code can mechanically never reach a shipped binary. The fakes themselves are
+  load-bearing in six consumer test suites, which is what pins their behavior.
+- `make shell-complexity`: `go tool gocyclo`/`gocognit` over every `*_shell.go` file; **fails if
+  any function exceeds cyclomatic or cognitive complexity 6**. Shell files are coverage-exempt,
+  so this keeps them thin: a violation means *extract the logic into gated (covered) core*,
+  never raise the budget. No per-function escape hatch by design: the standalone tools ignore
+  golangci `//nolint`, and the gate also rejects their native `//gocyclo:ignore` and
+  `//gocognit:ignore` directives in shell files. AST-only (no `make generate` needed); fails
+  closed on any non-zero exit. Core (non-shell) files stay under `.golangci.yaml` (`cyclop` 30,
+  `gocognit` 20).
+- Run a single test: `go test ./internal/agent -run TestName` (add `-v` for output, `-count=1`
+  to skip cache).
 - Build the binary: `go build ./cmd/cynative` (or `go run ./cmd/cynative -p "..."`).
+- `make snapshot`: builds the release archives via a goreleaser snapshot (no publish;
+  `--skip=before` keeps it hermetic/offline). `make install-e2e`: standalone release-confidence
+  check, not part of `make check`; builds the snapshot, then runs the real `install.sh` against
+  a loopback fixture server (`test/install.e2e.test.sh`, needs `python3`), verifying install,
+  `--version`, uninstall, and the fail-closed checksum-mismatch path.
 
-The coverage gate is real and enforced on every PR: **100% of core statements** (core = everything except `*_shell.go` files and the test-only fake-provider package `internal/auth/authtest`), with the whole suite running `-race -shuffle=on`. When adding code, add tests alongside it or `make check` will fail. The authtest exemption carries its own companion guard inside `make test`: an import check fails the build if any non-test file imports `internal/auth/authtest`, so "coverage-exempt code never ships" stays a mechanical property rather than a convention (the fakes themselves are load-bearing in six consumer test suites, which is what pins their behavior). The `paralleltest` linter requires every test (and subtest) to call `t.Parallel()`, and `forbidigo` bans `os.Getenv`/`LookupEnv`/`Environ` and `t.Setenv` outside the composition root and config shell — so new tests must be parallel and resolve env through an injected seam, never the process environment. A companion gate, `make shell-complexity`, mechanically enforces that `*_shell.go` functions stay below cyclomatic **and** cognitive complexity 6: because shell files are coverage-exempt, this stops testable logic from creeping back in to dodge the gate — the fix is always to extract the logic into a covered core file, never to raise the budget. The gate has no per-function suppression by design: the standalone tools ignore golangci `//nolint` (so it cannot quiet them), and the gate additionally bans the tools' own native `//gocyclo:ignore`/`//gocognit:ignore` skip directives in shell files.
+Two linters shape every new test: `paralleltest` requires each test and subtest to call
+`t.Parallel()`, and `forbidigo` bans `os.Getenv`/`LookupEnv`/`Environ` and `t.Setenv` outside
+the composition root and config shell, so code and tests resolve env through an injected seam,
+never the process environment.
 
 ## Architecture
 
-`cynative` is a single Go binary that drives an LLM-based "research" loop over the user's cloud/source environments. The agent's primary tool is `code_execution`: the model writes JavaScript that runs in an embedded sandbox and calls the host tools (currently `http_request`) programmatically — looping, filtering, and chaining calls without a round-trip per call — and the loop accumulates conversation history until the model stops requesting tools. The loop is an **in-house, hand-rolled DeepAgents-style agent** (`internal/agent`): a single tool-calling loop that calls the model, dispatches every tool call it returns, appends the results, and repeats until the assistant answers with no tool calls — augmented by two host orchestration tools, `write_todos` (planning) and `task` (a context-quarantined sub-agent that re-enters the same loop), and — always-on — `verify_findings` (`verify.go`): an adversarial verifier that runs exactly TWO batched tool-less `Generate` passes total (a benign-explanation lens, then an evidence-sufficiency lens), each sending all findings in one prompt and requiring strict JSON keyed by host-assigned finding ID; folds per finding (refuted in either pass → REFUTED, confirmed in both → VERIFIED, else UNVERIFIED), renders a `## 🔬 Verification panel` block, and returns outcomes + clamped justifications as the tool result; depth-0 only, max 16 findings/call, 16 KiB evidence clamp with `</evidence>` escaping, strict fail-closed parsing (a missing/unknown/malformed/refused/truncated/timed-out/budget-skipped verdict degrades to insufficient_evidence, so no parse problem can mint VERIFIED). The provider-agnostic message/tool currency is `internal/schema` (this repo's own types, not a framework's). The LLM backend is an embedded Bifrost SDK wrapped as a single custom `schema.ChatModel`, so any of Bifrost's ~23 Chat Completions providers can be selected from config without code changes; cynative configures exactly one provider per run. (The agent framework was previously CloudWeGo eino's ADK plan-execute agent; eino has been removed entirely — only Bifrost remains as the LLM provider/streaming layer.)
+`cynative` is a single Go binary that drives an LLM-based "research" loop over the user's
+cloud/source environments. The agent's primary tool is `code_execution`: the model writes
+JavaScript that runs in an embedded sandbox and calls the host tools (currently `http_request`)
+programmatically, looping, filtering, and chaining calls without a round-trip per call. The loop
+is an in-house, hand-rolled DeepAgents-style agent (`internal/agent`): call the model, dispatch
+every tool call it returns, append the results, repeat until the assistant answers with no tool
+calls. Two host orchestration tools augment it, `write_todos` (planning) and `task` (a
+context-quarantined sub-agent that re-enters the same loop), plus the always-on `verify_findings`
+adversarial verifier. The provider-agnostic message/tool currency is `internal/schema` (this
+repo's own types, not a framework's); the LLM backend is an embedded Bifrost SDK wrapped as a
+single custom `schema.ChatModel`, so any of Bifrost's ~23 Chat Completions providers can be
+selected from config without code changes. Cynative configures exactly one provider per run.
 
-The cmd → cli → agent (the in-house loop) → tools → transport → auth flow is the spine of the app (`code_execution` drives the `internal/sandbox` runtime, `http_request` drives `internal/transport`), with `internal/schema` supplying the shared message/tool types and `internal/llm` supplying the Bifrost-backed `schema.ChatModel` the loop drives:
+The spine is cmd → cli → agent → tools → transport → auth: `code_execution` drives the
+`internal/sandbox` runtime, `http_request` drives `internal/transport`, `internal/schema`
+supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-backed
+`schema.ChatModel` the loop drives.
 
-- **`cmd/cynative`** is a thin `main` that calls `cli.Execute()`.
-- **`internal/cli`** owns cobra commands (`root.go`, `research.go`) and is the **composition root**. `Execute` builds a `deps` struct of injected collaborators in `wire_shell.go` (`newDeps` — the one place that reads the real environment: `os.LookupEnv` via `config.NewLoader`, `auth.GetProviders`, `ui.New`, stdio, and the `llm`/`tools`/`agent` constructors), then `NewRootCmd(deps)` wires the root run command (the `research` subcommand was replaced by `-p`/`--print` + bare interactive). The root `PersistentPreRunE` loads config onto `deps.cfg`, and its `RunE` calls `deps.runRoot`, which reads any piped stdin (`readStdin`, 1 MiB-capped + UTF-8-repaired) and resolves the invocation (`resolveInvocation`/`joinTask`) into a task string + interactive flag before dispatching to `deps.runResearch`. `runResearch` builds the Bifrost-backed chat model (a local `chatModel` interface = `schema.ChatModel` + `Shutdown()`, torn down via `defer`), assembles the `schema.InvokableTool` set — the `http_request` primitive plus a `code_execution` tool (`tools.NewCodeExecutionTool`) that re-exposes the primitives as JS functions inside its sandbox, capped at `cfg.SandboxMaxConcurrency` concurrent inner calls — and **approval-wraps every I/O tool unconditionally** (`tools.NewApprovalTool(tool, prompter, style)`, the synchronous blocking decorator); `--auto-approve` does not skip the wrapper, it swaps the prompter to `ui.AutoApproveToolCall` (prints and approves without pausing). It then constructs the agent (`agent.New`), passing the approval-wrapped I/O tool set, the auth providers, and the UI renderer (the `write_todos`/`task` orchestration tools are registered unwrapped — surfaced, not gated), and runs the task once (`-p`/`--print`, or any piped/non-TTY invocation) or — when `-p` is absent and stdin is a TTY — enters an interactive follow-up loop (bare `cynative`, or `cynative "task"` seeded by the positional arg) that survives transient turn errors (only context cancellation aborts; `exit`/`quit`/EOF ends it). Piped stdin combined with a positional task is folded in as untrusted `<piped_input>` context (`agent.WrapPipedInput`); tool-approval prompts use the controlling terminal — `/dev/tty` via the build-tagged `resolveInteraction` (`tty_unix_shell.go`/`tty_other_shell.go`) when stdin is piped, so a piped one-shot can still prompt — and a run with no usable terminal and no `--auto-approve` fails closed with `ErrNoApprovalTerminal` (empty non-interactive input fails with `ErrNoTask`). `research` also builds a `metrics.Accumulator` (with `metrics.WithBudget(cfg.MaxTotalTokens)`, so the per-session token ceiling is shared across the turn and all interactive follow-ups) and threads it to both the chat model (`llm.WithUsageRecorder`, wired in `wire_shell.go`) and the agent (`agent.Config.Metrics`); it renders the accumulated stats as single-scope operational footers on **stderr** (`ui.RenderFooter`) — a per-turn `turn` footer each interactive turn plus one cumulative `session` footer at session end (`-p`/non-interactive prints only the `session` footer) — so redirecting stdout keeps the answer clean. `--verbose`/`-v` routes per-tool-call output to stderr (threaded as `VerboseWriter` into the code tool and the agent). `auth.GetProviders` takes an `auth.GithubHardeningConfig` (a `Permissions map[string]string` from `cfg.Connectors.Github.Permissions` plus an embedded `cache.Config` — `Dir` namespaced via `filepath.Join(cfg.Cache.Dir, "github")` for the category table — `TTL`/`Clock`) as its first argument, followed by an `auth.GitLabHardeningConfig` (`host`/`api_host`/`allow_private_network`/`ca_cert` plus a `permissions` exposure map and an embedded `cache.Config` namespaced to `<cache>/gitlab`, from `cfg.Connectors.GitLab`) as its second argument, followed by an `auth.AWSHardeningConfig` (PolicyARN from `cfg.Connectors.AWS.Policy`; an embedded `cache.Config` — `Dir` namespaced per provider via `filepath.Join(cfg.Cache.Dir, "aws")`, `TTL` from `cfg.Cache.TTL`, `Clock` `time.Now`), then an `auth.EKSHardeningConfig` (ClusterRole from `cfg.Connectors.EKS.ClusterRole`), then an `auth.GCPHardeningConfig` and `auth.GKEHardeningConfig` (ClusterRole from `cfg.Connectors.GKE.ClusterRole`), then an `auth.AzureHardeningConfig` and `auth.AKSHardeningConfig` (ClusterRole from `cfg.Connectors.AKS.ClusterRole`), and finally an `auth.KubernetesHardeningConfig` (ClusterRole from `cfg.Connectors.Kubernetes.ClusterRole`). Every collaborator is a `deps` field (no package globals); the orchestration core is tested with fakes, and `wire_shell.go` is the excluded shell. A SIGINT/SIGTERM signal handler (`installSignalHandler` in `interrupt_shell.go`) shares a leaf-package `interrupt.State` with the optional `TerminalController`: SIGTERM always restores the terminal and exits 143; a SIGINT calls `State.Trip()` — first in-turn press → graceful (sets `Interrupted`, no exit so the agent loop handles it); second in-turn press or any idle press → restores and exits 130; the pure `signalAction` branch is tested directly. On an editor TTY the `TerminalController` becomes the `deps.interrupter` (satisfying `agent.Interrupter`) and is also wired as the ui `Controller`; on non-editor runs `wire_shell.go` uses the shared `*interrupt.State` itself as the `deps.interrupter` (so a SIGINT still drives the same two-stage machine — there is no `TerminalController`/cbreak watcher, but the signal handler trips the state). There is no separate no-op interrupter type; a test or default needing an inert interrupter uses a zero `*interrupt.State` (whose `Interrupted()` is false until armed).
-- **`internal/schema`** is the provider-agnostic message/tool **currency** shared by the `llm`, `agent`, `tools`, and `ui` packages — the in-house replacement for the framework's `schema` package. It is a pure leaf: it imports only the standard library and `github.com/invopop/jsonschema`, so nothing it depends on can create an import cycle (no internal import may ever be added). `message.go` defines `Message{Role, Content []Block}` with three typed, sealed content `Block` variants — `TextBlock{Text}`, `ToolCallBlock{ID,Name,Arguments}` (the raw JSON argument object as the model produced it), and `ToolResultBlock{ToolCallID,Content}` — plus the accessors `Text()`/`ToolCalls()`/`ToolResults()` and the constructors `SystemMessage`/`UserMessage`/`AssistantMessage`/`ToolMessage`. `model.go` defines `ChatModel{Generate}` (the single-method interface the loop drives; `BifrostChatModel` is the production impl). `usage.go` defines `Usage`, the per-call token accounting (prompt/completion/total, cached read/write) that the `llm` layer reports and `internal/metrics` accumulates. `tool.go` defines `InvokableTool{Info,Run}` (named `InvokableTool` because `Tool` is already a `Role` constant), the optional `StructuredRunner`, `ToolInfo{Name,Desc,Params *jsonschema.Schema}`. `ChatModel.Generate` takes the offered tools as a direct `tools []*ToolInfo` argument (tool-less calls pass `nil`); the prior per-call `Options`/`WithTools`/`ApplyOptions` functional-option machinery was removed. `reflect.go`'s `ReflectParams[T]()` generates a tool's JSON Schema from a Go struct via invopop/jsonschema (a `Reflector{Anonymous:true, AllowAdditionalProperties:false, DoNotReference:true}` so strict-mode providers get `additionalProperties:false` and inlined definitions; descriptions from `jsonschema_description` tags), the replacement for the framework's struct-to-params helper.
-- **`internal/llm`** owns the embedded Bifrost SDK and adapts it to `internal/schema`. `BifrostChatModel` (`chatmodel.go`) implements `schema.ChatModel` (`Generate`, plus `Shutdown`) over a `BifrostBackend`; the `schema*`-prefixed converters in `convert.go` translate between `internal/schema` types and Bifrost types, and `schemaToToolParameters` marshals a tool's `*jsonschema.Schema` directly into Bifrost's `ToolFunctionParameters` (no intermediate conversion step). The Anthropic rolling cache-breakpoint logic (`applyCacheBreakpoints`/`cacheMarkIndices`/`markMessage`) is unchanged. `options.go`'s `WithUsageRecorder` is the one production-facing `ChatModelOption`: it installs a sink invoked with the `schema.Usage` of every successful `Generate` (the cli wires it to the metrics accumulator; default no-op). `FileAccount` implements Bifrost's multi-provider `schemas.Account` but wraps a single `ProviderEntry` (cynative runs one provider per run). `ProviderEntry` (`account.go`) embeds Bifrost's `schemas.ProviderConfig` via `json:",squash"` so every Bifrost field is exposed without per-field translation, and adds cynative selectors (`Provider`, `Model`), the `api_key` top-level alias, the hoisted per-provider key-config aliases (`azure`/`vertex`/`bedrock`/`vllm`/`ollama`/`sgl`/`replicate`), and a `Keys` slice; all other Bifrost fields — including `network_config` (proxy/timeout/retries/headers) — are exposed verbatim through the `json:",squash"` embed (there are no flat top-level `base_url`/`request_timeout`/`max_retries`/`extra_headers` aliases; those were removed in 0.6.0). `providers.go` derives the provider catalog (`ChatProviders()` = Bifrost's `schemas.StandardProviders` minus the hand-triaged `nonChatProviders` exclusions, whose Bifrost impls cannot chat and are rejected at config load) plus the `CanonicalEnvKeyLookup` table that `CanonicalEnvKey` reads for the env-var fallback. `env.go` defines the `LookupEnv` port and `ResolveEnvVar`, which turns an `env.X` string into a `schemas.EnvVar` by resolving the reference through the injected lookup (not the process env, unlike Bifrost's `schemas.NewEnvVar`); `decodehooks.go` holds the mapstructure decode hooks (the EnvVar hooks take a `LookupEnv` and call `ResolveEnvVar`; plus duration-string enforcement); `envcheck.go` reflectively verifies referenced env vars are set (`ValidateEnvVars`); `bindenv.go` reflectively lists the dotted key path of every `ProviderEntry` leaf (`ProviderEnvKeys`), which `config` enumerates to map `CYNATIVE_LLM_*` vars onto fields; `keyconfig.go` enforces that the providers whose Bifrost impl dereferences a per-key config without a nil guard (azure, vertex) actually supply it (`ValidateKeyConfigs`, direct field checks so an upstream rename fails at compile time). `reasoning.go` validates the operator's reasoning config — `llm.reasoning_effort` (enum none|minimal|low|medium|high) and `llm.reasoning_max_tokens` (≥1), two flat `ProviderEntry` fields that `BifrostChatModel.buildRequest` attaches per call as `Params.Reasoning`; `ValidateReasoning` also rejects effort "none" combined with a budget, which Bifrost's Anthropic-style converters would otherwise let silently re-enable thinking. The `BifrostBackend` interface lives in `bifrost.go` (moq'd in tests); the real Bifrost client is built in `bifrost_shell.go` and injected as a defaulted factory field on `BifrostChatModel`.
-- **`internal/agent`** drives the in-house **DeepAgents-style** research loop — pure Go, directly tested against a fake `schema.ChatModel` (no framework runner, no checkpoint store, no interrupt/resume, no moq'd runner seam). Key points:
-  - `Agent.run(ctx, rs, turn, maxIter)` (`loop.go`) is a single tool-calling loop: it calls `model.Generate` (offering the bound tool schemas as the direct `tools []*schema.ToolInfo` argument), renders the assistant turn, and — if the assistant emitted no tool calls — returns its text as the final answer; otherwise it dispatches each `ToolCallBlock` (`dispatch` looks the tool up by name and runs it), appends a `ToolMessage` per result, and loops. Every I/O (plain-`Run`) tool result is fenced as untrusted data via `wrapUntrusted` (`framing.go`: `<tool_output tool="…">…</tool_output>` with `</tool_output>` escaping) before it re-enters the transcript, and `task` self-frames its summary; the orchestration acks (`write_todos`, the `verify_findings` panel) stay unframed (trusted host rendering, with echoed finding fields escaped). `prompt.go` carries the matching untrusted-data clause, and `verify.go` shares the same `escapeFence` helper — the main-loop counterpart to the verifier framing. It terminates on a tool-call-free turn or after `maxIter` iterations (returning ""). Tool failures and unknown-tool names come back as tool-result content, never as a Go error, so the model can self-correct. When a `metrics.Budget` is configured the loop checks `metrics.BudgetExceeded()` at the top of every iteration, immediately after each model response, and after each tool dispatch (so a low-budget turn that crosses on its own answer or inside one of a message's tool calls halts at once, not only on the next turn), and the `verify_findings` two batched passes use a coarse budget backstop (`metrics.BudgetExceeded()` checked before each pass → that pass's verdicts degrade to insufficient_evidence). On a budget exceed the loop returns the `errBudgetExceeded` sentinel, and `Run` renders a one-line `⚠️ Budget reached — …` notice and stops the turn (returning nil, no partial answer recorded) — the bound is cumulative across the main loop, `task` sub-runs, and the verifier via the shared accumulator, and per-session (it survives `StartTurn`). The loop also halts on: **(a) a graceful interrupt** — Esc or first Ctrl-C (via the host `Interrupter`, checked at the top of each iteration, after `Generate`, and before every I/O dispatch) surfaces as `errInterrupted`; `Run` renders `⏸ Stopped. …` and returns `ErrInterrupted` — non-fatal in an interactive session, exit 130 in one-shot; a second Ctrl-C (or any Ctrl-C outside a turn) hard-kills via `os.Exit`; **(b) `max_consecutive_failures` consecutive no-progress tool calls** — a tool error, a denial, or an `http_request` whose response is `≥400` each increment `rs.consecutiveFailures`; any progress resets it; when the ceiling is reached `failureSummary` (`failure_summary.go`) renders a `⏸ Stopped after N consecutive failures` notice, runs ONE tool-less `Generate` asking the model to name the wall and the required input, and returns that text as the turn's answer (recorded to history so an interactive follow-up resumes with context); a blank/errored summary falls back to a deterministic notice. The `haltAndAskClause` in `prompt.go`'s `systemPrompt` steers the model to stop and ask the operator for a missing identifier (project/account/region/etc.) rather than guess or probe candidates.
-  - Per-run execution state lives in `runState{depth, out}` (`loop.go`), one instance per run; `dispatch` hands it to the in-package `runScoped` orchestration tools while I/O tools keep the plain `Run` path. `*Agent` holds no per-run mutable state, so concurrent sub-runs are race-free; pinned by `TestRun_ConcurrentRunsShareNoMutableState`.
-  - Host orchestration tools live **in this package** (not `internal/tools`, to avoid a `tools`→`agent` import cycle): `write_todos` (`todos.go`) records and renders a todo checklist (it tolerates a double-encoded `todos` payload and normalizes unknown statuses to `pending`), and `task` (`task.go`) is a sub-agent tool that re-enters the **same** `run` loop with a fresh transcript seeded only with the system prompt + the task `description` — "context quarantine", with a fresh `runState` (depth+1, verbose-writer output, empty plan) — reusing the parent's approval-wrapped I/O tools (so approval and auth still propagate) and returning only the sub-run's final text. `New` registers both **unwrapped** — they perform no credentialed I/O, so they are surfaced rather than approval-gated: `write_todos` renders the checklist to its own run's output (a sub-run's plan renders to the verbose writer and does not touch the parent's), and `task` brackets its sub-run with `▶ Delegating sub-task: …` / `■ Sub-task complete|failed` notices on the main output. That reuse of the parent's approval-wrapped I/O tools is the load-bearing invariant pinned by `TestIntegration_SubagentIOStaysGated`. `buildToolset` indexes every tool by name and collects the schemas the model sees.
-  - `prompt.go`'s `systemPrompt` builds a DeepAgents system prompt that teaches the workflow (plan with `write_todos`, script with `code_execution` over `http_request`, delegate with `task`, stop and answer when done), opens with a positively-framed `SCOPE:` clause that anchors the agent to the question's subject (investigate only what the question requires; reach beyond to other providers/accounts/services only when the task calls for it; narrowest enumeration — imperatives, not prohibitions, so the guidance travels across small/local models too), and lists the available auth providers (Name + Description, nudging "use only the providers the question requires") so the model knows the valid `auth_provider` values.
-  - `Run` seeds the working transcript from the agent's clean Q&A history (`[]*schema.Message`: prior user questions + final answers only — intermediate plans/steps/tool output are rendered live but not replayed) plus the system message and the new question, drives `run` under `Config.MaxIterations`, and records the question + final answer to history; `render.go` renders each assistant turn's prose through the injected UI renderer and (under `--verbose`) a one-line notice per tool call. `Config.MaxIterations` bounds the main loop; `Config.MaxSubagentIterations` bounds the `task` sub-agent loop.
-  - Per-tool-call approval (I/O tools only — orchestration tools are not gated) is **synchronous** (see `internal/tools`): the approval decorator blocks on the host prompter and runs-or-denies the call inline. `schema.Message` is the currency; the package has no direct Bifrost dependency.
-- **`internal/tools`** exposes the I/O `schema.InvokableTool`s. `http_request` (`httptool.go`) is a `schema.InvokableTool` whose JSON Schema is built from `transport.RequestArgs` via `schema.ReflectParams`; its `Run` forwards the model's raw JSON arguments straight to the transport `Client.Execute` (preserving auth's raw-bytes contract), and it also implements the optional `schema.StructuredRunner` (`StructuredRun` returning valid JSON). `code_execution` (`codeexec.go`) wraps the other tools as async JS functions inside an `internal/sandbox` runtime so the model can script multi-call workflows; `invokerToToolFunc` calls a tool's `StructuredRun` when it has one (so the script receives a parsed object) and falls back to `Run` otherwise — the direct `Run` output is unchanged. `approval.go` is a **synchronous, blocking** decorator: `NewApprovalTool(inner, prompter, style)` wraps any `schema.InvokableTool` so each `Run` first calls the host `Prompter` (`func(name, arguments, style string) bool`, which blocks until the user decides) and then either runs the inner tool or returns `DeniedMessage` (a result string, not a Go error, so the loop continues and the model can adapt) — no interrupt/resume, no gob registration, no checkpoint. The orchestration tools `write_todos`/`task` are **not** here (they live in `internal/agent` to avoid a `tools`→`agent` import cycle). New I/O tools are added here; expose one to scripts by implementing `schema.StructuredRunner`.
-- **`internal/sandbox`** runs untrusted, model-authored JavaScript in an embedded Grafana **sobek** runtime (`sandbox.go`), exposing host capabilities only through explicitly registered `ToolFunc`s — there is no `fetch`, `require`, filesystem, network, timers, or Node/browser API. `New(funcs, verbose, maxOutput, maxConcurrency, redact)` builds one persistent, mutex-serialized runtime per session (the `redact func(string) string` is a required non-nil security boundary — a nil redactor panics on first use rather than silently leaking unredacted content): state survives across `Run`s only via `globalThis`, because each `Run`'s code is wrapped in an async IIFE (`loop.go`'s `compileWrapped`) so top-level `await` works and top-level declarations are call-scoped. Each `Run` has a timeout context with a watchdog that calls `vm.Interrupt`; output is captured from `console.log/error` and `finalize`d (truncated to `maxOutput`, UTF-8-repaired); script errors and timeouts come back as the *result string* (not a Go error) so the model can self-correct. Tool calls are async (`loop.go`): `toolFunc` returns a JS Promise and spawns a worker goroutine bounded by a `maxConcurrency` semaphore, the single loop goroutine drains worker postbacks until none are in flight, and `Run` waits for all workers before returning. `New` clamps a non-positive `maxConcurrency` to `DefaultMaxConcurrency` (16) so a zero value cannot park every call. `prelude.go` holds the pure-JS source for `mapConcurrent(items, fn, limit)` — an order-preserving bounded fan-out helper over the registered tool functions (default limit = the semaphore capacity; it stops launching new work after the first failure and rethrows it), installed non-writable on `globalThis` by `buildRuntime`. `natives.go` registers two synchronous built-ins on every runtime — `xml.parse(str)` (mxj defaults; leaves stay strings, attrs keyed `-name`, text `#text`; called with defaults only, so race-safe) and `jmespath.search(data, expr)` (normalized through JSON so go-jmespath's float64 comparisons work). `sandbox_shell.go` (`buildRuntime`) is the excluded shell that calls `sobek.New`, registers `console`/`xml`/`jmespath`, evaluates the `mapConcurrent` prelude, and registers one function per tool. The package has no `agent`/`tools`/Bifrost dependency — `tools.codeexec` adapts it via the `codeRunner` port (default `sandbox.New(funcs, w, 32 KiB output, maxConcurrency, redact)`, where maxConcurrency is the configured `sandbox_max_concurrency`, default 16, and redact is `redact.New().RedactPreservingLocation`).
-- **`internal/transport`** executes `http_request` calls: parses args (the model must name an `auth_provider`, one of `github`/`gitlab`/`aws`/`eks`/`gcp`/`gke`/`azure`/`aks`/`kubernetes`), clamps timeout/body limits, **rejects any non-`https` URL** (credentials never traverse plaintext), never follows redirects (the per-request client's `CheckRedirect` returns `http.ErrUseLastResponse`, so a 3xx is surfaced to the model as the tool result and any follow-up hop is a fresh, fully-gated request), authorizes a model-supplied `Host` header override through `auth.AuthorizeHost` like the URL host (the wire authority cannot slip host pinning), builds the request, then runs three auth gates in order — `auth.AuthorizeHost` (the provider must allow the request host), `auth.AuthorizeAction` (optional per-request action authorization; AWS hardening hooks in here), and `auth.Inject` (credential injection — fails closed with `ErrModelSuppliedCredential` when the request already carries a model-supplied credential: an `Authorization`/`Proxy-Authorization`/`X-Ms-Authorization-Auxiliary` header with any value, or URL userinfo) — before `configureTransport` installs a fresh per-request `*http.Transport` (built from scratch, never the shared default — Proxy intentionally nil and no DialTLS inherited, so an embedding process that customized the global transport can't bypass the guard): TLS-aware when the provider supplies a CA cert and/or client cert (mTLS), and **always** wired with `dialGuard`, a `net.Dialer.ControlContext` hook that authorizes the DNS-resolved IP via `auth.AuthorizeAddr` before the connection is established — the dial-time chokepoint against DNS-rebinding/TOCTOU SSRF (Go fires Control on every dial, including IP-literal targets). Responses are redacted at the source — denylisted credential headers and secret-shaped body/header content scrubbed via `internal/redact` (`FormatResponse` on the direct `Execute` path, `ExecuteStructured` on the sandbox path) — before being dumped via `httputil.DumpResponse` and truncated. `Execute` returns the HTTP status code (0 on a transport-level error) alongside the response text; `http_request`'s `Run` (`httptool.go`) calls `audit.MarkFailed` on a transport error OR a `≥400` response so the agent's consecutive-failure counter (`runState.consecutiveFailures`) sees both classes as no-progress outcomes.
-- **`internal/auth`** is an extensible provider registry. `GetProviders(githubCfg auth.GithubHardeningConfig, gitlabCfg auth.GitLabHardeningConfig, awsCfg auth.AWSHardeningConfig, eksCfg auth.EKSHardeningConfig, gcpCfg auth.GCPHardeningConfig, gkeCfg auth.GKEHardeningConfig, azureCfg auth.AzureHardeningConfig, aksCfg auth.AKSHardeningConfig, kubernetesCfg auth.KubernetesHardeningConfig)` probes the environment and returns whatever it finds (github via `githubOutcome` — an eager `*registrationDeps` method that resolves the gh token and, when present, validates it with a hardened `GET /user`→`GET /rate_limit` probe over the `githubDialAllowed` public-internet dial guard (denies ALL internal + special-use ranges including CGNAT, benchmarking, documentation, 0.0.0.0/8, 240.0.0.0/4, and non-global-unicast — plus IPv4-embedding IPv6 (NAT64 `64:ff9b::/96`, 6to4 `2002::/16`) whose embedded IPv4 is internal, while a NAT64-wrapped public github IPv4 stays allowed so IPv6-only/DNS64 hosts work; no redirects) before registering; `Available` for github means validated-live this startup — an invalid/expired/unreachable token shows unavailable with a reason; a genuinely absent token is a silent ambient skip; gitlab via `gitlabOutcome` — an eager `*registrationDeps` method that discovers the token (`GITLAB_TOKEN`/`GITLAB_ACCESS_TOKEN`/`OAUTH_TOKEN`, then when unset by delegating to the pinned `glab auth credential-helper` binary) and, when present, validates it with a dial-guarded `GET /api/v4/user` through the gitlab provider's own host-pinned/allow_private_network/CA path before registering; `Available` means validated-live (an invalid/expired/unreachable token shows unavailable with a reason, an unreadable `ca_cert` is a loud config skip, an absent token is a silent ambient skip), and the identity is `@username` (plus ` · host` for self-managed); AWS+EKS via default AWS config, GCP+GKE via ADC, Azure+AKS via the Azure credential chain `azure.NewCredentialChain` — DefaultAzureCredential's sources but with managed identity demoted to last and made non-fatal so the IMDS probe can't abort the chain on a non-Azure host, e.g. a GCP VM whose metadata server shares 169.254.169.254; and a self-managed/generic `kubernetes` provider via the local kubeconfig — `registerKube` on `*registrationDeps` (wired in `kubernetes_shell.go`), using kubectl's own discovery: `KUBECONFIG`, then `~/.kube/config`, current-context (no Cynative-level override, consistent with the other connectors); after a successful kubeconfig load `registerKube` eagerly validates the cluster via a dial-guarded `defaultFetchView` ClusterRole fetch (the same host/IP-pinned path used at request time) — a cluster that is unreachable or whose identity cannot read the configured ClusterRole shows unavailable with a reason; the managed K8s connectors (eks/gke/aks) do not probe the Kubernetes API at registration); if AWS credentials are present but the hardened provider can't be built (config load / credential probe fails), AWS+EKS are skipped (logged to stderr). `auth.Inject` — the dispatcher every credentialed request flows through — rejects model-supplied credentials before dispatching (`ErrModelSuppliedCredential`): `Authorization`/`Proxy-Authorization`/`X-Ms-Authorization-Auxiliary` header values (checked via `Header.Values`, so duplicate/empty values count) and URL userinfo (which Go's client would otherwise turn into `Authorization: Basic ...` exactly when an mTLS provider sets no header). Provider `InjectAuth` implementations are therefore the sole setters of credential material; the Azure-specific SAS `sig=` query check stays in `azure.go`'s `rejectModelSuppliedSAS`. The GitHub provider gates each request against a configurable exposure ceiling via the `internal/auth/github` subpackage: it classifies the request to its GitHub category/subcategory and required access level (`classifier.go`'s `ClassifyRequest`/`RequiredLevel` over a distilled OpenAPI category `Table` — `table.go`, fetched anonymously by `bootstrap_fetch.go`'s `newGithubOpenAPIFetcher` (the shared, dial-guarded github/gitlab spec fetcher in gated core: one timeout-parameterized client builder + one URL/Accept/error-prefix-parameterized fetcher, so every branch is covered) and TTL-cached via `internal/cache.TTLCache`; `sensitive.go`'s `AdmitTable` rejects any table that maps a secret-scanning template to a different category, and the `secret-scanning:none` Exposure baseline + fail-closed-on-unknown are the runtime guards — no request-time segment override is used, to avoid false-positive denials from user-controlled path segments), then allows it only when the operator's `Exposure` (`policy.go`: `category[/subcategory]→read|write|none`, secure baseline = read-all-except-`secret-scanning`, built by `BuildExposure`, resolved most-specific-first) permits that level. A request that can't be classified (`ErrUnclassifiable`), a missing table (`ErrTableNotReady`), exceeding the ceiling (`ErrExposureExceeded`), or a configured key naming no real category (`ValidateExposureKeys`/`ErrUnknownKey`) all fail closed. A best-effort post-response `AuditResponse` (the new `auth.ResponseAuditor` dispatcher) compares GitHub's authoritative `X-Accepted-GitHub-Permissions` header against the classification and logs a `DriftWarning` (advisory; never blocks). The provider emits a one-line `github_hardening: mode=scoped …` posture on first resolve (loud `⚠️` when `default=write`, `secret-scanning` is opened, or any category is widened), rendered by `ScopedPosture` in `internal/auth/github`; the `githubProvider` holds an injected `errOut io.Writer` + a `sync.Once` and emits on the first `AuthorizeAction`/`InjectAuth`, and `provider_shell.go` injects `os.Stderr`. `InjectAuth` strips any model-supplied `X-GitHub-Api-Version` header (so the model cannot select an API surface the table did not model) and lets GitHub use its current default version, which the live-fetched `main`-branch OpenAPI spec describes — keeping table and wire behaviour aligned. The provider also authorizes the GitHub-owned download hosts (`codeload.github.com`, `release-assets.githubusercontent.com`, `objects.githubusercontent.com`) GET/HEAD-only — regardless of the permissions ceiling — so the model can explicitly follow api.github.com download redirects; every allow-listed host must be GitHub-operated because `InjectAuth` attaches the gh token unconditionally. Every provider implements `Provider` — `Name`/`Description`/`InjectAuth` **and `AuthorizesHost`** (host pinning is a baseline control, not optional) — and optionally `CACertProvider`, `ClientCertProvider`, `ActionAuthorizer` (per-request action authorization, dispatched by `auth.AuthorizeAction`; implemented by every provider today — GitHub category+level exposure-ceiling classification, GitLab category+level exposure-ceiling classification, AWS IAM-policy simulation, K8s configured-ClusterRole authorization, and Azure/GCP delegated action hardening), and/or `AddrAuthorizer` (`addr.go` — dial-time authorization of the DNS-resolved IP, dispatched by `auth.AuthorizeAddr` from the transport's `dialGuard`; the four K8s providers implement it to pin the dial to the cluster endpoint's exact resolved IPs (`dialcontrol.go`, the `addrResolver` seam), while providers that don't implement it inherit the fail-safe default: deny internal ranges — loopback, link-local incl. cloud metadata, RFC1918, ULA, IPv4-mapped forms — plus the exact Azure WireServer / Alibaba metadata addresses, allow everything else). The optional cert interfaces are what let the K8s providers supply per-cluster CA bundles and client certificates to the transport. The generic `k8sGate[A]` (`k8sgate.go`) is the shared K8s authorization path all four K8s providers compose: it owns the identical validate → resolve-view → classify → authorize sequence and the per-cluster ClusterRole-policy cache (keyed by the connector's configured ClusterRole, default `view`), while credential and cluster-fact mechanics stay per-provider. `syncCache[T]` (`cert_cache.go`) coalesces concurrent CA/cert lookups via `singleflight` and caches successes (not errors).
-- **`internal/auth/aws`** is the AWS request-hardening subpackage (pure core + `*_shell.go` data fetchers) that the parent `awsProvider` composes. It layers three defenses: **(1) credential scoping** — `ScopedProvider` (`federation.go`) re-vends the base creds via STS `AssumeRole` scoped to the configured read-only managed policy (default `SecurityAudit`) via `PolicyArns` **only for assumed-role identities** (self-chain), degrading to disabled on a definitive `AccessDenied` (e.g. an SSO trust policy that forbids self-assumption) and propagating transient errors. **IAM-user and root identities run unscoped** (base credentials) and are gated by defenses (2) and (3) alone — cynative no longer mints `GetFederationToken` sessions, which cannot call IAM and so defeated IAM auditing; **(2) host pinning** — `ParseHost` (`network.go`) maps the request host to a `(service, region)` and verifies it against the model's `aws_auth` claim (rejecting IP literals/localhost/VPC endpoints); `ParseHost` additionally recognizes account-scoped S3 Control hosts (`{account}.s3-control[-fips][.dualstack].{region}.amazonaws.com[.cn]` → endpoint prefix `s3-control`), and account-prefixed S3 access-point hosts (`{name}-{account}.s3-accesspoint[-fips][.dualstack].{region}.amazonaws.com[.cn]`), which resolve to the ordinary `s3` endpoint prefix (no separate access-point model) and so host-pin and SigV4-sign through the unchanged plain-S3 path; their virtual-hosted requests are action-classified by prepending the host-implied {Bucket} segment to the path before matching the path-style URI templates (ParsedHost.BucketInHost → classificationPath); and `Verify` compares the `aws_auth.service` claim case- and hyphen-insensitively so the endpoint-prefix and SDK-id spellings (`s3-control`, `s3control`) reconcile, while the signing-name spelling (`s3`) continues to reconcile via the existing `AuthorizesHost` signing-name alias path — safe because the action-authorization decision derives the service purely from the host (`ParseHost`), and SigV4 signing uses the host-resolved canonical signing name (falling back to the claim only when the model archive cannot resolve the host); **(3) action authorization** — `AuthorizeAction` resolves the request to a service model via the cached `ModelArchive`, classifies the operation (`classifier.go`), resolves its required IAM action(s) through a three-tier chain (Service Reference API → iam-dataset → `namespace:op` derivation, `actions.go`), and requires the configured policy (default `arn:aws:iam::aws:policy/SecurityAudit`) to allow every action via `iam:SimulateCustomPolicy` (`policy_eval.go`), failing closed on any unresolved action; namespace-shadowed services (a different-dir model owns the IAM namespace as its endpoint prefix, e.g. S3 Control under the `s3` namespace) are resolved only by their own identity — Service Reference under their own dir/endpoint-prefix keys, then the iam-dataset by their own SDK id (`LookupSDKID`) — excluding the foreign namespace key and the derivation tier, and fail closed on a miss — so account-level S3 Control operations authorize against `s3:GetAccountPublicAccessBlock`, not the bucket-level action. All AWS I/O (GCI, policy fetch, model-archive/serviceref/iam-dataset downloads cached under the shared `cfg.Cache.Dir/aws` subdirectory, namespaced by the composition root via `filepath.Join(cfg.Cache.Dir, "aws")`) is deferred to first use via lazy init (`lazy.go`, `awsProvider.ensureReady`); the startup connector inventory is the source of truth for the `sts=` credential-scope status (no steady-state posture log), and a definitive scoping degrade emits a one-line `aws_hardening: degraded cred_scope=disabled …` notice to stderr.
-- **`internal/auth/gcp`** is the pure GCP request-hardening subpackage (core + `*_shell.go` data fetchers) that the parent `gcpProvider` composes via `AuthorizeAction`. It resolves the request host to a Google API service through a live API **Discovery directory** catalog (`catalog.go`; now backed by the shared `internal/cache` TTL cache — a transient partial fetch is cached fail-closed, denying dropped services until the next refresh), classifies the operation (`classifier.go`), resolves its required IAM permissions (`permissions.go`, backed by the cached iam-dataset in `iamdataset.go`), and authorizes every permission against the single configured predefined role (default `roles/viewer`, `roleeval.go`), failing closed on anything unresolved. All GCP I/O is deferred to first use (`lazy.go`) and cached under the shared `cfg.Cache.Dir/gcp` subdirectory (namespaced by the composition root via `filepath.Join(cfg.Cache.Dir, "gcp")`); the role definition is fetched live per run (no role cache); a one-line `gcp_hardening: …` posture log (`posture.go`) is emitted at first resolve.
-- **`internal/auth/azure`** is the pure Azure request-hardening subpackage (core + `*_shell.go` data fetchers) that the parent `azureProvider` composes via `AuthorizeAction`. Azure has no credential-downscoping primitive, so this in-process action gate is the sole client-side control: it resolves the request to a service via a cached catalog (`catalog.go`), classifies the operation (`classifier.go`/`actions.go`), and authorizes it against the single configured RBAC **role definition** (default `Reader`, a single `role_definition` rather than an allow-list; `roleeval.go`). Data-plane operations (Key Vault secrets, Blob/Queue/Table data, SQL/Cosmos data) are out of scope — Cynative is control-plane only and denies data-plane hosts at the network layer. I/O is lazy-init'd (`lazy.go`) and cached under the shared `cfg.Cache.Dir/azure` subdirectory (namespaced by the composition root via `filepath.Join(cfg.Cache.Dir, "azure")`); the role definition is fetched live per run (no role cache); an `azure_hardening: …` posture log (`posture.go`) is emitted at first resolve.
-- **`internal/auth/k8s`** is the shared Kubernetes API authorization core (pure, no network) used by the `eks`/`gke`/`aks`/`kubernetes` providers' `AuthorizeAction` (composed through the parent package's generic `k8sGate`): a faithful kube-apiserver `RequestInfo` classifier (`Classify`), an allow-only RBAC matcher (`ViewPolicy`/`Allows`) built from the cluster's live **configured** ClusterRole (default `view`, set via `connectors.<eks|gke|aks|kubernetes>.cluster_role`; `url.PathEscape`-d into the `clusterroles/<name>` fetch path), a ClusterRole-JSON parser (`ParseClusterRoleRules`, fail-closed on a non-`ClusterRole`/empty body), and an `Authorize` combiner with a safe non-resource GET allow-set. The four K8s providers fetch and cache each cluster's configured ClusterRole (the HTTPS fetch lives in the excluded `*_shell.go`: `k8s_fetch_shell.go` plus per-provider `eks_shell.go`/`gke_shell.go`/`aks_shell.go`/`kubernetes_shell.go`) and **fail closed** when it cannot be resolved; a one-line `k8s_hardening: connector=… cluster_role=…` posture log is emitted on the first authorization. Kubernetes decouples authn from authz, so there is no credential downscoping for K8s — the in-process request gate is the sole client-side control. The fetch is an internal bootstrap call that bypasses `AuthorizeAction` to avoid circularity.
-- **`internal/auth/gitlab`** (the exposure-classifier subpackage: `table.go`/`policy.go`/`classifier.go`/`sensitive.go`/`exposure.go`) plus the parent-package `gitlabProvider` (`gitlab.go`) implement the GitLab connector (gitlab.com + self-managed). The provider injects `Authorization: Bearer` — which authenticates PAT, project/group, AND OAuth tokens (`glab auth login` defaults to an OAuth token that `PRIVATE-TOKEN` would 401) — discovered from `GITLAB_TOKEN`/`GITLAB_ACCESS_TOKEN`/`OAUTH_TOKEN` (exec-free static source), else by delegating to the pinned `glab auth credential-helper` binary — cynative sets `GITLAB_HOST` to the login host (`glabLoginHost`: the explicit `host`, or the `api_host` when only that is configured, never the un-configured `gitlab.com` default, so an `api_host`-only config gets the api_host's own token not the public one) and `GITLAB_API_HOST` to the served API host authority (api_host or host, **including any `:port`**, so a non-443 self-managed OAuth token refreshes against the right endpoint), then validates the returned `instance_url` matches the login OR api host (`validateInstanceURL`). The token is **eagerly validated at registration** via a dial-guarded `GET /api/v4/user` (`gitlabOutcome` on `*registrationDeps` in `registration.go`, mirroring github/k8s), so the startup inventory shows it validated-live — `@username` (plus ` · host` for self-managed), or unavailable-with-reason for a dead/unreachable token. It enforces a **per-resource-category exposure ceiling** (`connectors.gitlab.permissions: category → read|write|none`, secure baseline `{default: read, ci-variables: none}`), mirroring the GitHub connector. The subpackage live-fetches GitLab's first-party OpenAPI v3 (`gitlab.com/gitlab-org/gitlab/-/raw/master/doc/api/openapi/openapi_v3.yaml`, anonymous, dial-guarded, no-redirect, size-capped) and distills it (`DistillOpenAPI`) into a `(method, path-template) → category` `Table` (the operation's normalized `tags[0]`; cached via `internal/cache.TTLCache` under `<cache>/gitlab`); `Lookup` anchors on the FIRST decoded `api`/`v4` segment pair so self-managed subpath installs match. `AuthorizeAction` classifies each request to `(category, required-level)` (`RequiredLevel` by method — `GET`/`HEAD`/`OPTIONS` + `POST /api/v4/markdown` are reads; the GraphQL API `/api/graphql` is denied entirely) and allows it only when `Exposure.Resolve(category)` permits that level — failing closed on an unclassifiable route (`ErrUnclassifiable`), a missing table (`ErrTableNotReady`), an over-ceiling request (`ErrExposureExceeded`), or a configured key naming no real category (`ValidateExposureKeys`/`ErrUnknownKey`). `ci-variables` is the secret-leak-on-read sensitive category (GET returns plaintext CI/CD variable values): `DistillOpenAPI` maps any TEMPLATE whose segments contain a literal `variables` segment to `ci-variables` at distill time (on the trusted spec templates — so a `variables` path-PARAMETER value, e.g. a file named `variables`, keeps its true category and cannot inherit an opened `ci-variables` ceiling), and `AdmitTable` rejects a fetched/cached table that downgrades a `variables` template (cache-poison defense). A one-line `gitlab_hardening: mode=scoped …` posture is emitted on first resolve (`ScopedPosture`/`PostureLoud`; loud `⚠️` when `default=write`, `ci-variables` is opened, or any category is widened); the compact `CYNATIVE_CONNECTORS_GITLAB_PERMISSIONS="default=read,issues=write"` env scalar replaces the file map wholesale. `AuthorizeAction` also pins the request/Host-override port to the configured port and rejects sudo impersonation and smuggled credential params (`token`/`private_token`/`access_token`/`job_token` in query + urlencoded/multipart/JSON body, matched on the base name so Rack `[...]` and `_`↔`-` folding can't evade it). `AuthorizesAddr` denies internal IPs by default (RFC1918 allowed only behind `connectors.gitlab.allow_private_network`; the loopback/link-local/metadata/ULA-IPv6 floor always stays), then fresh-resolves + exact-IP-pins the served host; `CACertProvider` supplies a configured `connectors.gitlab.ca_cert`. The central `auth.rejectModelSuppliedCredential` denylist and `redact.denylistedHeaders` are extended with the GitLab credential headers (`Private-Token`/`Job-Token`/`Deploy-Token`/`X-Gitlab-Static-Object-Token`/`Cookie`, matched `_`↔`-`-normalized) and the `feed_token`/`rss_token` query params. The glab OAuth credential is resolved by delegating to the pinned `glab auth credential-helper` binary (`gitlab_glab.go` gated core + `gitlab_glab_shell.go` exec shell — the codebase's first production `os/exec`), which reads `config.yml` or the OS keyring, refreshes an expired OAuth token, and prints JSON; glab owns the token lifecycle, config.yml, and refresh token (cynative reads/writes neither). Behind the unchanged `tokenSource oauth2.TokenSource` seam sits a static source for env/PAT tokens and, for a glab credential, a caching `glabHelperSource` (60s skew, failure cooldown, adopt-on-failure, seeded at registration). `parseCredentialHelperOutput` accepts only glab's `oauth2` (must carry an expiry) and `pat` token types — `job-token` and any unknown type are rejected (a CI job token cannot authenticate over Bearer). The exec is hardened per the issue's five requirements: `lookGlab` resolves one absolute path (`filepath.IsAbs`, no shell), `glabHelperEnv` curates the child env by allowlist (cynative's secrets dropped; kept: HOME/XDG/GLAB_CONFIG_DIR + Windows APPDATA/USERPROFILE + keyring/proxy/CA; `GITLAB_HOST`/`GITLAB_API_HOST`/telemetry-off set), `runGlab` sets a neutral cwd, a timeout + `WaitDelay`, `/dev/null` stdin, and size-capped drain-to-EOF output that never echoes the token into an error (stderr redacted); `parseCredentialHelperOutput` trusts the JSON `type` field, not the exit code (glab exits 0 on error). Discovery classifies startup via `decideGlab` against an `os.Stat` config-presence signal (`glabConfigExists`): keyring tokens now work, and a `config.yml` with a missing or too-old glab (needs **v1.85.2+** — the neutral-cwd run relies on glab's non-git-folder host fallback added there) is a loud skip steering to `GITLAB_TOKEN`. glab performs its own OAuth-refresh TLS handshake with its own trust; `connectors.gitlab.ca_cert` governs cynative's request path, not glab's refresh (glab already trusts the instance it authenticated to).
-- **`internal/cache`** is the stdlib-only leaf holding the one on-disk cache primitive, `cache.TTLCache[T]` (in-memory → on-disk per TTL → fetch, with stale-on-error fallback), plus `cache.Config{Dir, TTL, Clock}` which every connector cache embeds. It imports nothing from `internal/auth`, so all auth subpackages depend on it without a cycle. The aws serviceref / aws+gcp iam-dataset registries, the aws model-archive byte tier, and the gcp/azure catalogs all use it. `cloudauth` keeps only the host normalizer + HTTP/string shell helpers.
-- **`internal/interrupt`** is a stdlib-only leaf (`state.go`) providing the mutex-guarded two-stage interrupt `State` shared by the SIGINT/SIGTERM signal handler in `internal/cli` (L1) and the `TerminalController` in `internal/ui` (L3). `BeginTurn`/`EndTurn` arm/disarm interrupt handling and clear any stale trip from a prior turn; `Trip()` classifies a press — idle or second in-turn press → `true` (kill); first in-turn press → `false` (graceful, sets `Interrupted`); `Interrupted()` reports the graceful-stop flag. Keeping it in a separate package prevents an import cycle between `cli` (which imports `ui`) and `ui` (which cannot import `cli`).
-- **`internal/redact`** is a stdlib-only leaf holding the response **redactor** (`redact.New()` → `Redactor`). `Redact(string)` replaces secret-shaped content (PEM private keys, JWTs, GitHub/GitLab/Slack/Google tokens, AWS access-key IDs, credential-named JSON/XML field values, signed-URL signatures) with type-labeled `[REDACTED:<type>]` placeholders via high-precision keyword-pre-gated RE2 rules (no entropy heuristics; patterns sourced from the gitleaks default ruleset). `RedactHeader(http.Header)` blanks denylisted credential headers (`Set-Cookie`, `Authorization`, `Proxy-Authorization`, `X-Amz-Security-Token`, `X-Ms-Authorization-Auxiliary`) wholesale while exempting `Location` (redirect-following needs the signed URL) and content-redacting other header values. `transport.Client` injects it via a small local `redactor` interface (defaulted in `NewClient` to `redact.New()`) and applies it at **both** response exits — `FormatResponse` (the direct `Execute` path) and `ExecuteStructured` (the `code_execution` sandbox path) — so credential material is redacted at the source before reaching the model or the JS sandbox.
-- **`internal/config`** is a `Loader` (`config.NewLoader(env llm.LookupEnv, ...LoaderOption)`) that loads from `~/.cynative/config.yaml` (overridable via `--config`) and `CYNATIVE_*` env vars. It uses a fresh `viper.New()` per load (no global viper) and, instead of `viper.AutomaticEnv`, resolves each `CYNATIVE_*` var through the injected `env`: `applyEnv` walks `envKeys()` — `llm.ProviderEnvKeys()`, every field of each non-llm nested struct (e.g. `connectors.aws.policy`, `cache.dir`, `cache.ttl`), and every top-level scalar — and `v.Set`s any that are present (empty = unset, matching AutomaticEnv). The active provider is a single flat `llm:` block unmarshaled into `cfg.LLM` (`llm.ProviderEntry`); `llm.provider` and `llm.model` are both required. A top-level `cache:` block (`config.CacheConfig`: `dir` — default `~/.cynative/cache`, env `CYNATIVE_CACHE_DIR`; `ttl` — default `24h`, min `1m`, env `CYNATIVE_CACHE_TTL`) configures the shared cache directory and TTL for all connectors; the composition root (`research.go`) namespaces it per provider via `filepath.Join(cfg.Cache.Dir, "<provider>")`. Under a top-level `connectors:` key, an `aws:` block (`config.AWSConfig`: `policy` — the IAM policy ARN the action-authorization layer evaluates against, default `arn:aws:iam::aws:policy/SecurityAudit`, must start with `arn:aws:iam:`) configures AWS hardening, and parallel `gcp:` (`config.GCPConfig`: `role` — the role the action-authorization layer evaluates against, default `roles/viewer`; accepts a predefined `roles/<id>` or a custom `projects/<p>/roles/<r>` or `organizations/<o>/roles/<r>`) and `azure:` (`config.AzureConfig`: `role_definition` — the RBAC role definition, default `Reader`, required) blocks configure GCP and Azure hardening the same way; nested connector defaults are registered into viper via the now-recursive `registerStructDefaults` (durations stored as their `.String()` form so the strict duration decode-hook accepts them). A `github:` block under `connectors:` (`config.GithubConfig`: `permissions` — a `category[/subcategory]→read|write|none` map, default empty = secure baseline; besides the YAML/JSON map it accepts a compact `CYNATIVE_CONNECTORS_GITHUB_PERMISSIONS="default=read,issues=write,secret-scanning=none"` scalar that `structEnvKeys` enumerates as a leaf and the chain's `llm.StringToStringMapHookFunc` splits on unmarshal (rejecting duplicate keys) — a non-empty env value replaces the file map wholesale, while a blank value is treated as unset (`applyEnv` skips whitespace-only values, so a blank env var never silently wipes the file map) — but it is still skipped in `registerStructDefaults` since a map has no scalar *default*; validated by `validateGithubPermissions`) configures GitHub hardening; a `gitlab:` block (`config.GitLabConfig`: `host` default `gitlab.com`, optional `api_host`/`ca_cert`/`allow_private_network`, and a `permissions` `category→read|write|none` map — same secure-baseline + compact `CYNATIVE_CONNECTORS_GITLAB_PERMISSIONS` scalar mechanics as github; `host`/`api_host` validated as a bare hostname or `host:port`) configures GitLab hardening; the four K8s connector blocks `eks:`/`gke:`/`aks:`/`kubernetes:` each map to the shared `config.ClusterRoleConfig` type (a single `cluster_role` field — the ClusterRole the action-authorization layer evaluates against, default `view`, validated as a safe URL path segment by `validateClusterRoleName` which also fails-closed on an empty value, envs `CYNATIVE_CONNECTORS_{EKS,GKE,AKS,KUBERNETES}_CLUSTER_ROLE`) — the first three are the managed K8s connectors and `kubernetes:` is the self-managed one (kubectl-default discovery, no Cynative override); all four K8s connector configs do not use the `cache:` block (the ClusterRole policy is cached in memory only). `aliases.go` folds the convenience aliases into the squashed Bifrost fields (`materializeLLM`, threaded the same `env`) and rejects setting both an alias and its nested form (`detectAliasConflicts`); the `api_key` "env.X" form and the canonical-env fallback (e.g. `OPENAI_API_KEY`) both resolve through the injected `env` (via `llm.ResolveEnvVar`), never the process environment. Unmarshal runs through `mapstructure` with `TagName="json"` and the `llm` decode-hook chain (the EnvVar hooks also take `env`); `Loader.Load` then runs `llm.ValidateProvider`, `llm.ValidateKeyConfigs`, `llm.ValidateEnvVars`, and `llm.ValidateReasoning` before `go-playground/validator` checks the top-level fields (`render_style` — one of adaptive/notty, default `adaptive` (the terminal-foreground-inheriting style) — `max_iterations` — default `32`, env `CYNATIVE_MAX_ITERATIONS`, bounds the main agent loop — and `max_subagent_iterations` — default `10`, env `CYNATIVE_MAX_SUBAGENT_ITERATIONS`, bounds the `task` sub-agent loop; both `min=1`; `verify_findings` now runs unconditionally as two batched passes, with no config knob — and `sandbox_max_concurrency` — caps how many in-sandbox tool calls run at once, default `16`, min `1`, max `64`, env `CYNATIVE_SANDBOX_MAX_CONCURRENCY` — and `max_total_tokens` (the optional per-session token ceiling the agent loop enforces mid-turn, default `0` = unbounded, `min=0`, env `CYNATIVE_MAX_TOTAL_TOKENS`) — and `max_consecutive_failures` (consecutive no-progress tool calls before a halt-and-summarize, default `5`, `0` disables, `min=0`, env `CYNATIVE_MAX_CONSECUTIVE_FAILURES`) — plus `cache.ttl ≥ 1m` and the `connectors.aws`/`connectors.gcp`/`connectors.azure` blocks: `connectors.aws.policy` an IAM policy ARN, `connectors.gcp.role` a `roles/`-prefixed role, `connectors.azure.role_definition` required; and `connectors.eks.cluster_role`/`connectors.gke.cluster_role`/`connectors.aks.cluster_role`/`connectors.kubernetes.cluster_role` each a safe URL path segment, default `view`). `Loader` also injects `homeDir func() (string, error)` (defaulted to `os.UserHomeDir`, overridable via `LoaderOption`) for the default `~/.cynative` path and `~`-expansion of `cache.dir`.
-- **`internal/metrics`** accumulates **session-cumulative** operational telemetry — token usage (`schema.Usage`), model round-trips, tool calls, sub-agent spawns, verifiers, active compute time — for the stderr footer. It is a pure leaf over `internal/schema`. The `Accumulator` is fed by the agent loop (`AddRoundTrip`/`AddToolCall`/`AddSubagent`/`AddVerifier`) and by the llm layer's usage sink (`AddUsage`); counters and `usage` **never reset** (a session is one continuous tally, which keeps the per-turn footer from being misread as a session total). `StartTurn`/`EndTurn` bracket each turn's active-compute window (both called by `Agent.Run`, `EndTurn` via `defer` so every exit path closes it), and `Snapshot().Elapsed` is the sum of those windows plus the open turn's elapsed — **excluding** the idle time between interactive follow-ups; the cli renders these as single-scope footers via `ui.RenderFooter`: an interactive session prints a per-turn `turn` footer (`TurnSnapshot()`) after every turn plus one cumulative `session` footer (`Snapshot()`) at session end (a `defer` in `interactiveLoop`, gated on `RoundTrips > 0`); a `-p`/non-interactive one-shot prints only the gated `session` footer. Every method is nil-receiver-safe, so an `Agent` built without an accumulator (`Config.Metrics` nil, e.g. in tests) is a no-op; the clock is injected (`WithClock`) for deterministic tests. It also carries the optional per-session token ceiling (`WithBudget(maxTokens)` sets a plain `maxTokens int` field on the `Accumulator`; `0` = unbounded): the ceiling's token basis is `billedTokens` (`Σ usageTokens(per-call)` — `TotalTokens`, falling back to prompt+completion — accumulated in `AddUsage`; kept as a per-call sum rather than derived from the summed `usage`, which would diverge under inconsistent provider `total_tokens` reporting); the nil-safe `BudgetExceeded()`/`BudgetReason()`/`HasBudget()` answer the threshold query the agent loop (and the verifier's coarse per-pass backstop) enforces.
-- **`internal/ui`** wraps `charm.land/glamour/v2` for markdown rendering and provides the interactive prompter (`PromptToolApproval`, `AutoApproveToolCall` for the `--auto-approve` path, `PromptUserInput`) plus `PrintToolCall`. `formatToolCall` detects a `code_execution`-style payload (a non-empty `code` field) and renders it as a reviewable ` ```javascript ` block so the host can inspect sandboxed code before approving, otherwise it pretty-prints the JSON arguments. `RenderMessage` takes a `*schema.Message`. `RenderFooter(s, label)` writes a single-scope operational footer to stderr at the terminal-default foreground (no ANSI dim — the `footerColor` seam was removed), as do `RenderBanner`/`RenderConnector`: a chrome line plus one token line labeled by scope (`turn` or `session`, always showing the running total); displayed input is split into fresh (`PromptTokens − CachedReadTokens`) vs always-shown `cached` (incl. `0 cached`), with cache-write as a parenthetical subset of fresh. The token line is omitted when no usage was reported, and the sub-agent/verifier chrome segments and the cache-write parenthetical are omitted when empty/zero. Markdown answers render with the default `adaptive` style (`adaptiveStyleConfig`): body text inherits the terminal foreground (so it is never the old faint gray), inline code uses a dark chip, and the heading/link accent palette is chosen from a lazy, cached `lipgloss.HasDarkBackground` probe (dark vs light) that fires only on the first `adaptive` render — so non-TTY/`NO_COLOR` runs (forced to `notty`) never query the terminal. The interactive `>` prompt uses a raw-mode line editor (`golang.org/x/term`, `termLineReader` in `lineeditor_shell.go`: a fresh `term.Terminal` per read for a pristine cursor/buffer state, shared `boundedHistory` — capacity 100 — across reads, `applySize` sync) with history navigation (up/down) via the `lineReader` seam; a cooked `scannerLineReader` is the fallback for non-editor input (non-unix, piped, headless). On a unix editor TTY, a `TerminalController` (`terminal_controller_shell.go`) owns the interaction fd: `BeginTurn` arms the `interrupt.State` and enters **cbreak** (clears `ICANON`/`ECHO`/`ISIG`/`IEXTEN`/`IXON`, keeps `OPOST`/`ONLCR`, `VMIN=0`/`VTIME=1` polling); on success it sets `watching` and starts a single keystroke-watcher goroutine, but if cbreak entry fails it leaves `watching` false and starts no watcher (a degraded turn — the fd stays canonical, SIGINT still works via the signal handler's cooked-mode `ISIG`). `EndTurn` joins the watcher only when `watching` (signals it, waits, then `Restore`s the tty to its captured cooked state) before disarming; the POSIX signal handler and panic paths also call `Restore`. The watcher feeds bytes one at a time through `keyDecoder` (`watcher_decode.go`), a pure state machine (`modeGround`/`modeEsc`/`modeEscSeq`) that disambiguates a lone Esc (interrupt) from CSI/SS3 escape sequences via a `VTIME` timeout tick, recognizes Ctrl-C, and — when an approval window is active — maps `y`/`a` to approve-once/approve-session and **fails closed**: `n` and any other printable key deny, matching the cooked `parseDecision`. An interrupt event trips the shared `interrupt.State` — first in-turn press → graceful (`Interrupted()` true, any pending approval channel closed so it denies); second press → `os.Exit(130)`; idle press → `os.Exit(130)`. Single-key tool approval during a turn (`BeginApproval`) delivers the `tools.Decision` on a buffered channel and `approveSingleKey`'s select makes interrupt dominate (a pre-read interrupt check, then a post-decision `Interrupted()` re-check, so a stop that raced in with the keystroke still denies); on a degraded (no-watcher) turn `BeginApproval` fails closed by returning a pre-closed interrupt channel so the approval denies at once. The line-edited fallback is used on non-editor runs.
-- **`internal/audit`** records every tool call to a fail-closed JSONL audit log (`~/.cynative/audit.log`). `audit.go` is the gated core: `Logger.Log` stamps `Time`/`Seq`/`Actor`, **always** redacts the `Result`, and writes the call arguments verbatim unless `RedactArgs` is set (inner `code_execution`/ungated-orchestration/unknown-tool records set it). `rotate.go` (core) wraps the writer in an `ageRotatingWriter` that rotates the active file once its oldest record ages past `retention_days` (`rotateDueByAge` + `parseFirstRecordTime` over an injected `rotatingWriteCloser` + clock; fail-closed on a triggered `Rotate` error). `audit_shell.go` (`Open`, the excluded shell) seeds the oldest-record time from the existing file's first line, builds the size-rotating `*lumberjack.Logger` (`MaxSize`/`MaxAge`/`MaxBackups:0`), forces mode `0600`, and injects `time.Now`. Mapped from `config.AuditConfig` (`enabled`/`path`/`max_size_mb`/`retention_days`/`compress`).
+- **`cmd/cynative`**: a thin `main` that calls `cli.Execute()`.
 
-### Conventions in this codebase
+- **`internal/cli`**: cobra commands and the **composition root**. `wire_shell.go`'s `newDeps`
+  is the one place that reads the real environment (`os.LookupEnv` into `config.NewLoader`,
+  `auth.GetProviders`, `ui.New`, stdio, and the `llm`/`tools`/`agent` constructors); every
+  collaborator is a field on the `deps` struct (no package globals), the orchestration core is
+  tested with fakes, and `wire_shell.go` is the excluded shell. The root command replaces the
+  old `research` subcommand: `-p`/`--print` (or any piped/non-TTY invocation) runs the task
+  once; a TTY without `-p` enters an interactive follow-up loop (optionally seeded by a
+  positional arg) that survives transient turn errors; `exit`/`quit`/EOF ends it, and it
+  aborts only on context cancellation, a fail-closed audit-write failure, or an LLM generation
+  failure before the first successful turn. Piped stdin (1 MiB-capped, UTF-8-repaired)
+  combined with a positional task is folded in as untrusted `<piped_input>` context
+  (`agent.WrapPipedInput`).
+  Invariants:
+  - Every I/O tool is **approval-wrapped unconditionally** (`tools.NewApprovalTool`);
+    `--auto-approve` swaps the prompter for `ui.AutoApproveToolCall` (prints and approves), it
+    never skips the wrapper. The orchestration tools (`write_todos`/`task`) are registered
+    unwrapped: surfaced, not gated.
+  - Approval prompts use the controlling terminal (`/dev/tty` via the build-tagged
+    `resolveInteraction`) when stdin is piped, so a piped one-shot can still prompt; a run with
+    no usable terminal and no `--auto-approve` fails closed with `ErrNoApprovalTerminal` (empty
+    non-interactive input fails with `ErrNoTask`).
+  - `auth.GetProviders` receives a single `auth.HardeningConfig` bundling one config per
+    connector, built from `cfg.Connectors.*` (permission maps, policy/role names,
+    ClusterRoles); the cached connectors (github/gitlab/aws/gcp/azure) additionally embed a
+    `cache.Config` namespaced per provider via `filepath.Join(cfg.Cache.Dir, "<provider>")`,
+    while the four K8s connector configs carry only a ClusterRole.
+  - Operational footers render on **stderr** (`ui.RenderFooter`): a `turn` footer per
+    interactive turn plus one cumulative `session` footer at session end (`-p` prints only the
+    `session` footer), so redirecting stdout keeps the answer clean. One `metrics.Accumulator`
+    (with `metrics.WithBudget(cfg.MaxTotalTokens)`) spans the session and is threaded to both
+    the chat model (`llm.WithUsageRecorder`) and the agent. `--verbose`/`-v` routes per-tool-call
+    output to stderr.
+  - SIGINT/SIGTERM: a two-stage handler shares a leaf-package `interrupt.State` with the
+    optional ui `TerminalController`. SIGTERM always restores the terminal and exits 143; a
+    first in-turn SIGINT is graceful (the agent loop handles it), a second in-turn press or any
+    idle press restores and exits 130. On an editor TTY the `TerminalController` is the
+    `deps.interrupter`; otherwise the shared `*interrupt.State` itself is. There is no no-op
+    interrupter type; an inert one is a zero `*interrupt.State`.
 
-- **Dependency injection via constructor-injected seams (ports & adapters).** The strict lint config bans `init()` and mutable globals (`gochecknoglobals`, `gochecknoinits`) — the old `//nolint:gochecknoglobals // injectable for testing` global-swapper pattern is gone, do not reintroduce it. Each package splits into a pure **core** (100%-coverage-gated, every test `t.Parallel()` under `-race`) and a thin imperative **shell** (`*_shell.go`, excluded from the coverage gate, integration-tested). Shell functions are additionally capped at cyclomatic **and** cognitive complexity 6 by `make shell-complexity` — keep them to untestable glue; push any branchy/testable logic into the gated core. Anything that touches the outside world (cloud SDKs, `os`/env, filesystem, network `Do`, stdin/stdout, `term`, `json.Marshal`, the Bifrost client, the sobek runtime) is injected, never reached for directly:
-  - **Required deps** → small consumer-owned interfaces or func fields, defaulted to the real impl in the constructor; tests inject fakes via `With*` functional options exposed in `export_test.go`.
-  - **Multi-method ports** → `moq` mocks via `//go:generate go tool moq -out <pkg>_mock_test.go . <Iface>` (the `*_mock_test.go` output is gitignored, regenerated by `make generate`). A thin one-call seam stays a func field. Where an external interface can't be moq'd directly (pulls internal symbols), mirror it with a drift-pinned local interface (see `internal/auth`, `internal/auth/aws`).
-  - **Default factories whose real impl has an unreachable error path** → a factory field defaulted **branch-free** to a shell function in `*_shell.go`, so core stays 100% with no injectable global (see the `llm` Bifrost backend in `bifrost_shell.go` and the `sandbox` runtime build in `sandbox_shell.go`).
-  - **Env resolves once at the edge:** the composition root (`internal/cli/wire_shell.go`'s `newDeps`) passes `os.LookupEnv` to `config.NewLoader`; everything downstream takes an injected `llm.LookupEnv` (`func(string)(string,bool)`), so no test uses `t.Setenv`.
-- **Test package layout.** Flavors coexist:
-  - `foo_test.go` — external `package foo_test`, exercises the public API.
-  - `foo_internal_test.go` — internal `package foo`, for tests that need unexported access (e.g. building a package's `deps`/struct with fakes, or injecting via unexported options).
-  - `export_test.go` — internal package; exposes `With*` options and small test constructors that inject fakes into the package's structs (it no longer holds `Stub*` global-swappers).
-  - `*_mock_test.go` — `moq`-generated, gitignored; run `make generate` first on a fresh checkout.
-  - `internal/auth/authtest` is a sibling package of reusable fake `Provider` implementations. It is test support imported only from `_test.go` files: exempt from the coverage gate (its fakes are pinned by the six consumer suites that depend on them) and guarded by the `make test` import check, which rejects any non-test importer.
-- **Lint config is strict** (`.golangci.yaml`, ~485 lines based on the maratori "golden config"): `modernize`, `mnd`, `funlen`, `cyclop`, `godot`, `gochecknoglobals`, `gochecknoinits`, `paralleltest`, `forbidigo`, and many more are on (`exhaustruct` is configured but commented out in the "you may want to enable" block, so its `//nolint:exhaustruct` markers are inert). Line length is **120** (golines). Local-prefix `goimports` group is `github.com/cynative/cynative`. `*_shell.go`, `internal/cli/{root,wire_shell}.go` are exempt from `forbidigo` (legitimate edge env reads); `*_shell_test.go` from `paralleltest`. Most violations are intentional in this code; if you must suppress, mirror existing `//nolint:rule // reason` comments — always include the reason.
-- **Comments end in a period** (`godot`).
-- **Error wrapping with `%w`** and sentinel errors named `ErrX`; error types named `XError` (`errname`, `errorlint`).
-- **No `init()` functions and no mutable global state.** Wire dependencies through constructor-injected struct fields/options (see `agent.Agent`, the `cli` `deps` struct, `config.Loader`). The only permitted `//nolint:gochecknoglobals` exceptions, each with a `// reason`, are stateless singletons (e.g. a `validator.New()` instance, cached `reflect.Type`s) and `// test export` function-value aliases that re-export unexported helpers from `export_test.go` (e.g. `config.ErrMsg`/`ErrMsgFromType`).
-- **Provider catalog is derived and test-enforced.** `llm.ChatProviders()` is Bifrost's `schemas.StandardProviders` minus the hand-triaged `nonChatProviders` exclusions (chat capability is not mechanically verifiable, so re-check each provider's `ChatCompletion` body on every Bifrost bump); package tests pin the exclusion triple and fail unless the `CanonicalEnvKeyLookup` keys (empty string = "no single-env fallback") are set-equal to the catalog and every catalog entry has a `docs/providers/<name>.md` guide. When a Bifrost bump changes the provider set, triage the change and update the exclusions, env row, and doc together. The connector registry has the same convention: `internal/auth/connector_docs_test.go` fails unless every connector id `GetProviders` can register has a guide at `docs/connectors/<file>.md` — when adding a connector, add its doc and the test-table row together.
+- **`internal/schema`**: the provider-agnostic message/tool currency shared by `llm`, `agent`,
+  `tools`, and `ui`. A pure leaf: it imports only the standard library and
+  `github.com/invopop/jsonschema`, and **no internal import may ever be added** (nothing it
+  depends on can create a cycle). `Message{Role, Content []Block}` with three sealed block
+  variants: `TextBlock`, `ToolCallBlock` (the raw JSON arguments as the model produced them),
+  `ToolResultBlock`. `ChatModel{Generate}` takes the offered tools as a direct
+  `tools []*ToolInfo` argument (tool-less calls pass nil; there is no per-call options
+  machinery). `InvokableTool{Info, Run}` plus the optional `StructuredRunner`; `Usage` is the
+  per-call token accounting. `ReflectParams[T]()` generates a tool's JSON Schema from a Go
+  struct via invopop/jsonschema, configured with inlined definitions and
+  `additionalProperties:false` so strict-mode providers accept it.
+
+- **`internal/llm`**: owns the embedded Bifrost SDK and adapts it to `internal/schema`.
+  `BifrostChatModel` implements `schema.ChatModel` (plus `Shutdown`) over a `BifrostBackend`
+  port (moq'd in tests; the real client is built in `bifrost_shell.go` and injected as a
+  defaulted factory field). The Anthropic rolling cache-breakpoint marking is applied per
+  request. `ProviderEntry` embeds Bifrost's `schemas.ProviderConfig` via `json:",squash"` so
+  every Bifrost field (including `network_config` for proxy/timeout/retries/headers) is exposed
+  without per-field translation, plus the cynative selectors (`provider`, `model`), the
+  `api_key` top-level alias, and hoisted per-provider key-config aliases
+  (`azure`/`vertex`/`bedrock`/`vllm`/`ollama`/`sgl`/`replicate`). Invariants:
+  - The provider catalog is **derived**: `ChatProviders()` is Bifrost's `StandardProviders`
+    minus the hand-triaged `nonChatProviders` exclusions (providers whose Bifrost impl cannot
+    chat, rejected by `config.ValidateLLM`). `CanonicalEnvKeyLookup` backs the single-env-var
+    fallback.
+  - Env references resolve through the injected `LookupEnv`, never the process environment:
+    `ResolveEnvVar` turns `env.X` strings into Bifrost `SecretVar`s, `ProviderEnvKeys` enumerates
+    the dotted key paths that `CYNATIVE_LLM_*` vars map onto, and `ValidateEnvVars` verifies
+    referenced vars are set.
+  - `ValidateKeyConfigs` guards the providers whose Bifrost impl dereferences a per-key config
+    without a nil check (azure, vertex), with direct field checks so an upstream rename fails at
+    compile time. `ValidateReasoning` validates `llm.reasoning_effort` (none through high) and
+    `llm.reasoning_max_tokens`, and rejects effort "none" combined with a budget, which
+    Bifrost's Anthropic-style converters would otherwise let silently re-enable thinking.
+  - `WithUsageRecorder` is the one production `ChatModelOption`: a sink invoked with the
+    `schema.Usage` of every successful `Generate` (the cli wires it to the metrics accumulator).
+
+- **`internal/agent`**: the in-house DeepAgents-style research loop, pure Go, tested directly
+  against a fake `schema.ChatModel` (no framework runner, no checkpoint store, no
+  interrupt/resume). `Agent.run` (`loop.go`) calls `model.Generate`, renders the assistant turn,
+  and returns its text when there are no tool calls; otherwise it dispatches each tool call,
+  appends a `ToolMessage` per result, and loops (terminating after `maxIter` iterations with an
+  empty answer). Tool failures and unknown-tool names come back as tool-result content, never a
+  Go error, so the model can self-correct. `Run` seeds the working transcript from the agent's
+  clean Q&A history (prior questions and final answers only; intermediate plans/steps/tool
+  output render live but are not replayed) plus the system message and the new question, then
+  records the exchange. `Config.MaxIterations` bounds the main loop,
+  `Config.MaxSubagentIterations` the `task` sub-loop. Key invariants:
+  - **Untrusted fencing**: every plain-`Run` (I/O) tool result is fenced via `wrapUntrusted`
+    (`framing.go`: `<tool_output tool="...">` with `</tool_output>` escaping) before it
+    re-enters the transcript, and `task` self-frames its summary; the orchestration acks (todo
+    checklist, verification panel) stay unframed as trusted host rendering with echoed finding
+    fields escaped. `prompt.go` carries the matching untrusted-data clause and `verify.go`
+    shares the same `escapeFence` helper.
+  - **Halt conditions.** Budget: when a token budget is configured (`metrics.WithBudget`) the
+    loop checks `BudgetExceeded()` at the top of every iteration, after each model response,
+    and after each tool dispatch; on exceed it returns the `errBudgetExceeded` sentinel and
+    `Run` renders a
+    one-line notice and stops the turn with no partial answer recorded. The bound is cumulative
+    across the main loop, `task` sub-runs, and the verifier, and is per-session (it survives
+    `StartTurn`). Interrupt: Esc or a first Ctrl-C (via the host `Interrupter`, checked at the
+    top of each iteration, after `Generate`, and before every I/O dispatch) surfaces as
+    `ErrInterrupted`, non-fatal in an interactive session, exit 130 in one-shot. Failures:
+    `max_consecutive_failures` consecutive no-progress tool calls (a tool error, a denial, or an
+    `http_request` response >= 400) trigger `failureSummary`: one tool-less `Generate` asking
+    the model to name the wall and the required input, returned and recorded as the turn's
+    answer (a blank or errored summary falls back to a deterministic notice). The
+    `haltAndAskClause` in the system prompt steers the model to stop and ask the operator for a
+    missing identifier rather than guess or probe candidates.
+  - **Orchestration tools live in this package** (not `internal/tools`, avoiding a
+    `tools`→`agent` import cycle) and are registered unwrapped since they perform no credentialed
+    I/O. `write_todos` records and renders the todo checklist (tolerating a double-encoded
+    payload, normalizing unknown statuses to `pending`); `task` re-enters the same `run` loop
+    with a fresh transcript seeded only with the system prompt + task description (context
+    quarantine, depth+1, fresh `runState`) while **reusing the parent's approval-wrapped I/O
+    tools**, so approval and auth still propagate; that invariant is pinned by
+    `TestIntegration_SubagentIOStaysGated`. Per-run mutable state lives in `runState`, never on
+    `*Agent`, so concurrent sub-runs are race-free (pinned by
+    `TestRun_ConcurrentRunsShareNoMutableState`).
+  - **`verify_findings`** (`verify.go`) is always on, with no config knob: exactly two batched
+    tool-less `Generate` passes (a benign-explanation lens, then an evidence-sufficiency lens),
+    each sending all findings in one prompt and requiring strict JSON keyed by host-assigned
+    finding ID. Refuted in either pass → REFUTED; confirmed in both → VERIFIED; else UNVERIFIED.
+    Depth-0 only, max 16 findings per call, 16 KiB evidence clamp with `</evidence>` escaping,
+    and **strict fail-closed parsing**: a missing, unknown, malformed, refused, truncated,
+    timed-out, or budget-skipped verdict degrades to insufficient_evidence, so no parse problem
+    can mint VERIFIED. Each pass has a coarse budget backstop (`BudgetExceeded()` checked before
+    the pass).
+  - `prompt.go` teaches the workflow (plan with `write_todos`, script with `code_execution` over
+    `http_request`, delegate with `task`, stop and answer when done), carries a
+    positively-framed `SCOPE:` clause near the top (right after the identity preamble and
+    optional About block) anchoring the agent to the question's subject (narrowest
+    enumeration; imperatives rather than prohibitions, so the guidance travels to small/local
+    models too), and lists the available auth providers so the model knows the valid
+    `auth_provider` values.
+
+- **`internal/tools`**: the I/O `schema.InvokableTool`s. `http_request` builds its JSON Schema
+  from `transport.RequestArgs` via `schema.ReflectParams` and forwards the model's raw JSON
+  arguments straight to `transport.Client.Execute` (preserving auth's raw-bytes contract); it
+  also implements `StructuredRunner`, so sandbox scripts receive a parsed object.
+  `code_execution` wraps the other tools as async JS functions inside an `internal/sandbox`
+  runtime, capped at `cfg.SandboxMaxConcurrency` concurrent inner calls; a tool's
+  `StructuredRun` is preferred and `Run` is the fallback. `approval.go` is a **synchronous,
+  blocking** decorator: each `Run` first calls the host `Prompter`
+  (`func(name, arguments, style string, alreadyGranted bool) Decision`; `Decision` is `Deny`,
+  the zero value, so an undecided prompt fails closed, `ApproveOnce`, or `ApproveSession`,
+  which latches a per-tool session grant so later calls to that tool are displayed and
+  auto-approved without pausing; every decision is recorded to the audit log) and either runs
+  the inner tool or returns `DeniedMessage` as a result string (not a Go error), so the loop
+  continues and the model can adapt. New I/O tools are added here; every tool handed to
+  `code_execution` is exposed to scripts automatically, and implementing
+  `schema.StructuredRunner` makes scripts receive a parsed object instead of a string.
+
+- **`internal/sandbox`**: runs untrusted, model-authored JavaScript in an embedded Grafana
+  **sobek** runtime, exposing host capabilities only through explicitly registered `ToolFunc`s;
+  there is no `fetch`, `require`, filesystem, network, timers, or Node/browser API. One
+  persistent, mutex-serialized runtime per session; each `Run` is wrapped in an async IIFE so
+  top-level `await` works and top-level declarations are call-scoped (state survives across
+  `Run`s only via `globalThis`). Each `Run` has a timeout context with a watchdog that calls
+  `vm.Interrupt`; output is captured from `console.log/error`, truncated to `maxOutput`, and
+  UTF-8-repaired; script errors and timeouts are included in the result string AND signaled
+  with the `ErrScript` sentinel (nil error only on success), so callers can record the failure
+  without parsing text; the `code_execution` tool converts `ErrScript` back into a plain
+  result string so the model can self-correct.
+  Tool calls are async: each returns a JS Promise backed by a worker goroutine bounded by a
+  `maxConcurrency` semaphore (a non-positive value clamps to `DefaultMaxConcurrency` = 16), a
+  single loop goroutine drains worker postbacks, and `Run` waits for all workers. The
+  `redact func(string) string` passed to `New` is a required security boundary: a nil redactor
+  panics on first use rather than silently leaking unredacted content. `mapConcurrent(items,
+  fn, limit)` (a pure-JS prelude installed non-writable on `globalThis`) gives bounded,
+  order-preserving fan-out that stops launching after the first failure; `xml.parse` and
+  `jmespath.search` are synchronous natives. `sandbox_shell.go` builds the runtime; the package
+  has no `agent`/`tools`/Bifrost dependency (`tools.codeexec` adapts it via the `codeRunner`
+  port, defaulting to a 32 KiB output cap and `redact.New().RedactPreservingLocation`).
+
+- **`internal/transport`**: executes `http_request` calls. The gauntlet, in order: parse args
+  (the model must name an `auth_provider`, one of `github`/`gitlab`/`aws`/`eks`/`gcp`/`gke`/
+  `azure`/`aks`/`kubernetes`), clamp timeout and body limits, **reject any non-`https` URL**
+  (credentials never traverse plaintext), never follow redirects (`CheckRedirect` returns
+  `http.ErrUseLastResponse`, so a 3xx is surfaced to the model and any follow-up hop is a
+  fresh, fully-gated request), authorize a model-supplied `Host` header override through
+  `auth.AuthorizeHost` like the URL host (the wire authority cannot slip host pinning), then run
+  the three auth gates: `auth.AuthorizeHost`, `auth.AuthorizeAction`, `auth.Inject`.
+  `configureTransport` installs a fresh per-request `*http.Transport` built from scratch, never
+  the shared default (Proxy intentionally nil, no inherited DialTLS, so an embedding process
+  that customized the global transport cannot bypass the guard), TLS-aware when the provider
+  supplies a CA cert or client cert (mTLS), and **always** wired with `dialGuard`: a
+  `net.Dialer.ControlContext` hook that authorizes the DNS-resolved IP via `auth.AuthorizeAddr`
+  before the connection is established, the dial-time chokepoint against DNS-rebinding/TOCTOU
+  SSRF (Go fires Control on every dial, including IP literals). Responses are redacted at the
+  source via `internal/redact` on **both** exits, `FormatResponse` (the direct `Execute` path)
+  and `ExecuteStructured` (the sandbox path), before dumping and truncation. `Execute` returns
+  the HTTP status code (0 on a transport-level error); `http_request`'s `Run` marks a transport
+  error or a >= 400 response as a no-progress outcome for the agent's consecutive-failure
+  counter.
+
+- **`internal/auth`**: the extensible provider registry. `GetProviders` takes a single
+  `auth.HardeningConfig` (bundling one config per connector: github, gitlab, aws, eks, gcp,
+  gke, azure, aks, kubernetes) plus an `onStatus` callback that receives a `ConnectorStatus`
+  per connector for the startup inventory, probes the environment, and returns whatever
+  registers. Registration is eager where it matters:
+  - github validates its token live with a hardened `GET /user` probe over `githubDialAllowed`,
+    a public-internet dial guard that denies all internal and special-use ranges (CGNAT,
+    benchmarking, documentation, 0.0.0.0/8, 240.0.0.0/4, non-global-unicast) plus
+    IPv4-embedding IPv6 (NAT64, 6to4) whose embedded IPv4 is internal, while a NAT64-wrapped
+    public GitHub IPv4 stays allowed so IPv6-only/DNS64 hosts work.
+  - gitlab discovers its token (`GITLAB_TOKEN`/`GITLAB_ACCESS_TOKEN`/`OAUTH_TOKEN`, else the
+    pinned `glab auth credential-helper`) and validates it with a dial-guarded
+    `GET /api/v4/user` through the provider's own host-pinned/CA path.
+  - AWS+EKS register via default AWS config, GCP+GKE via ADC, Azure+AKS via a credential chain
+    with managed identity demoted to last and made non-fatal (so the IMDS probe cannot abort the
+    chain on a non-Azure host whose metadata server shares 169.254.169.254), and a self-managed
+    `kubernetes` provider via the local kubeconfig using kubectl's own discovery
+    (`KUBECONFIG`, then `~/.kube/config`, current-context, no Cynative-level override); it
+    eagerly validates the cluster by fetching the configured ClusterRole over the same
+    dial-guarded path used at request time. The managed K8s connectors do not probe the API at
+    registration.
+  - "Available" means validated-live this startup: an invalid/expired/unreachable credential
+    shows unavailable with a reason, a genuinely absent ambient credential is a silent skip, and
+    an unbuildable hardened provider is a logged skip.
+
+  Core contracts:
+  - Every provider implements `Name`/`Description`/`InjectAuth` **and `AuthorizesHost`** (host
+    pinning is a baseline control, not optional). Optional interfaces: `CACertProvider`,
+    `ClientCertProvider` (how the K8s providers supply per-cluster CA bundles and client
+    certs), `ActionAuthorizer` (per-request action authorization, implemented by every provider
+    today), and `AddrAuthorizer` (dial-time authorization of the resolved IP; the four K8s
+    providers pin the dial to the cluster endpoint's exact resolved IPs, and providers that
+    don't implement it inherit the fail-safe default: deny internal ranges, loopback,
+    link-local including cloud metadata, RFC1918, ULA, IPv4-mapped forms, plus the exact Azure
+    WireServer and Alibaba metadata addresses; allow everything else).
+  - `auth.Inject`, the dispatcher every credentialed request flows through, rejects
+    model-supplied credentials before dispatching (`ErrModelSuppliedCredential`):
+    `Authorization`/`Proxy-Authorization`/`X-Ms-Authorization-Auxiliary` header values and URL
+    userinfo (which Go's client would otherwise turn into `Authorization: Basic ...` exactly
+    when an mTLS provider sets no header). The header match scans the raw header map keys
+    case-insensitively with `_` normalized to `-`, not via `Header.Values`, which would miss a
+    non-canonical key set by direct map assignment; presence is what matters, so duplicate or
+    empty values still count. Provider `InjectAuth` implementations are the sole setters of
+    credential material;
+    the Azure SAS `sig=` query check lives with the Azure provider.
+  - The GitHub provider gates each request against a configurable exposure ceiling
+    (`internal/auth/github`): classify the request to its category/subcategory and required
+    access level over a distilled OpenAPI category table (fetched anonymously by the shared
+    dial-guarded github/gitlab bootstrap fetcher in `bootstrap_fetch.go`, TTL-cached via
+    `internal/cache`), then allow it only when the operator's `Exposure`
+    (`category[/subcategory]` → read|write|none, secure baseline read-all-except
+    `secret-scanning`, resolved most-specific-first) permits that level. An unclassifiable
+    request, a missing table, an over-ceiling request, or a configured key naming no real
+    category each **fail closed**. `AdmitTable` rejects a fetched or cached table that remaps a
+    secret-scanning template (cache-poison defense); no request-time segment override is used,
+    to avoid false-positive denials from user-controlled path segments. `InjectAuth` strips any
+    model-supplied `X-GitHub-Api-Version` header so the model cannot select an API surface the
+    table did not model. GitHub-owned download hosts (`codeload.github.com`, release/objects
+    `githubusercontent.com`) are authorized GET/HEAD-only regardless of the ceiling; every
+    allow-listed host must be GitHub-operated because `InjectAuth` attaches the token
+    unconditionally. A best-effort post-response audit (`auth.ResponseAuditor`) compares
+    GitHub's `X-Accepted-GitHub-Permissions` header against the classification and logs drift,
+    advisory only. The github posture is computed at registration and surfaced in the startup
+    connector inventory (`ConnectorStatus.Posture`, warn-flagged by `PostureLoud` when the
+    default is write, `secret-scanning` is opened, or any category is widened); nothing is
+    emitted at request time.
+  - `k8sGate[A]` is the shared K8s authorization path all four K8s providers compose: it owns
+    the identical validate → resolve-view → classify → authorize sequence and the per-cluster
+    ClusterRole-policy cache, while credential and cluster-fact mechanics stay per-provider.
+    `syncCache[T]` coalesces concurrent CA/cert lookups via singleflight and caches successes,
+    not errors.
+
+- **`internal/auth/aws`**: AWS request hardening (pure core + `*_shell.go` fetchers), three
+  layers. (1) **Credential scoping**: `ScopedProvider` re-vends the base credentials via STS
+  `AssumeRole` scoped to the configured read-only managed policy (default `SecurityAudit`) via
+  `PolicyArns`, **only for assumed-role identities** (self-chain), degrading to disabled on a
+  definitive `AccessDenied` (e.g. an SSO trust policy forbidding self-assumption) and
+  propagating transient errors. IAM-user and root identities run unscoped, gated by the other
+  two layers alone; cynative no longer mints `GetFederationToken` sessions, which cannot call
+  IAM and so defeated IAM auditing. (2) **Host pinning**: `ParseHost` maps the request host to
+  a `(service, region)` and verifies it against the model's `aws_auth` claim, rejecting IP
+  literals, localhost, and VPC endpoints. It also recognizes account-scoped S3 Control hosts
+  and account-prefixed S3 access-point hosts (which resolve to the plain `s3` path: their
+  virtual-hosted requests are classified by prepending the host-implied bucket to the path);
+  `Verify` compares the service claim case- and hyphen-insensitively so endpoint-prefix and
+  SDK-id spellings reconcile, while signing uses the host-resolved canonical signing name.
+  (3) **Action authorization**: resolve the request to a service model via the cached
+  `ModelArchive`, classify the operation, resolve its required IAM action(s) through a
+  three-tier chain (Service Reference API → iam-dataset → `namespace:op` derivation), and
+  require the configured policy to allow every action via `iam:SimulateCustomPolicy`, failing
+  closed on any unresolved action. Namespace-shadowed services (e.g. S3 Control living under
+  the `s3` IAM namespace) are resolved only by their own identity, excluding the foreign
+  namespace key and the derivation tier, and fail closed on a miss, so account-level S3 Control
+  operations authorize against their own actions. All AWS I/O is lazy (first use) and cached
+  under `<cache>/aws`; a definitive scoping degrade emits a one-line `aws_hardening: degraded`
+  notice to stderr.
+
+- **`internal/auth/gcp`**: pure GCP request hardening composed via `AuthorizeAction`. Resolves
+  the request host to a Google API service through a live API Discovery-directory catalog
+  (TTL-cached via `internal/cache`; a transient partial fetch is cached fail-closed, denying
+  dropped services until the next refresh), classifies the operation, resolves its required
+  IAM permissions (pinned overrides first, then derive-and-validate against the live
+  testable-permissions catalog, with the cached iam-dataset as a read-fallback and write-union
+  tier), and authorizes every permission against the single configured role (default
+  `roles/viewer`; predefined or custom), failing closed on anything unresolved. I/O is lazy
+  and cached under `<cache>/gcp`; the role definition is fetched live per run (no role cache);
+  the `role=<configured role>` posture surfaces in the startup connector inventory.
+
+- **`internal/auth/azure`**: pure Azure request hardening composed via `AuthorizeAction`. Azure
+  has no credential-downscoping primitive, so this in-process action gate is the sole
+  client-side control: resolve the service via a cached catalog, classify the operation, and
+  authorize it against the single configured RBAC role definition (default `Reader`).
+  Data-plane operations (Key Vault secrets, Blob/Queue/Table data, SQL/Cosmos data) are out of
+  scope: Cynative is control-plane only and denies data-plane hosts at the network layer. I/O
+  is lazy and cached under `<cache>/azure`; the role definition is fetched live per run; the
+  `role definition=<name> (<guid>)` posture surfaces in the startup connector inventory.
+
+- **`internal/auth/k8s`**: the shared Kubernetes authorization core (pure, no network) used by
+  the `eks`/`gke`/`aks`/`kubernetes` providers through `k8sGate`: a faithful kube-apiserver
+  `RequestInfo` classifier, an allow-only RBAC matcher built from the cluster's live
+  **configured** ClusterRole (default `view`, set via `connectors.<connector>.cluster_role`,
+  path-escaped into the fetch path), a fail-closed ClusterRole-JSON parser, and an `Authorize`
+  combiner with a safe non-resource GET allow-set. The providers fetch and cache each cluster's
+  ClusterRole (the HTTPS fetch lives in the excluded shells) and **fail closed** when it cannot
+  be resolved; the `cluster role=<name>` posture surfaces in the startup connector inventory.
+  Kubernetes decouples authn from authz, so there is no credential downscoping; the in-process
+  gate is the sole client-side control. The ClusterRole fetch is an internal bootstrap call
+  that bypasses `AuthorizeAction` to avoid circularity.
+
+- **`internal/auth/gitlab`** (the exposure-classifier subpackage) plus the parent-package
+  `gitlabProvider` implement the GitLab connector (gitlab.com and self-managed). The provider
+  injects `Authorization: Bearer`, which authenticates PAT, project/group, **and** OAuth tokens
+  (`glab auth login` defaults to an OAuth token that `PRIVATE-TOKEN` would 401). Token
+  discovery: the env vars above, else delegation to the pinned `glab auth credential-helper`
+  binary; cynative sets `GITLAB_HOST` to the login host (the explicit `host`, or the `api_host`
+  when only that is configured, never the un-configured `gitlab.com` default) and
+  `GITLAB_API_HOST` to the served API authority including any `:port`, then validates the
+  returned `instance_url` against the login or api host. glab owns the token lifecycle,
+  config.yml, and refresh (cynative reads and writes neither; glab needs **v1.85.2+** for the
+  neutral-cwd host fallback). The exec is hardened: one absolute path (no shell), an
+  allowlisted child env with cynative's secrets dropped, a neutral cwd, timeout + `WaitDelay`,
+  `/dev/null` stdin, size-capped drain-to-EOF output that never echoes the token, and a parser
+  that trusts the JSON `type` field rather than the exit code (glab exits 0 on error),
+  accepting only `oauth2`-with-expiry and `pat` token types. Behind the `tokenSource` seam sit
+  a static source for env/PAT tokens and a caching `glabHelperSource` (60s skew, failure
+  cooldown, adopt-on-failure). Startup classification (`decideGlab`) uses a config-presence
+  signal: keyring tokens work, and a config.yml with a missing or too-old glab is a loud skip
+  steering to `GITLAB_TOKEN`. Authorization mirrors github: a per-category exposure ceiling
+  (`connectors.gitlab.permissions`, secure baseline `{default: read, ci-variables: none}`)
+  classified over GitLab's distilled first-party OpenAPI v3 spec (anonymous, dial-guarded,
+  size-capped fetch; TTL-cached; `Lookup` anchors at the root, requiring the path's first two
+  decoded segments to be exactly `api`/`v4`, so a subpath-mounted install is denied rather
+  than classified; subpath installs cannot register anyway since the eager `/api/v4/user`
+  probe runs at the host root). `GET`/`HEAD`/`OPTIONS` plus `POST /api/v4/markdown`
+  are reads; the GraphQL API is denied entirely; unclassifiable routes, a missing table,
+  over-ceiling requests, and unknown configured keys fail closed. `ci-variables` is the
+  secret-leak-on-read category: the mapping happens at distill time on the trusted spec
+  templates (so a `variables` path-parameter value cannot inherit an opened ceiling) and
+  `AdmitTable` rejects a table that downgrades a `variables` template (cache-poison defense).
+  `AuthorizeAction` also pins the request/Host-override port to the configured port and
+  rejects sudo impersonation and smuggled credential params (`token`/`private_token`/
+  `access_token`/`job_token` in query and urlencoded/multipart/JSON bodies, matched on the base
+  name so Rack `[...]` and `_`/`-` folding can't evade it). `AuthorizesAddr` denies internal
+  IPs (RFC1918 allowed only behind `connectors.gitlab.allow_private_network`; the
+  loopback/link-local/metadata/ULA floor always stays), then fresh-resolves and exact-IP-pins
+  the served host; `CACertProvider` supplies a configured `ca_cert` (which governs cynative's
+  request path, not glab's own refresh handshake). The GitLab credential headers
+  (`Private-Token`/`Job-Token`/`Deploy-Token`/`X-Gitlab-Static-Object-Token`/`Cookie`) and the
+  `feed_token`/`rss_token` query params are folded into the central credential denylist and
+  the redactor. The exposure ceiling renders in the startup connector-inventory line (built at
+  registration via `gitlabPosture`, warn-flagged by `PostureLoud` when the default is write,
+  `ci-variables` is opened, or any category is widened); the compact
+  `CYNATIVE_CONNECTORS_GITLAB_PERMISSIONS` env scalar replaces the file map wholesale.
+
+- **`internal/cache`**: stdlib-only leaf holding the one on-disk cache primitive,
+  `TTLCache[T]` (in-memory → on-disk per TTL → fetch, with stale-on-error fallback), plus
+  `Config{Dir, TTL, Clock}`, which every connector cache embeds. It imports nothing from
+  `internal/auth`, so all auth subpackages depend on it without a cycle.
+
+- **`internal/interrupt`**: stdlib-only leaf providing the mutex-guarded two-stage interrupt
+  `State` shared by the cli signal handler and the ui `TerminalController`; a separate package
+  purely to prevent a cli↔ui import cycle. `BeginTurn`/`EndTurn` arm and disarm (clearing any
+  stale trip); `Trip()` classifies a press: idle or second in-turn press means kill, first
+  in-turn press means graceful (sets `Interrupted`).
+
+- **`internal/redact`**: stdlib-only leaf holding the response redactor. `Redact` replaces
+  secret-shaped content (PEM private keys, JWTs, GitHub/GitLab/Slack/Google tokens, AWS
+  access-key IDs, credential-named field values, signed-URL signatures) with type-labeled
+  `[REDACTED:<type>]` placeholders via high-precision keyword-pre-gated RE2 rules (no entropy
+  heuristics; patterns sourced from the gitleaks default ruleset). `RedactHeader` blanks
+  denylisted credential headers wholesale while exempting `Location` (redirect-following needs
+  the signed URL) and content-redacting other header values. `transport.Client` injects it via
+  a small local interface and applies it at both response exits, so credential material is
+  scrubbed at the source before reaching the model or the sandbox.
+
+- **`internal/config`**: a `Loader` (`config.NewLoader(env llm.LookupEnv, ...)`, with an
+  injected `homeDir` for `~` expansion) that loads `~/.cynative/config.yaml` (overridable via
+  `--config`) and `CYNATIVE_*` env vars. It uses a fresh `viper.New()` per load and no
+  `AutomaticEnv`: `applyEnv` walks a generated key list (`llm.ProviderEnvKeys()`, every field
+  of each non-llm nested struct, every top-level scalar) and `v.Set`s any that are present
+  (whitespace-only counts as unset, so a blank env var never silently wipes a file map). The
+  active provider is a single flat `llm:` block unmarshaled into `llm.ProviderEntry`;
+  `detectAliasConflicts` rejects setting both an alias and its nested form, alias folding
+  (`materializeLLM`) then folds the aliases into the squashed Bifrost fields, and the
+  `api_key` `env.X` form and canonical-env fallback both resolve through the injected env.
+  Unmarshal runs mapstructure with `TagName:"json"` and the `llm` decode-hook chain; `Load`
+  then runs the connector validators and `go-playground/validator` over the top-level fields.
+  The LLM-block checks (`llm.provider`/`llm.model` presence plus the `llm`
+  provider/key/env/reasoning validators) live in `config.ValidateLLM`, which `Load` does not
+  call: the CLI invokes it and renders a missing or invalid `llm:` block as an LLM
+  startup-status block instead of failing config loading. Nested connector defaults are registered
+  recursively (durations stored as their `.String()` form for the strict duration hook). The
+  permission maps (`connectors.{github,gitlab}.permissions`) also accept a compact
+  `key=value,...` env scalar that replaces the file map wholesale (duplicate keys rejected).
+  Knobs and defaults: `render_style` `adaptive`; `max_iterations` 32;
+  `max_subagent_iterations` 10; `sandbox_max_concurrency` 16 (min 1, max 64);
+  `max_total_tokens` 0 = unbounded; `max_consecutive_failures` 5 (0 disables); `cache.dir`
+  `~/.cynative/cache`; `cache.ttl` 24h (min 1m); `connectors.aws.policy` an IAM policy ARN
+  (default `SecurityAudit`); `connectors.gcp.role` `roles/viewer` (accepts predefined or
+  custom project/org roles); `connectors.azure.role_definition` `Reader` (required);
+  `connectors.{eks,gke,aks,kubernetes}.cluster_role` `view` (validated as a safe URL path
+  segment, fail-closed on empty). Each knob has a matching `CYNATIVE_*` env var.
+  `verify_findings` has no knob; it always runs.
+
+- **`internal/metrics`**: session-cumulative operational telemetry (token usage, model
+  round-trips, tool calls, sub-agent spawns, verifiers, active compute time) for the stderr
+  footer; a pure leaf over `internal/schema`. Counters and usage **never reset**: a session is
+  one continuous tally, which keeps the per-turn footer from being misread as a session total.
+  `StartTurn`/`EndTurn` bracket each turn's active-compute window (both called by `Agent.Run`,
+  `EndTurn` via defer), and `Snapshot().Elapsed` excludes idle time between interactive
+  follow-ups. Every method is nil-receiver-safe (an `Agent` built without an accumulator is a
+  no-op); the clock is injected. It also carries the optional per-session token ceiling
+  (`WithBudget`): the basis is the per-call sum of usage tokens (`TotalTokens`, falling back to
+  prompt+completion), kept as a per-call sum rather than derived from the summed usage, which
+  would diverge under inconsistent provider `total_tokens` reporting; `BudgetExceeded()`/
+  `BudgetReason()`/`HasBudget()` answer the threshold query the loop and verifier enforce.
+
+- **`internal/ui`**: wraps `charm.land/glamour/v2` for markdown rendering and provides the
+  approval prompter, `PromptUserInput`, and `PrintToolCall`. `formatToolCall` detects a
+  `code_execution`-style payload (non-empty `code` field) and renders it as a reviewable
+  fenced-javascript block so the host can inspect sandboxed code before approving; other
+  payloads pretty-print as JSON. Markdown renders with the default `adaptive` style: body text
+  inherits the terminal foreground, and the accent palette comes from a one-time, cached
+  dark-background probe: editor-TTY (controller) runs prime it up front via `PrimeBackground`
+  before the keystroke watcher starts, so the OSC 11/DA1 probe reply cannot be stolen by a
+  concurrent reader and misread as Esc, while non-controller runs detect lazily on the first
+  `adaptive` render (non-TTY/`NO_COLOR` runs are forced to `notty` and never query the
+  terminal). `RenderFooter` writes single-scope
+  footers (`turn`/`session`) to stderr at the terminal-default foreground; displayed input is
+  split fresh vs `cached` (cached always shown, including `0 cached`), with cache-write as a
+  parenthetical subset omitted when zero; the token line is omitted when no usage was
+  reported, and the sub-agent/verifier chrome segments are omitted when zero. The interactive
+  `>` prompt is a raw-mode line editor (`golang.org/x/term`; a fresh
+  `term.Terminal` per read, shared bounded history of 100) behind the `lineReader` seam, with a
+  cooked scanner fallback for non-editor input. On a unix editor TTY the `TerminalController`
+  (shell) owns the interaction fd: `BeginTurn` arms the interrupt state and enters cbreak,
+  starting a single keystroke-watcher goroutine; if cbreak entry fails the turn degrades (no
+  watcher, fd stays canonical, SIGINT still works via the signal handler). `EndTurn` joins the
+  watcher and restores the tty; signal and panic paths also restore. The watcher feeds
+  `keyDecoder`, a pure state machine that disambiguates a lone Esc (interrupt) from CSI/SS3
+  sequences via a timeout tick, recognizes Ctrl-C, and during an approval window maps `y`/`a`
+  to approve-once/approve-session and **fails closed** (any other printable key denies,
+  matching the cooked parser). Interrupt dominates approval: a pre-read interrupt check plus a
+  post-decision re-check means a stop that raced in with the keystroke still denies; on a
+  degraded turn `BeginApproval` returns a pre-closed channel so the approval denies at once.
+
+- **`internal/audit`**: records every tool call to a fail-closed JSONL audit log
+  (`~/.cynative/audit.log`). The gated core's `Logger.Log` stamps `Time`/`Seq`/`Actor`,
+  **always** redacts the `Result`, and writes the call arguments verbatim unless `RedactArgs`
+  is set (inner `code_execution`, ungated-orchestration, and unknown-tool records set it).
+  Age-based rotation lives in core over an injected writer and clock (fail-closed on a
+  triggered rotate error); the shell (`Open`) seeds the oldest-record time from the existing
+  file's first line, adds size rotation via lumberjack, and forces mode 0600. Mapped from
+  `config.AuditConfig` (`enabled`/`path`/`max_size_mb`/`retention_days`/`compress`).
+
+### Conventions
+
+- **Ports & adapters with constructor injection.** The lint config bans `init()` and mutable
+  globals (`gochecknoglobals`, `gochecknoinits`); the old injectable-global-swapper pattern is
+  gone, do not reintroduce it. Each package splits into a pure **core** (100% coverage-gated,
+  every test parallel under `-race`) and a thin imperative **shell** (`*_shell.go`,
+  coverage-exempt, integration-tested, complexity-capped at 6; keep shells to untestable glue
+  and push branchy logic into gated core). Anything that touches the outside world (cloud SDKs,
+  `os`/env, filesystem, network `Do`, stdio, `term`, `json.Marshal`, the Bifrost client, the
+  sobek runtime) is injected, never reached for directly:
+  - Required deps become small consumer-owned interfaces or func fields defaulted to the real
+    impl in the constructor; tests inject fakes via `With*` functional options exposed in
+    `export_test.go`.
+  - Multi-method ports get `moq` mocks
+    (`//go:generate go tool moq -out <pkg>_mock_test.go . <Iface>`; output gitignored,
+    regenerated by `make generate`). A thin one-call seam stays a func field. Where an external
+    interface can't be moq'd directly (it pulls internal symbols), mirror it with a
+    drift-pinned local interface (see `internal/auth`, `internal/auth/aws`).
+  - A default factory whose real impl has an unreachable error path is a factory field
+    defaulted **branch-free** to a shell function, so core stays 100% with no injectable global
+    (see `bifrost_shell.go`, `sandbox_shell.go`).
+  - Env resolves once at the edge: `wire_shell.go` passes `os.LookupEnv` to `config.NewLoader`,
+    and everything downstream takes an injected `llm.LookupEnv`. No test uses `t.Setenv`.
+- **Test package layout.** `foo_test.go` (external `package foo_test`, exercises the public
+  API); `foo_internal_test.go` (internal package, for tests needing unexported access);
+  `export_test.go` (internal; exposes `With*` options and small test constructors, never
+  global-swappers); `*_mock_test.go` (moq-generated, gitignored; run `make generate` first).
+  `internal/auth/authtest` is a sibling package of reusable fake `Provider` implementations:
+  test support imported only from `_test.go` files, coverage-exempt, and guarded by the
+  `make test` import check.
+- **Lint config is strict** (`.golangci.yaml`, based on the maratori golden config):
+  `modernize`, `mnd`, `funlen`, `cyclop`, `godot`, `gochecknoglobals`, `gochecknoinits`,
+  `paralleltest`, `forbidigo`, and many more are on (`exhaustruct` is configured but commented
+  out, so its `//nolint:exhaustruct` markers are inert). Line length is **120** (golines);
+  the local goimports prefix is `github.com/cynative/cynative`. `*_shell.go` and
+  `internal/cli/{root,wire_shell}.go` are exempt from `forbidigo` (legitimate edge env reads);
+  `*_shell_test.go` from `paralleltest`. Most violations are intentional in this code; if you
+  must suppress, mirror the existing `//nolint:rule // reason` comments, always with the
+  reason. Comments end in a period (`godot`). Errors wrap with `%w`; sentinels are named
+  `ErrX`, error types `XError`. The only permitted `//nolint:gochecknoglobals` exceptions are
+  stateless singletons (a `validator.New()`, cached `reflect.Type`s) and `// test export`
+  aliases in `export_test.go`.
+- **Derived catalogs are test-enforced.** Package tests pin the `nonChatProviders` exclusions
+  and fail unless the `CanonicalEnvKeyLookup` keys are set-equal to the LLM provider catalog
+  and every catalog entry has a `docs/providers/<name>.md` guide; chat capability is not
+  mechanically verifiable, so re-check each provider's `ChatCompletion` body on every Bifrost
+  bump and update the exclusions, env row, and doc together. The connector registry has the
+  same convention: `internal/auth/connector_docs_test.go` fails unless every connector id
+  `GetProviders` can register has a guide at `docs/connectors/<file>.md`; when adding a
+  connector, add its doc and the test-table row together.
 
 ### CI and release
 
-- `.github/workflows/ci.yaml` runs `make check` (Go + shell + PowerShell) as the single **`Lint & Test`** job on every PR against `main` — a bootstrap step installs the pinned `shellcheck` (download + SHA-256 verify, no Docker) and the pinned Pester/PSScriptAnalyzer modules (versions read from the `Makefile` via `make -s print-*`) before `make check`. The job is gated `if: github.event_name == 'pull_request'` (the workflow also fires on push to `main`, but the only job is skipped there). Direct pushes to `main` are **blocked**: an active GitHub **ruleset** (`default`, surfaced via the `rulesets`/`rules` API rather than classic branch protection; no human can bypass) requires a PR with squash-only merges and linear history (no force-push or deletion), required review-thread resolution, and — as **required status checks** under a strict (up-to-date) policy — **`Lint & Test`** (this CI job), **`Validate PR title`** (the `.github/workflows/semantic-pr.yaml` conventional-commit check), and **`Build & smoke-test macOS packaging toolchain`** (`.github/workflows/pkg-tools.yaml`), so no PR merges unless `make check` passes in CI; the ruleset also runs Copilot code review on each push. The pre-commit hook (`.pre-commit-config.yaml`) runs the fast hermetic `make check-go` (Go only) — a **local** mirror of the Go half of the CI gate, not the enforcement boundary.
-- `.github/workflows/install-e2e.yaml` exercises the real installer against the goreleaser release archives for release confidence (issues #41/#42). It does not run on every normal PR: a `detect` job flags release-please PRs (branch `release-please--branches--main` or the `autorelease: pending` label) and manual `workflow_dispatch`; a single `snapshot` job then builds the archives once (`make snapshot`) and uploads them; and per-OS consumer jobs download that one artifact and run their installer test. `linux-install-e2e` runs `test/install.e2e.test.sh`; `windows-install-e2e` runs the Pester suite `test/install.e2e.Tests.ps1` under Windows PowerShell 5.1 (the `install.ps1` floor), covering install-from-fixture-zip, `cynative.exe --version`, uninstall, and the fail-closed checksum-mismatch path. All four jobs skip on a normal PR, and none is a required status check, so they gate release-please PRs and on-demand runs instead of blocking merges. The Windows job stays hermetic by stubbing `gh` and serving the archive from a loopback `test/serve-fixture.py`.
-- Releases are automated by **release-please** (config in `release-please-config.json`, version in `.release-please-manifest.json`). Conventional Commit prefixes in PR titles (`feat:`, `fix:`, `chore:`, etc.) determine the version bump — `.github/workflows/semantic-pr.yaml` enforces this.
-- `.goreleaser.yaml` handles binary builds for release tags.
+- `.github/workflows/ci.yaml` runs `make check` as the single **`Lint & Test`** job on every PR
+  against `main`; a bootstrap step installs the pinned shellcheck (download + SHA-256 verify)
+  and the pinned Pester/PSScriptAnalyzer modules, versions read from the `Makefile` via
+  `make -s print-*`. The job is gated to pull requests (the workflow also fires on push to
+  `main`, where it skips). Direct pushes to `main` are **blocked** by an active GitHub
+  **ruleset** (squash-only merges, linear history, required review-thread resolution, no human
+  bypass) whose required status checks, under a strict up-to-date policy, are **`Lint & Test`**,
+  **`Validate PR title`** (`semantic-pr.yaml`), and **`Build & smoke-test macOS packaging
+  toolchain`** (`pkg-tools.yaml`); the ruleset also runs Copilot code review on each push. The
+  pre-commit hook runs the fast hermetic `make check-go`, a local mirror of the Go half of the
+  gate, not the enforcement boundary.
+- `.github/workflows/install-e2e.yaml` exercises the real installer against the goreleaser
+  release archives for release confidence. It does not run on normal PRs: a `detect` job flags
+  release-please PRs and manual `workflow_dispatch`, one `snapshot` job builds the archives
+  (`make snapshot`), and per-OS jobs run the installer tests: Linux via
+  `test/install.e2e.test.sh`, Windows via the Pester suite under Windows PowerShell 5.1 (the
+  `install.ps1` floor), hermetic via a stubbed `gh` and a loopback fixture server. None is a
+  required status check, so they gate release-please PRs and on-demand runs, never normal
+  merges.
+- Releases are automated by **release-please** (`release-please-config.json`,
+  `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
+  version bump, enforced by `semantic-pr.yaml`. `.goreleaser.yaml` handles binary builds for
+  release tags.
+- The macOS packaging toolchain (the `pkg-tools.yaml` required check) is built by
+  `scripts/release/install-pkg-tools.sh` from two git submodules, `third_party/bomutils` and
+  `third_party/xar`, plus `tools/rcodesign` (a Cargo stub that pins the `apple-codesign`
+  version so Dependabot tracks it). A normal clone does not need the submodules: `make check`
+  never touches them. Run `git submodule update --init third_party/bomutils third_party/xar`
+  only when working on the packaging scripts; the workflow rebuilds only when those paths
+  change.


### PR DESCRIPTION
## What & why

AGENTS.md had grown to 77KB of single-line paragraphs: hard to diff, with the coverage-gate rules stated twice and a number of claims the code had moved past. This rewrites it in place:

- Wraps the prose at ~100 columns so future diffs of this file are reviewable, and folds the duplicated coverage-gate paragraph into the make-target bullets.
- Trims the per-package walkthrough to the invariants, security properties, and decision rationale that are not discoverable from the code, dropping the file-by-file mechanics (77KB to 51KB).
- Fixes claims the code has moved past, each verified against the source: connector postures surface in the startup connector inventory rather than per-request `hardening:` logs; `GetProviders` takes a bundled `HardeningConfig` plus an `onStatus` callback; the LLM block is validated by `config.ValidateLLM` from the CLI, not by `Load`; the approval `Prompter` returns a `Decision` (`Deny`/`ApproveOnce`/`ApproveSession`); Bifrost's `EnvVar` is now `SecretVar`; sandbox failures signal the `ErrScript` sentinel (`code_execution` converts it back for the model); the GitLab table `Lookup` is root-anchored, denying subpath installs; GCP permission resolution order and custom-role support; the credential-header check scans raw header keys rather than `Header.Values`; plus smaller naming and ordering corrections.
- Adds `make snapshot` / `make install-e2e` to the commands list and documents the macOS packaging toolchain submodules.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change (n/a: docs-only)
- [x] Docs updated if behavior changed (this is the docs change)