### PR TITLE
test: add live Vertex/Gemini no-tool e2e smoke test

### DIFF
--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -1,0 +1,87 @@
+name: Live LLM smoke
+
+# Runs the real `cynative -p` against a live Vertex/Gemini model (cynative#38):
+# a no-tool nonce-echo smoke proving the CLI + config + Bifrost wiring + response
+# handling work against a real provider. Mirrors install-e2e.yaml's detect gating,
+# so the heavy live run only fires for release-please PRs or a manual dispatch.
+# Authenticates to GCP project cynative-cli-ci via keyless Workload Identity
+# Federation; the credential step is gated to same-repo events so untrusted forks
+# never reach it. Not a required status check.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect release-please PR
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Detect release-please PR
+        id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          relevant=false
+          # Manual dispatch is an intentional run on any branch.
+          [ "${EVENT}" = "workflow_dispatch" ] && relevant=true
+          # release-please's branch name is deterministic and present from PR creation.
+          [ "${HEAD_REF}" = "release-please--branches--main" ] && relevant=true
+          # The autorelease label is a secondary fallback (it can lag creation).
+          case ",${LABELS}," in *",autorelease: pending,"*) relevant=true ;; esac
+          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
+          if [ "${relevant}" = "true" ]; then
+            echo "Release-please PR or manual dispatch - running the live LLM smoke."
+          else
+            echo "Not a release-please PR - skipping the live LLM smoke."
+          fi
+
+  vertex-smoke:
+    name: Vertex/Gemini no-tool smoke
+    needs: detect
+    # Run only when relevant AND either a manual dispatch (no PR context) or a
+    # same-repo PR. A fork PR must never reach the WIF/OIDC credential step.
+    if: >-
+      needs.detect.outputs.relevant == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token for Workload Identity Federation
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Report tested head SHA
+        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      # Keyless WIF into cynative-cli-ci. export_environment_variables:false keeps
+      # GOOGLE_APPLICATION_CREDENTIALS out of the process env, so the gcp connector
+      # stays dark; the minted credentials JSON is fed to cynative inline instead.
+      - name: Authenticate to GCP (Workload Identity Federation)
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
+          workload_identity_provider: ${{ vars.CYNATIVE_CLI_CI_WIF_PROVIDER }}
+          service_account: ${{ vars.CYNATIVE_CLI_CI_SA }}
+          create_credentials_file: true
+          export_environment_variables: false
+      - name: Run the Vertex/Gemini no-tool smoke
+        env:
+          CYNATIVE_LLM_PROVIDER: vertex
+          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_VERTEX_MODEL }}
+          CYNATIVE_LLM_VERTEX_PROJECT_ID: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
+          CYNATIVE_LLM_VERTEX_REGION: ${{ vars.CYNATIVE_CLI_CI_VERTEX_REGION }}
+          SMOKE_REQUIRE_NO_CONNECTORS: "1"
+          CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
+        run: |
+          CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-smoke

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -8,7 +8,11 @@ name: Live LLM smoke
 # Federation; the credential step is gated to same-repo events so untrusted forks
 # never reach it. Not a required status check.
 on:
+  # Include `labeled` (on top of the opened/synchronize/reopened defaults) so the
+  # `autorelease: pending` fallback in the detect job actually fires when that
+  # label is added after the PR is created, which is the lag it exists to cover.
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -82,6 +82,8 @@ jobs:
           CYNATIVE_LLM_VERTEX_PROJECT_ID: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
           CYNATIVE_LLM_VERTEX_REGION: ${{ vars.CYNATIVE_CLI_CI_VERTEX_REGION }}
           SMOKE_REQUIRE_NO_CONNECTORS: "1"
+          # Missing/renamed provider vars must fail the job, never silently skip.
+          SMOKE_REQUIRE_RUN: "1"
           CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
         run: |
           CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,11 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
   `--skip=before` keeps it hermetic/offline). `make install-e2e`: standalone release-confidence
   check, not part of `make check`; builds the snapshot, then runs the real `install.sh` against
   a loopback fixture server (`test/install.e2e.test.sh`, needs `python3`), verifying install,
-  `--version`, uninstall, and the fail-closed checksum-mismatch path.
+  `--version`, uninstall, and the fail-closed checksum-mismatch path. `make llm-smoke`:
+  standalone live LLM smoke (not part of `make check`); runs the real `cynative -p` against a
+  real provider chosen via `CYNATIVE_LLM_*` env (nonce echo, no tools; `test/llm.smoke.test.sh`),
+  asserting the nonce on stdout and `0 tool calls` in the footer, and skips cleanly when no
+  provider is set. See `docs/e2e/live-llm-smoke.md`.
 
 Two linters shape every new test: `paralleltest` requires each test and subtest to call
 `t.Parallel()`, and `forbidigo` bans `os.Getenv`/`LookupEnv`/`Environ` and `t.Setenv` outside

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: check check-go check-scripts lint format test generate shell-complexity \
-	windows-build shellcheck pwsh-lint pwsh-test sh-test snapshot install-e2e
+	windows-build shellcheck pwsh-lint pwsh-test sh-test snapshot install-e2e llm-smoke
 
 # Pinned external (non-Go) tool versions for check-scripts. Unlike the Go tools
 # (pinned via go.mod / `go tool`), these are NOT Dependabot-managed — Dependabot has
@@ -156,3 +156,10 @@ install-e2e:
 	$(MAKE) snapshot
 	sh test/install.e2e.test.sh ./dist
 	@echo "OK: install-e2e (real archive install + version + uninstall + checksum-failure)"
+
+# llm-smoke: live, no-tool LLM smoke test (cynative#38). Standalone (NOT part of
+# `make check`): runs the real `cynative -p` against a real provider selected via
+# CYNATIVE_LLM_* env and needs real credentials; skips cleanly when none are set.
+# See docs/e2e/live-llm-smoke.md.
+llm-smoke:
+	sh test/llm.smoke.test.sh

--- a/docs/e2e/live-llm-smoke.md
+++ b/docs/e2e/live-llm-smoke.md
@@ -49,6 +49,7 @@ sh test/llm.smoke.test.sh /path/to/cynative
 | `SMOKE_TIMEOUT` | `60` | Wall-clock seconds for the run. |
 | `SMOKE_MAX_TOKENS` | `16000` | Token ceiling (a safety backstop, not a tight budget). One turn of a thinking model like `gemini-2.5-flash` spends a few thousand tokens, and the budget is checked after the response, so too low a value discards the answer for a budget notice. |
 | `SMOKE_REQUIRE_NO_CONNECTORS` | unset | When `1`, hard-fail unless no connector registers. CI sets this on its clean runner; leave it unset on a cloud host (see the caveat below). |
+| `SMOKE_REQUIRE_RUN` | unset | When `1`, a missing `CYNATIVE_LLM_PROVIDER`/`CYNATIVE_LLM_MODEL` is a hard failure instead of a skip. CI sets this so a misconfigured job (for example a renamed model variable) fails loudly rather than passing green without exercising the model. |
 
 ## What it asserts
 

--- a/docs/e2e/live-llm-smoke.md
+++ b/docs/e2e/live-llm-smoke.md
@@ -1,0 +1,109 @@
+# Live LLM smoke test
+
+A small, live end-to-end check that the real `cynative -p` still works against a
+real LLM provider. Unlike the rest of the test suite (which is hermetic), this
+one talks to a real provider over the network, so it needs real credentials and
+is **not** part of `make check`. It is meant to be run by repo owners on trusted
+PRs and on release-please PRs, as release confidence.
+
+## What it proves
+
+One bounded, no-tool round-trip: the CLI starts, config loads, the Bifrost
+provider is wired correctly, a real model answers, and the response is handled
+and rendered. It is deliberately narrow so a failure points at exactly one of:
+provider config, credentials, model access, or response handling.
+
+The harness is provider-agnostic: everything is driven by `CYNATIVE_LLM_*` env,
+so the same script covers any provider. Vertex/Gemini is the first caller
+documented here.
+
+## Run it locally
+
+```bash
+export CYNATIVE_LLM_PROVIDER=vertex
+export CYNATIVE_LLM_MODEL=gemini-2.5-flash
+export CYNATIVE_LLM_VERTEX_PROJECT_ID=my-gcp-project
+export CYNATIVE_LLM_VERTEX_REGION=us-central1
+# Credentials: either inline the service-account JSON content, or rely on ADC
+# (see docs/providers/vertex.md). Inline keeps the gcp connector dark:
+export CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat /path/to/service-account.json)"
+
+make llm-smoke
+```
+
+With no `CYNATIVE_LLM_PROVIDER`/`CYNATIVE_LLM_MODEL` set, `make llm-smoke` prints
+a `skip:` line and exits 0, so it is a safe no-op.
+
+The script builds the current checkout (`go build ./cmd/cynative`), so it
+exercises your code, not a released binary. Pass a prebuilt binary path as the
+first argument to skip the build:
+
+```bash
+sh test/llm.smoke.test.sh /path/to/cynative
+```
+
+### Knobs
+
+| Env | Default | Meaning |
+| --- | --- | --- |
+| `SMOKE_TIMEOUT` | `60` | Wall-clock seconds for the run. |
+| `SMOKE_MAX_TOKENS` | `16000` | Token ceiling (a safety backstop, not a tight budget). One turn of a thinking model like `gemini-2.5-flash` spends a few thousand tokens, and the budget is checked after the response, so too low a value discards the answer for a budget notice. |
+| `SMOKE_REQUIRE_NO_CONNECTORS` | unset | When `1`, hard-fail unless no connector registers. CI sets this on its clean runner; leave it unset on a cloud host (see the caveat below). |
+
+## What it asserts
+
+- The process exits 0.
+- The model echoes a unique nonce on **stdout** (`grep -F`), so it survives
+  markdown reflow and only the answer text is matched.
+- The footer on **stderr** reports `0 tool calls`, proving the run used no tools
+  (the CLI still registers the tools; the assertion is that none were called).
+- Connectors: soft by default. If the startup inventory does not report
+  `(no connectors detected)`, the script prints a `warn:` line and continues.
+  With `SMOKE_REQUIRE_NO_CONNECTORS=1` this becomes a hard failure instead.
+
+## Failure classification
+
+The script separates stdout from stderr and reports a distinct reason per class:
+
+| Class | Signal | Likely cause |
+| --- | --- | --- |
+| harness/setup | `FAIL:` before any run (build failed, tool missing) | local toolchain, not the provider |
+| provider/config/access | non-zero exit with an LLM status on stderr | bad project/region, invalid or missing credentials, model not found, auth failure |
+| timeout | exit 124 | provider slow or unreachable within `SMOKE_TIMEOUT` |
+| unexpected response | exit 0 but nonce missing | the model did not echo, or the budget was too low and a notice replaced the answer |
+
+## Continuous integration
+
+`.github/workflows/llm-smoke.yaml` runs the same `make llm-smoke` against Vertex
+on release-please PRs and manual dispatch (the `detect` job gates it; it never
+runs on ordinary PRs and is not a required status check).
+
+Credentials use keyless **Workload Identity Federation** into the dedicated GCP
+project `cynative-cli-ci`, so no long-lived key is stored. The credential step
+is gated to same-repo events, so a fork PR never reaches it. The auth step runs
+with `export_environment_variables: false` and the minted credentials JSON is
+fed to cynative inline via `CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS`, deliberately
+**not** `GOOGLE_APPLICATION_CREDENTIALS`. That keeps the `gcp` connector from
+auto-registering, so `(no connectors detected)` holds and CI can set
+`SMOKE_REQUIRE_NO_CONNECTORS=1`.
+
+Non-secret configuration lives in repo Actions variables:
+`CYNATIVE_CLI_CI_PROJECT`, `CYNATIVE_CLI_CI_SA`, `CYNATIVE_CLI_CI_WIF_PROVIDER`,
+`CYNATIVE_CLI_CI_VERTEX_MODEL`, `CYNATIVE_CLI_CI_VERTEX_REGION`.
+
+## No-connectors caveat on cloud hosts
+
+Connectors auto-discover ambient credentials. On a GCP host (for example a GCE
+instance), the metadata server provides Application Default Credentials, so the
+`gcp` connector can register even when no connector is configured and even with
+inline Vertex credentials. That is why the local default is a soft warning: the
+real safety property is `0 tool calls` (no connector was actually exercised),
+which always holds. On the clean CI runner there is no metadata server and creds
+are inline, so the connector set is dark and the hard check is used.
+
+## Extending to other providers
+
+The harness is provider-agnostic. A new provider needs only its own
+`CYNATIVE_LLM_*` env block; the assertions are unchanged. For example, a Bedrock
+smoke sets `CYNATIVE_LLM_PROVIDER=bedrock`, a model id, and the AWS credentials
+its provider needs, then runs the same `make llm-smoke`.

--- a/test/llm.smoke.test.sh
+++ b/test/llm.smoke.test.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# llm.smoke.test.sh - live, no-tool LLM smoke test (cynative#38).
+#
+# Runs the real `cynative -p` one-shot against a real LLM provider selected via
+# CYNATIVE_LLM_* env, with a deterministic nonce-echo prompt, and asserts the
+# answer round-trips with no tool call. Provider-agnostic: Vertex/Gemini is the
+# first caller (cynative#38); Bedrock (cynative#48) reuses this with other env.
+#
+# NOT hermetic: it talks to a real provider and needs real credentials. Skips
+# (exit 0) when no provider is configured, so `make llm-smoke` is a safe no-op.
+#
+# Usage: sh test/llm.smoke.test.sh [BINARY]
+#   BINARY  optional path to a prebuilt cynative binary; default builds from
+#           ./cmd/cynative so the smoke exercises this checkout's code.
+#
+# Env:
+#   CYNATIVE_LLM_PROVIDER, CYNATIVE_LLM_MODEL   required (else skip)
+#   provider creds (e.g. CYNATIVE_LLM_VERTEX_* / _AUTH_CREDENTIALS for Vertex)
+#   SMOKE_TIMEOUT               wall-clock seconds (default 60)
+#   SMOKE_MAX_TOKENS            token ceiling (default 16000; a backstop, not a
+#                               tight budget - one turn of a thinking model like
+#                               gemini-2.5-flash spends a few thousand tokens, and
+#                               the budget is checked after the response, so too
+#                               low a value discards the answer for a budget notice)
+#   SMOKE_REQUIRE_NO_CONNECTORS =1 hard-fails unless no connector registers
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+
+# Skip cleanly when no provider is configured.
+if [ -z "${CYNATIVE_LLM_PROVIDER:-}" ] || [ -z "${CYNATIVE_LLM_MODEL:-}" ]; then
+	printf 'skip: llm.smoke (set CYNATIVE_LLM_PROVIDER + CYNATIVE_LLM_MODEL + creds to run)\n' >&2
+	exit 0
+fi
+
+command -v go >/dev/null 2>&1 || { printf 'FAIL: go not found (needed to build cynative)\n' >&2; exit 1; }
+command -v timeout >/dev/null 2>&1 || { printf 'FAIL: timeout not found\n' >&2; exit 1; }
+
+workdir=$(mktemp -d)
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT INT TERM
+
+# Build the binary (or accept a prebuilt one). Build BEFORE relocating HOME so
+# the Go build cache under the real HOME is reused.
+bin=${1:-}
+if [ -z "$bin" ]; then
+	bin="$workdir/cynative"
+	printf '== BUILD ==\n' >&2
+	( cd "$root" && go build -o "$bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; exit 1; }
+fi
+[ -x "$bin" ] || { printf 'FAIL: binary not executable: %s\n' "$bin" >&2; exit 1; }
+
+# Long, contiguous, no-whitespace nonce that survives markdown reflow.
+nonce="SMOKE-$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+prompt="Reply with exactly this token and nothing else: $nonce"
+
+# Isolate HOME (relocates ~/.cynative config/cache/audit) and silence connector
+# discovery sources unrelated to any LLM provider (github/gitlab/kube tokens and
+# config-dir overrides are never LLM creds). Do NOT unset AWS/GCP/Azure creds:
+# the LLM provider may need them (e.g. Bedrock uses AWS creds, so the gcp/aws
+# connectors can still register on a cloud host - the 0-tool-calls assertion is
+# the real safety net, and SMOKE_REQUIRE_NO_CONNECTORS is opt-in).
+export HOME="$workdir"
+unset XDG_CONFIG_HOME GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
+	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+
+printf '== RUN == %s/%s\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
+# timeout returns non-zero on a slow/failed run, which under `set -e` would abort
+# before rc is captured, so wrap it (house pattern, test/install.e2e.test.sh).
+set +e
+CYNATIVE_MAX_ITERATIONS=1 CYNATIVE_MAX_TOTAL_TOKENS="${SMOKE_MAX_TOKENS:-16000}" \
+	timeout "${SMOKE_TIMEOUT:-60}" "$bin" -p "$prompt" --auto-approve \
+		>"$workdir/out" 2>"$workdir/err" </dev/null
+rc=$?
+set -e
+
+# Failure classification.
+if [ "$rc" -eq 124 ]; then
+	printf 'FAIL: timed out after %ss\n' "${SMOKE_TIMEOUT:-60}" >&2
+	exit 1
+fi
+if [ "$rc" -ne 0 ]; then
+	printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$rc" >&2
+	tail -n 20 "$workdir/err" >&2
+	exit 1
+fi
+
+# Hard: the model echoed the nonce on stdout.
+if ! grep -Fq "$nonce" "$workdir/out"; then
+	printf 'FAIL: nonce not found in answer (unexpected model response). stdout tail:\n' >&2
+	tail -n 20 "$workdir/out" >&2
+	exit 1
+fi
+
+# Hard: no tool was called (footer on stderr).
+if ! grep -Fq '0 tool calls' "$workdir/err"; then
+	printf 'FAIL: expected "0 tool calls" in footer (a tool was called). stderr tail:\n' >&2
+	tail -n 20 "$workdir/err" >&2
+	exit 1
+fi
+
+# Connector check: soft warn by default, hard when SMOKE_REQUIRE_NO_CONNECTORS=1.
+if ! grep -Fq '(no connectors detected)' "$workdir/err"; then
+	if [ "${SMOKE_REQUIRE_NO_CONNECTORS:-}" = "1" ]; then
+		printf 'FAIL: a connector registered (SMOKE_REQUIRE_NO_CONNECTORS=1)\n' >&2
+		exit 1
+	fi
+	printf 'warn: a connector registered (expected none); the 0-tool-calls assertion still holds\n' >&2
+fi
+
+printf 'llm.smoke: OK (%s/%s)\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2

--- a/test/llm.smoke.test.sh
+++ b/test/llm.smoke.test.sh
@@ -23,12 +23,20 @@
 #                               the budget is checked after the response, so too
 #                               low a value discards the answer for a budget notice)
 #   SMOKE_REQUIRE_NO_CONNECTORS =1 hard-fails unless no connector registers
+#   SMOKE_REQUIRE_RUN          =1 hard-fails (instead of skipping) when provider/
+#                               model are unset, so a misconfigured CI job that
+#                               would silently skip is caught as a failure
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 
-# Skip cleanly when no provider is configured.
+# Skip cleanly when no provider is configured - unless SMOKE_REQUIRE_RUN=1, where
+# a missing provider/model is a failure (a CI job must never go green by skipping).
 if [ -z "${CYNATIVE_LLM_PROVIDER:-}" ] || [ -z "${CYNATIVE_LLM_MODEL:-}" ]; then
+	if [ "${SMOKE_REQUIRE_RUN:-}" = "1" ]; then
+		printf 'FAIL: CYNATIVE_LLM_PROVIDER/CYNATIVE_LLM_MODEL unset but SMOKE_REQUIRE_RUN=1\n' >&2
+		exit 1
+	fi
 	printf 'skip: llm.smoke (set CYNATIVE_LLM_PROVIDER + CYNATIVE_LLM_MODEL + creds to run)\n' >&2
 	exit 0
 fi
@@ -40,8 +48,7 @@ workdir=$(mktemp -d)
 cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT INT TERM
 
-# Build the binary (or accept a prebuilt one). Build BEFORE relocating HOME so
-# the Go build cache under the real HOME is reused.
+# Build the binary (or accept a prebuilt one).
 bin=${1:-}
 if [ -z "$bin" ]; then
 	bin="$workdir/cynative"
@@ -54,14 +61,20 @@ fi
 nonce="SMOKE-$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
 prompt="Reply with exactly this token and nothing else: $nonce"
 
-# Isolate HOME (relocates ~/.cynative config/cache/audit) and silence connector
-# discovery sources unrelated to any LLM provider (github/gitlab/kube tokens and
-# config-dir overrides are never LLM creds). Do NOT unset AWS/GCP/Azure creds:
-# the LLM provider may need them (e.g. Bedrock uses AWS creds, so the gcp/aws
-# connectors can still register on a cloud host - the 0-tool-calls assertion is
-# the real safety net, and SMOKE_REQUIRE_NO_CONNECTORS is opt-in).
-export HOME="$workdir"
-unset XDG_CONFIG_HOME GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
+# Isolate cynative's OWN config/cache/audit without moving HOME, so the provider
+# SDKs can still find file-based credentials on a local run (~/.aws for Bedrock,
+# the gcloud ADC file for Vertex, ~/.azure for Azure). An empty --config makes
+# cynative ignore the caller's ~/.cynative/config.yaml, and cache/audit go to the
+# temp dir. Silence connector discovery sources unrelated to any LLM provider
+# (github/gitlab/kube tokens and config-dir overrides are never LLM creds). Do
+# NOT unset AWS/GCP/Azure creds: the LLM provider may need them (e.g. Bedrock uses
+# AWS creds), so the aws/gcp connectors can still register on a cloud host - the
+# 0-tool-calls assertion is the real safety net, and SMOKE_REQUIRE_NO_CONNECTORS
+# is opt-in (CI only, where the runner is clean).
+: > "$workdir/config.yaml"
+export CYNATIVE_CACHE_DIR="$workdir/cache"
+export CYNATIVE_AUDIT_PATH="$workdir/audit.log"
+unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
 	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
 
 printf '== RUN == %s/%s\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
@@ -69,7 +82,7 @@ printf '== RUN == %s/%s\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
 # before rc is captured, so wrap it (house pattern, test/install.e2e.test.sh).
 set +e
 CYNATIVE_MAX_ITERATIONS=1 CYNATIVE_MAX_TOTAL_TOKENS="${SMOKE_MAX_TOKENS:-16000}" \
-	timeout "${SMOKE_TIMEOUT:-60}" "$bin" -p "$prompt" --auto-approve \
+	timeout "${SMOKE_TIMEOUT:-60}" "$bin" --config "$workdir/config.yaml" -p "$prompt" --auto-approve \
 		>"$workdir/out" 2>"$workdir/err" </dev/null
 rc=$?
 set -e

--- a/test/llm.smoke.test.sh
+++ b/test/llm.smoke.test.sh
@@ -92,8 +92,9 @@ if ! grep -Fq "$nonce" "$workdir/out"; then
 	exit 1
 fi
 
-# Hard: no tool was called (footer on stderr).
-if ! grep -Fq '0 tool calls' "$workdir/err"; then
+# Hard: no tool was called (footer on stderr). Anchor the count on a non-digit
+# boundary so "0 tool calls" is not matched inside "10 tool calls" etc.
+if ! grep -Eq '(^|[^0-9])0 tool calls' "$workdir/err"; then
 	printf 'FAIL: expected "0 tool calls" in footer (a tool was called). stderr tail:\n' >&2
 	tail -n 20 "$workdir/err" >&2
 	exit 1


### PR DESCRIPTION
## What & why

Adds the first live-network e2e check: a small, no-tool smoke that runs the real `cynative -p` against a live Vertex/Gemini model and asserts the answer round-trips. Unit tests run against fakes and cannot catch a real provider rejecting our request/tool-call shape; this proves the CLI, config loading, Bifrost wiring, and response handling still work against a real model, as release confidence.

- `test/llm.smoke.test.sh`: provider-agnostic POSIX harness. Generates a nonce, runs `cynative -p` (one iteration, bounded tokens, wall-clock timeout), and asserts the nonce on stdout plus `0 tool calls` in the footer. Skips cleanly when no provider is configured, so it is a safe no-op.
- `make llm-smoke`: standalone target, not part of `make check`.
- `.github/workflows/llm-smoke.yaml`: runs the smoke against Vertex on release-please PRs and manual dispatch only (never a required check). Keyless Workload Identity Federation into a dedicated GCP project; the credential step is gated to same-repo events so fork PRs never reach it.
- `docs/e2e/live-llm-smoke.md`: how to run it, the knobs, assertions, failure classification, and CI setup.

Provider-agnostic so a Bedrock smoke (and others) can reuse the harness with different env.

Ran live against real Vertex/Gemini (`gemini-2.5-flash`): the nonce round-tripped, the footer reported `0 tool calls`, and a bad-model run classified as a provider/config/access failure.

> Note: the `tmp:` commit temporarily allows this branch through the workflow's `detect` gate so the live smoke runs on this PR; it is removed before merge.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed

Closes #38

