### PR TITLE
fix: retry transient LLM provider errors by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,7 +507,11 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   (default `SecurityAudit`); `connectors.gcp.role` `roles/viewer` (accepts predefined or
   custom project/org roles); `connectors.azure.role_definition` `Reader` (required);
   `connectors.{eks,gke,aks,kubernetes}.cluster_role` `view` (validated as a safe URL path
-  segment, fail-closed on empty). Each knob has a matching `CYNATIVE_*` env var.
+  segment, fail-closed on empty); `llm.network_config.max_retries` 3 (the one llm-block
+  default, registered by hand since ProviderEntry embeds Bifrost's untaggable struct;
+  Bifrost retries 429/500/502/503/504, recognized rate-limit errors, and transport errors
+  with backoff; an explicit file/env value including 0 wins, and a negative value is
+  rejected by `llm.ValidateNetworkConfig`). Each knob has a matching `CYNATIVE_*` env var.
   `verify_findings` has no knob; it always runs.
 
 - **`internal/metrics`**: session-cumulative operational telemetry (token usage, model

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -59,7 +59,7 @@ llm:
   network_config:                  # any field on schemas.NetworkConfig
     base_url: https://...                          # optional
     default_request_timeout_in_seconds: 60         # optional; integer seconds
-    max_retries: 3                                 # optional
+    max_retries: 3                                 # optional; default 3 (0 disables retries)
     extra_headers:                                 # optional
       x-custom: value
     insecure_skip_verify: false                    # optional
@@ -118,3 +118,16 @@ underlying error comes from Bifrost and mentions
 Provider Name > Network Config" UI — that wording is Bifrost's (it even hard-codes
 "30 seconds" regardless of the effective timeout); cynative has no such UI, and
 the knob you want is `network_config.default_request_timeout_in_seconds` above.
+
+**Rate limits and transient errors.** LLM calls retry retryable failures (HTTP
+429/500/502/503/504, provider errors recognized as rate limits, and network
+errors) up to **3** times with exponential backoff (500ms initial, 5s max):
+cynative's default, replacing Bifrost's 0 retries, under which a single
+rate-limit blip fails the whole turn (and a `-p` run outright). Request
+timeouts are not retried. Override the count with
+`llm.network_config.max_retries` (an integer; `0` disables retries, negative
+is rejected) or the env var `CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES`, and
+tune the backoff with `network_config.retry_backoff_initial` /
+`retry_backoff_max` (durations, e.g. `500ms`). A run that still ends with
+"rate limited / out of quota (HTTP 429)" exhausted its retries: check the
+provider account's quota and billing, or retry later.

--- a/internal/cli/llmstatus.go
+++ b/internal/cli/llmstatus.go
@@ -72,12 +72,13 @@ func llmConfigStatus(cfg config.Config, err error) ui.LLMStatus {
 }
 
 // llmRuntimeStatus maps a first-interaction failure to a Tier-3 ✗ status. The
-// reason/hint are built ONLY from the GenerateError's StatusCode — NEVER the raw
-// provider/init message, which can echo a credential AND (for a chat-model-init
-// error) has not passed through RedactingChatModel. The message survives only in
-// err.Error() for -v / the turn-≥2 %v path, where it is redacted at the
-// RedactingChatModel boundary. Every first-interaction failure aborts regardless,
-// so the label is a generic, NON-per-provider bucket.
+// reason/hint are built ONLY from the GenerateError's StatusCode plus an
+// equality match on its machine Type, NEVER the raw provider/init message,
+// which can echo a credential AND (for a chat-model-init error) has not passed
+// through RedactingChatModel. The message survives only in err.Error() for
+// -v / the turn-≥2 %v path, where it is redacted at the RedactingChatModel
+// boundary. Every first-interaction failure aborts regardless, so the label is
+// a generic, NON-per-provider bucket.
 func llmRuntimeStatus(cfg config.Config, err error) ui.LLMStatus {
 	s := ui.LLMStatus{ //nolint:exhaustruct // Reason/Hint/NotConfigured/Example set per branch below.
 		State:    ui.ConnectorError,
@@ -88,6 +89,18 @@ func llmRuntimeStatus(cfg config.Config, err error) ui.LLMStatus {
 	status := 0
 	if ge, ok := errors.AsType[*llm.GenerateError](err); ok {
 		status = ge.StatusCode
+		// With retries enabled (max_retries defaults to 3), Bifrost collapses a
+		// permanent per-key 401/402/403 into a synthetic 502 once every
+		// configured key is dead, so the status code alone would render the
+		// generic "request failed" bucket for a plain bad key or billing
+		// failure. Restore the credential guidance from the machine Type.
+		if ge.CredentialsExhausted() {
+			s.Reason = "invalid credentials or billing"
+			s.Hint = "The provider rejected the credentials (HTTP 401/402/403). Check your API key / auth " +
+				"and the account's billing; behind a gateway, this can be the gateway's own upstream keys."
+
+			return s
+		}
 	}
 
 	switch status {

--- a/internal/cli/llmstatus_internal_test.go
+++ b/internal/cli/llmstatus_internal_test.go
@@ -164,6 +164,20 @@ func TestLLMRuntimeStatus(t *testing.T) {
 			"request failed",
 		},
 		{
+			// With retries on, Bifrost collapses a permanent per-key 401/402/403
+			// into a synthetic 502 typed upstream_credentials_exhausted (the
+			// literal wire value, duplicated here on purpose as a drift pin).
+			"credentials-exhausted 502 → credential guidance",
+			//nolint:exhaustruct // Code unused.
+			&llm.GenerateError{StatusCode: 502, Type: "upstream_credentials_exhausted", Message: secret},
+			"invalid credentials or billing",
+		},
+		{
+			"plain 502 without the machine type → request failed",
+			&llm.GenerateError{StatusCode: 502, Message: secret}, //nolint:exhaustruct // Code/Type unused.
+			"request failed",
+		},
+		{
 			"no status → could not reach",
 			&llm.GenerateError{StatusCode: 0, Message: secret}, //nolint:exhaustruct // Code unused.
 			"could not reach",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,17 @@ func DefaultConfig() Config {
 	return cfg
 }
 
+// defaultLLMMaxRetries is cynative's retry budget for LLM calls, replacing
+// Bifrost's default of 0 retries, under which a single transient 429/5xx or
+// network error fails the turn (and a one-shot run outright). Bifrost retries
+// only retryable failures (HTTP 429/500/502/503/504, provider errors it
+// recognizes as rate limits, and transport errors) with exponential backoff
+// (its 500ms-initial/5s-max backoff defaults fill any unset backoff fields).
+// An explicit llm.network_config.max_retries in the file or env (including 0
+// to disable retries) wins over this default via viper layering; a negative
+// value is rejected by llm.ValidateNetworkConfig.
+const defaultLLMMaxRetries = 3
+
 // setDefaults registers default values into Viper so fields with `default`
 // struct tags take effect when neither the config file nor an env var sets
 // them. Top-level scalar fields are registered directly under their json key.
@@ -174,7 +185,9 @@ func DefaultConfig() Config {
 // default reaches viper under its full dotted key (e.g. connectors.aws.policy).
 //
 // The LLM block's env keys (provider, model, and every nested leaf) are
-// resolved separately by applyEnv in Load.
+// resolved separately by applyEnv in Load. It carries no `default` struct tags
+// (ProviderEntry embeds Bifrost's ProviderConfig, whose fields cynative cannot
+// tag), so its one cynative-owned default is registered by hand below.
 func setDefaults(v *viper.Viper) {
 	cfg := DefaultConfig()
 	val := reflect.ValueOf(cfg)
@@ -193,6 +206,8 @@ func setDefaults(v *viper.Viper) {
 		}
 		v.SetDefault(name, val.Field(i).Interface())
 	}
+
+	v.SetDefault("llm.network_config.max_retries", defaultLLMMaxRetries)
 }
 
 // registerStructDefaults walks the fields of a nested Config struct (e.g.
@@ -586,6 +601,10 @@ func ValidateLLM(entry *llm.ProviderEntry) error {
 	}
 
 	if err := llm.ValidateKeyPresence(entry); err != nil {
+		return err
+	}
+
+	if err := llm.ValidateNetworkConfig(entry); err != nil {
 		return err
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,6 +151,18 @@ func TestValidateLLM(t *testing.T) {
 			llm.ProviderEntry{Provider: "openai", Model: "gpt-5.5"},
 			llm.ErrNoKeysForProvider,
 		}, //nolint:exhaustruct // partial entry by design
+		{
+			"negative max_retries",
+			llm.ProviderEntry{
+				ProviderConfig: schemas.ProviderConfig{
+					NetworkConfig: schemas.NetworkConfig{MaxRetries: -1},
+				},
+				Provider: "openai",
+				Model:    "gpt-5",
+				Keys:     []schemas.Key{{Value: schemas.SecretVar{Val: "k"}}},
+			},
+			llm.ErrInvalidMaxRetries,
+		}, //nolint:exhaustruct // partial entry by design
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -696,6 +708,61 @@ func TestLoad_FutureProofedBifrostFields_OpenAI(t *testing.T) {
 	}
 	if cfg.LLM.OpenAIConfig == nil || !cfg.LLM.OpenAIConfig.DisableStore {
 		t.Errorf("OpenAIConfig.DisableStore: got %+v", cfg.LLM.OpenAIConfig)
+	}
+}
+
+// TestLoad_LLMMaxRetriesDefault pins cynative's retry default for LLM calls: an
+// unset llm.network_config.max_retries loads as 3 (Bifrost's own default is 0,
+// which makes every transient 429/5xx fatal), while an explicit file or env
+// value (including 0 to disable retries) still wins via viper layering.
+func TestLoad_LLMMaxRetriesDefault(t *testing.T) {
+	t.Parallel()
+
+	withMaxRetries := func(n string) string {
+		return validYAML + "  network_config:\n    max_retries: " + n + "\n"
+	}
+
+	tests := []struct {
+		name string
+		yaml string
+		env  map[string]string
+		want int
+	}{
+		{name: "unset defaults to 3", yaml: validYAML, want: 3},
+		{name: "explicit file value wins", yaml: withMaxRetries("1"), want: 1},
+		{name: "explicit file zero disables retries", yaml: withMaxRetries("0"), want: 0},
+		{
+			name: "env var overrides default",
+			yaml: validYAML,
+			env:  map[string]string{"CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES": "5"},
+			want: 5,
+		},
+		{
+			name: "env var zero disables retries",
+			yaml: validYAML,
+			env:  map[string]string{"CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES": "0"},
+			want: 0,
+		},
+		{
+			name: "env var overrides explicit file value",
+			yaml: withMaxRetries("1"),
+			env:  map[string]string{"CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES": "5"},
+			want: 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := config.NewLoader(envMap(tc.env)).Load(writeConfig(t, tc.yaml))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := cfg.LLM.NetworkConfig.MaxRetries; got != tc.want {
+				t.Errorf("MaxRetries: got %d, want %d", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/llm/chatmodel_test.go
+++ b/internal/llm/chatmodel_test.go
@@ -180,6 +180,86 @@ func TestBifrostChatModel_GenerateErrorNilCode(t *testing.T) {
 	}
 }
 
+// TestBifrostChatModel_GenerateErrorCredentialsExhausted verifies the exact
+// synthetic error Bifrost returns when retries mark every configured key dead
+// on a permanent 401/402/403 (a 502 carrying "upstream_credentials_exhausted"
+// in both the top-level and nested Type) surfaces with the machine type
+// captured and the CredentialsExhausted predicate true, so the CLI status can
+// restore the credential guidance the collapsed 502 would otherwise hide.
+func TestBifrostChatModel_GenerateErrorCredentialsExhausted(t *testing.T) {
+	t.Parallel()
+
+	status := http.StatusBadGateway
+	errType := "upstream_credentials_exhausted"
+	mock := &llm.BifrostBackendMock{ //nolint:exhaustruct // only needed funcs set
+		ChatCompletionRequestFunc: func(_ *bschemas.BifrostContext, _ *bschemas.BifrostChatRequest) (*bschemas.BifrostChatResponse, *bschemas.BifrostError) {
+			return nil, &bschemas.BifrostError{ //nolint:exhaustruct // the synthetic error's exact shape.
+				StatusCode: &status,
+				Type:       &errType,
+				Error: &bschemas.ErrorField{ //nolint:exhaustruct // no Code on the synthetic error.
+					Type:    &errType,
+					Message: "all configured keys returned permanent per-key errors (401/402/403)",
+				},
+			}
+		},
+		ShutdownFunc: func() {},
+	}
+
+	m, err := llm.NewBifrostChatModel(context.Background(), testAccount(), llm.WithBackend(mock))
+	if err != nil {
+		t.Fatalf("NewBifrostChatModel: %v", err)
+	}
+
+	_, err = m.Generate(context.Background(), []*schema.Message{schema.UserMessage("hi")}, nil)
+	var ge *llm.GenerateError
+	if !errors.As(err, &ge) {
+		t.Fatalf("errors.As failed: %v", err)
+	}
+	if ge.StatusCode != http.StatusBadGateway || ge.Type != errType {
+		t.Errorf("GenerateError fields lost: %#v", ge)
+	}
+	if !ge.CredentialsExhausted() {
+		t.Error("CredentialsExhausted() = false for Bifrost's synthetic credentials-exhausted error")
+	}
+}
+
+// TestBifrostChatModel_GenerateErrorTopLevelTypeFallback verifies that when
+// the nested Error.Type is absent, the top-level BifrostError.Type is captured
+// instead.
+func TestBifrostChatModel_GenerateErrorTopLevelTypeFallback(t *testing.T) {
+	t.Parallel()
+
+	errType := "some_top_level_type"
+	mock := &llm.BifrostBackendMock{ //nolint:exhaustruct // only needed funcs set
+		ChatCompletionRequestFunc: func(_ *bschemas.BifrostContext, _ *bschemas.BifrostChatRequest) (*bschemas.BifrostChatResponse, *bschemas.BifrostError) {
+			return nil, &bschemas.BifrostError{ //nolint:exhaustruct // only the fields under test.
+				Type: &errType,
+				Error: &bschemas.ErrorField{ //nolint:exhaustruct // nested Type is nil.
+					Message: "upstream failure",
+				},
+			}
+		},
+		ShutdownFunc: func() {},
+	}
+
+	m, err := llm.NewBifrostChatModel(context.Background(), testAccount(), llm.WithBackend(mock))
+	if err != nil {
+		t.Fatalf("NewBifrostChatModel: %v", err)
+	}
+
+	_, err = m.Generate(context.Background(), []*schema.Message{schema.UserMessage("hi")}, nil)
+	var ge *llm.GenerateError
+	if !errors.As(err, &ge) {
+		t.Fatalf("errors.As failed: %v", err)
+	}
+	if ge.Type != errType {
+		t.Errorf("Type = %q, want %q (top-level fallback)", ge.Type, errType)
+	}
+	if ge.CredentialsExhausted() {
+		t.Error("CredentialsExhausted() = true for an unrelated error type")
+	}
+}
+
 // TestBifrostChatModel_GenerateNoChoices verifies an empty Choices slice errors.
 func TestBifrostChatModel_GenerateNoChoices(t *testing.T) {
 	t.Parallel()

--- a/internal/llm/generateerror.go
+++ b/internal/llm/generateerror.go
@@ -12,14 +12,37 @@ import (
 // with [errors.Is] and reframe it into the operator-facing LLM status block.
 var ErrGenerate = errors.New("llm generate failed")
 
+// credentialsExhaustedType is the Type Bifrost stamps on the synthetic 502 it
+// returns when every configured key failed with a permanent per-key error
+// (401/402/403) inside its retry loop: the key is marked dead, the next
+// attempt's key selection finds no live key, and the original status code is
+// discarded. Hand-pinned string literal (Bifrost exports no constant for it);
+// re-check executeRequestWithRetries in bifrost core on every Bifrost bump.
+const credentialsExhaustedType = "upstream_credentials_exhausted" //nolint:gosec // machine error-type label, not a credential.
+
 // GenerateError carries the structured, operator-renderable facts of a failed
-// chat generation. StatusCode/Code come from the provider; Message is the
-// human text — REDACTED at the RedactingChatModel boundary before it reaches
-// any renderer (see redactmodel.go). StatusCode is 0 and Code "" when absent.
+// chat generation. StatusCode/Code/Type come from the provider (or, for a
+// synthetic failure, from Bifrost itself); Message is the human text, REDACTED
+// at the RedactingChatModel boundary before it reaches any renderer (see
+// redactmodel.go). StatusCode is 0 and Code/Type "" when absent.
 type GenerateError struct {
 	StatusCode int
 	Code       string
+	Type       string
 	Message    string
+}
+
+// CredentialsExhausted reports whether this failure is Bifrost's synthetic 502
+// for "every configured key was rejected with a permanent 401/402/403". With
+// retries enabled that collapse hides the original status, so status renderers
+// use this predicate (an equality match on the machine Type, never provider
+// text) to keep the credential/billing guidance a raw 401/402/403 would get.
+// The type can also arrive parsed verbatim from an upstream body when base_url
+// points at a Bifrost-based gateway whose own upstream keys died; there is no
+// provenance signal to tell the two apart, so callers should word guidance to
+// cover both (the dead credential may be the gateway's, not the operator's).
+func (e *GenerateError) CredentialsExhausted() bool {
+	return e.Type == credentialsExhaustedType
 }
 
 // Error renders the failure for logs/%v. Message is already redacted by the
@@ -36,14 +59,22 @@ func (e *GenerateError) Error() string {
 func (e *GenerateError) Unwrap() error { return ErrGenerate }
 
 // newGenerateError builds a *GenerateError from a Bifrost error, nil-safely
-// dereferencing the optional status code and provider error code.
+// dereferencing the optional status code, provider error code, and error type
+// (the nested field first, then the top-level one Bifrost also stamps on its
+// synthetic errors).
 func newGenerateError(bErr *bschemas.BifrostError) *GenerateError {
-	ge := &GenerateError{Message: bErr.GetErrorString()} //nolint:exhaustruct // status/code set below when present.
+	ge := &GenerateError{Message: bErr.GetErrorString()} //nolint:exhaustruct // fields set below when present.
 	if bErr.StatusCode != nil {
 		ge.StatusCode = *bErr.StatusCode
 	}
 	if bErr.Error != nil && bErr.Error.Code != nil {
 		ge.Code = *bErr.Error.Code
+	}
+	switch {
+	case bErr.Error != nil && bErr.Error.Type != nil:
+		ge.Type = *bErr.Error.Type
+	case bErr.Type != nil:
+		ge.Type = *bErr.Type
 	}
 
 	return ge

--- a/internal/llm/generateerror_test.go
+++ b/internal/llm/generateerror_test.go
@@ -24,3 +24,31 @@ func TestGenerateError_IsAndFields(t *testing.T) {
 		t.Error("Error() must be non-empty")
 	}
 }
+
+// TestGenerateError_CredentialsExhausted pins the predicate to Bifrost's
+// synthetic-502 machine type (the literal wire value, duplicated here on
+// purpose so an accidental constant change fails the test) and verifies that
+// ordinary provider types and an absent type do not match.
+func TestGenerateError_CredentialsExhausted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  string
+		want bool
+	}{
+		{"bifrost synthetic type matches", "upstream_credentials_exhausted", true},
+		{"ordinary provider type does not match", "invalid_request_error", false},
+		{"absent type does not match", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ge := &llm.GenerateError{Type: tt.typ} //nolint:exhaustruct // only Type drives the predicate.
+			if got := ge.CredentialsExhausted(); got != tt.want {
+				t.Errorf("CredentialsExhausted() with Type=%q = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/llm/networkconfig.go
+++ b/internal/llm/networkconfig.go
@@ -1,0 +1,31 @@
+package llm
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidMaxRetries is returned when llm.network_config.max_retries is
+// negative. Bifrost's retry loop runs `attempts <= MaxRetries`, so a negative
+// value would silently make zero provider requests; 0 (retries disabled) is
+// the smallest valid setting.
+var ErrInvalidMaxRetries = errors.New("invalid llm.network_config.max_retries")
+
+// ValidateNetworkConfig rejects an invalid llm.network_config at load time,
+// before the request path could send it. A nil entry is treated as nothing to
+// validate.
+func ValidateNetworkConfig(entry *ProviderEntry) error {
+	if entry == nil {
+		return nil
+	}
+
+	if entry.NetworkConfig.MaxRetries < 0 {
+		return fmt.Errorf(
+			"%w: %d; llm.network_config.max_retries (CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES) must be 0"+
+				" (retries disabled) or a positive retry count",
+			ErrInvalidMaxRetries, entry.NetworkConfig.MaxRetries,
+		)
+	}
+
+	return nil
+}

--- a/internal/llm/networkconfig_test.go
+++ b/internal/llm/networkconfig_test.go
@@ -1,0 +1,46 @@
+package llm_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cynative/cynative/internal/llm"
+)
+
+// TestValidateNetworkConfig pins the network_config sanity checks: a negative
+// llm.network_config.max_retries is rejected at load time (Bifrost's retry
+// loop runs `attempts <= MaxRetries`, so a negative value would silently make
+// zero provider requests), while zero (retries disabled) and positive values
+// pass, as does a nil entry.
+func TestValidateNetworkConfig(t *testing.T) {
+	t.Parallel()
+
+	entryWithRetries := func(n int) *llm.ProviderEntry {
+		e := &llm.ProviderEntry{Provider: "openai", Model: "gpt-5"}
+		e.NetworkConfig.MaxRetries = n
+
+		return e
+	}
+
+	tests := []struct {
+		name    string
+		entry   *llm.ProviderEntry
+		wantErr error
+	}{
+		{name: "nil entry is nothing to validate", entry: nil, wantErr: nil},
+		{name: "zero disables retries", entry: entryWithRetries(0), wantErr: nil},
+		{name: "positive is valid", entry: entryWithRetries(3), wantErr: nil},
+		{name: "negative is rejected", entry: entryWithRetries(-1), wantErr: llm.ErrInvalidMaxRetries},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := llm.ValidateNetworkConfig(tc.entry)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("ValidateNetworkConfig() = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

A transient 429 or 5xx from the LLM provider previously failed the whole turn, and a `-p` one-shot run outright: the embedded Bifrost client defaults to 0 retries, so a single rate-limit blip was fatal. This is exactly what hit the live GCP connector e2e on the release PR (#96's run at 12:47 UTC today): Vertex briefly throttled one workflow while an identical concurrent run succeeded, and the run died on the first model call.

- Default `llm.network_config.max_retries` to **3**, registered as a viper default in `setDefaults` (ProviderEntry embeds Bifrost's struct, so a `default` tag cannot express it). Bifrost retries only retryable failures (HTTP 429/500/502/503/504, recognized rate-limit errors, and transport errors) with exponential backoff (500ms initial, 5s max); request timeouts are not retried.
- An explicit file or env value, including `0` to disable retries, still wins via viper layering (pinned by tests for file, env, and env-over-file precedence).
- Reject a negative `max_retries` at startup (`llm.ValidateNetworkConfig`, wired into `config.ValidateLLM`): Bifrost's retry loop runs `attempts <= MaxRetries`, so a negative value would silently make zero provider requests.
- Docs: default and override documented in `docs/providers/README.md` (new troubleshooting entry mirroring the request-timeout one) and the AGENTS.md knobs list.
- Preserve the credential status under retries: Bifrost collapses a permanent 401/402/403 on the last live key into a synthetic 502 typed `upstream_credentials_exhausted`, which rendered as the generic `request failed (HTTP 502)`. `GenerateError` now captures the machine error type and the startup status maps it back to the invalid-credentials/billing guidance (equality match on the type only; provider text still never reaches the status).

Verified end to end against a loopback OpenAI-style fixture: with the default, a run that receives 429, 429, 200 retries and succeeds; with `CYNATIVE_LLM_NETWORK_CONFIG_MAX_RETRIES=0` the same run makes exactly one request and fails with the familiar "rate limited / out of quota (HTTP 429)" status. Live smoke (`make llm-smoke`) passes against Bedrock.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed
