### PR TITLE
test: add live LLM code_execution tool-use smoke

### DIFF
--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -1,12 +1,14 @@
 name: Live LLM smoke
 
-# Runs the real `cynative -p` against a live Vertex/Gemini model (cynative#38):
-# a no-tool nonce-echo smoke proving the CLI + config + Bifrost wiring + response
-# handling work against a real provider. Mirrors install-e2e.yaml's detect gating,
-# so the heavy live run only fires for release-please PRs or a manual dispatch.
-# Authenticates to GCP project cynative-cli-ci via keyless Workload Identity
-# Federation; the credential step is gated to same-repo events so untrusted forks
-# never reach it. Not a required status check.
+# Runs the real `cynative -p` against a live Vertex/Gemini model in two jobs: a
+# no-tool nonce-echo smoke (cynative#38) proving the CLI + config + Bifrost wiring
+# + response handling work against a real provider, and a code_execution tool-use
+# smoke (cynative#49) proving the model can drive the tool loop end to end.
+# Mirrors install-e2e.yaml's detect gating, so the heavy live runs only fire for
+# release-please PRs or a manual dispatch. Authenticates to GCP project
+# cynative-cli-ci via keyless Workload Identity Federation; the credential step is
+# gated to same-repo events so untrusted forks never reach it. Not a required
+# status check.
 on:
   # Include `labeled` (on top of the opened/synchronize/reopened defaults) so the
   # `autorelease: pending` fallback in the detect job actually fires when that
@@ -91,3 +93,50 @@ jobs:
           CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
         run: |
           CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-smoke
+
+  vertex-tools-smoke:
+    name: Vertex/Gemini code_execution smoke
+    needs: detect
+    # Same gating and trust boundary as vertex-smoke: relevant, and a manual
+    # dispatch or same-repo PR only. A fork PR must never reach the credential step.
+    if: >-
+      needs.detect.outputs.relevant == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token for Workload Identity Federation
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Report tested head SHA
+        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      # Keyless WIF into cynative-cli-ci. export_environment_variables:false keeps
+      # GOOGLE_APPLICATION_CREDENTIALS out of the process env, so the gcp connector
+      # stays dark; the minted credentials JSON is fed to cynative inline instead.
+      - name: Authenticate to GCP (Workload Identity Federation)
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
+          workload_identity_provider: ${{ vars.CYNATIVE_CLI_CI_WIF_PROVIDER }}
+          service_account: ${{ vars.CYNATIVE_CLI_CI_SA }}
+          create_credentials_file: true
+          export_environment_variables: false
+      - name: Run the Vertex/Gemini code_execution smoke
+        env:
+          CYNATIVE_LLM_PROVIDER: vertex
+          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_VERTEX_MODEL }}
+          CYNATIVE_LLM_VERTEX_PROJECT_ID: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
+          CYNATIVE_LLM_VERTEX_REGION: ${{ vars.CYNATIVE_CLI_CI_VERTEX_REGION }}
+          # No SMOKE_REQUIRE_NO_CONNECTORS here: this smoke asserts a code_execution
+          # tool call, not the connector set (inline creds keep the runner dark anyway).
+          # Missing/renamed provider vars must fail the job, never silently skip.
+          SMOKE_REQUIRE_RUN: "1"
+          CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
+        run: |
+          CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-tools-smoke

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-go check-scripts lint format test generate shell-complexity \
 	windows-build shellcheck pwsh-lint pwsh-test sh-test snapshot install-e2e llm-smoke \
-	connector-gcp-e2e homebrew-smoke install-script-smoke
+	llm-tools-smoke connector-gcp-e2e homebrew-smoke install-script-smoke
 
 # Pinned external (non-Go) tool versions for check-scripts. Unlike the Go tools
 # (pinned via go.mod / `go tool`), these are NOT Dependabot-managed — Dependabot has
@@ -166,6 +166,14 @@ install-e2e:
 # See docs/e2e/live-llm-smoke.md.
 llm-smoke:
 	sh test/llm.smoke.test.sh
+
+# llm-tools-smoke: live LLM tool-use smoke test (cynative#49). Standalone (NOT part
+# of `make check`): runs the real `cynative -p` against a real provider selected via
+# CYNATIVE_LLM_* env and proves the model drives the tool loop through
+# code_execution (sums a random integer list in the sandbox); needs real
+# credentials and skips cleanly when none are set. See docs/e2e/live-llm-smoke.md.
+llm-tools-smoke:
+	sh test/llm-tools.smoke.test.sh
 
 # connector-gcp-e2e: live GCP connector end-to-end test (cynative#39). Standalone
 # (NOT part of `make check`): runs the real `cynative -p` against a real GCP fixture

--- a/docs/e2e/live-llm-smoke.md
+++ b/docs/e2e/live-llm-smoke.md
@@ -6,6 +6,14 @@ one talks to a real provider over the network, so it needs real credentials and
 is **not** part of `make check`. It is meant to be run by repo owners on trusted
 PRs and on release-please PRs, as release confidence.
 
+There are two complementary smokes, both driven by the same `CYNATIVE_LLM_*` env
+and the same skip/require conventions:
+
+- the **no-tool smoke** (`make llm-smoke`, below) proves a bare round-trip with
+  no tools;
+- the **tool-use smoke** (`make llm-tools-smoke`, [below](#tool-use-smoke-code_execution))
+  proves the model can drive the tool loop through `code_execution`.
+
 ## What it proves
 
 One bounded, no-tool round-trip: the CLI starts, config loads, the Bifrost
@@ -102,9 +110,96 @@ real safety property is `0 tool calls` (no connector was actually exercised),
 which always holds. On the clean CI runner there is no metadata server and creds
 are inline, so the connector set is dark and the hard check is used.
 
+## Tool-use smoke (`code_execution`)
+
+The no-tool smoke proves a bare round-trip. The **tool-use smoke**
+(`test/llm-tools.smoke.test.sh`, `make llm-tools-smoke`) goes one step further and
+proves a real model can drive Cynative's tool loop. It hands the model a list of
+random integers and tells it to use `code_execution` to compute their exact sum,
+then answer with only that integer.
+
+Where the no-tool smoke asserts that **no** tool ran, this one asserts a tool
+**did** run - specifically `code_execution` - so it catches a different class of
+regression: provider/tool-schema rejection, broken tool-call parsing, a broken
+approval/auto-approve path, and sandbox breakage.
+
+### What it proves
+
+- The provider accepts our tool-schema shape and emits a well-formed
+  `code_execution` call.
+- The agent parses and dispatches the call.
+- The approval layer approves it (the run uses `--auto-approve`).
+- The sandbox actually executes the script and returns the result.
+- The model reads the result and answers with it.
+
+### Run it locally
+
+Same `CYNATIVE_LLM_*` env as the no-tool smoke, a different target:
+
+```bash
+export CYNATIVE_LLM_PROVIDER=bedrock
+export CYNATIVE_LLM_MODEL=us.anthropic.claude-opus-4-8
+export CYNATIVE_LLM_BEDROCK_REGION=us-east-1
+# Bedrock uses the standard AWS credential chain (see docs/providers/bedrock.md).
+
+make llm-tools-smoke
+```
+
+With no `CYNATIVE_LLM_PROVIDER`/`CYNATIVE_LLM_MODEL` set it prints a `skip:` line
+and exits 0, so `make llm-tools-smoke` is a safe no-op. Pass a prebuilt binary
+path to skip the build (then `go` is not needed):
+`sh test/llm-tools.smoke.test.sh /path/to/cynative`. `python3` is required (it
+parses the audit log), matching the repo's other live e2e tests.
+
+#### Knobs
+
+| Env | Default | Meaning |
+| --- | --- | --- |
+| `SMOKE_TIMEOUT` | `90` | Wall-clock seconds for the run. |
+| `SMOKE_MAX_TOKENS` | `40000` | Token ceiling. A tool turn is two model calls plus the echoed script, so it needs more headroom than the no-tool smoke's `16000`; too low a value discards the answer for a budget notice. |
+| `SMOKE_MAX_ITERATIONS` | `6` | Agent-loop bound. Tool use needs at least 2 (call the tool, then answer). |
+| `SMOKE_REQUIRE_RUN` | unset | When `1`, a missing `CYNATIVE_LLM_PROVIDER`/`CYNATIVE_LLM_MODEL` is a hard failure instead of a skip, so a misconfigured CI job fails loudly. |
+
+There is no `SMOKE_REQUIRE_NO_CONNECTORS` here: this smoke asserts a
+`code_execution` call, not the connector set, so ambient connectors on a cloud
+host are harmless.
+
+### What it asserts
+
+- The process exits 0.
+- The exact computed sum appears in the answer on **stdout** (thousands
+  separators are ignored, and the value is matched whole, not inside a longer
+  number).
+- The footer on **stderr** reports at least one tool call.
+- The audit log holds a `code_execution` **result** record with `outcome` `ok`
+  whose output contains the sum, so the sandbox executed, the approval gate
+  approved it, and it actually computed the answer (rather than the model doing
+  it in its head alongside an unrelated tool call). This is the load-bearing
+  check: it parses the record's outer JSON fields, so it is free of TTY/render
+  coupling and cannot be fooled by the model-controlled arguments.
+- The `--verbose` per-tool-call notice on **stderr** names `code_execution`.
+
+### Failure classification
+
+| Class | Signal | Likely cause |
+| --- | --- | --- |
+| harness/setup | `FAIL:` before any run (build failed, tool missing, fewer than 40 integers generated) | local toolchain, not the provider |
+| provider/config/access | non-zero exit with an LLM status on stderr | bad config, invalid or missing credentials, model not found, tool-schema rejected |
+| timeout | exit 124 | provider slow or unreachable within `SMOKE_TIMEOUT` |
+| no tool use | exit 0 but the tool-call / audit checks fail | the model answered without `code_execution`, or the call was denied or errored |
+
+### Continuous integration
+
+`.github/workflows/llm-smoke.yaml` runs this as a second job
+(`vertex-tools-smoke`) alongside the no-tool job, against Vertex, with the same
+release-please/dispatch gating, same-repo fork guard, and keyless WIF into
+`cynative-cli-ci`. It runs `make llm-tools-smoke` and is not a required status
+check.
+
 ## Extending to other providers
 
 The harness is provider-agnostic. A new provider needs only its own
 `CYNATIVE_LLM_*` env block; the assertions are unchanged. For example, a Bedrock
 smoke sets `CYNATIVE_LLM_PROVIDER=bedrock`, a model id, and the AWS credentials
-its provider needs, then runs the same `make llm-smoke`.
+its provider needs, then runs the same `make llm-smoke` (or `make
+llm-tools-smoke`).

--- a/test/llm-tools.smoke.test.sh
+++ b/test/llm-tools.smoke.test.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# llm-tools.smoke.test.sh - live LLM tool-use smoke test (cynative#49).
+#
+# Runs the real `cynative -p` one-shot against a real LLM provider selected via
+# CYNATIVE_LLM_* env and proves a real model can drive Cynative's tool loop
+# through `code_execution`: it is handed a list of random integers and told to
+# use the sandbox to compute their exact sum, then answer with only that integer.
+#
+# Where the no-tool smoke (test/llm.smoke.test.sh, cynative#38) asserts that NO
+# tool ran, this one asserts a tool DID run - and specifically code_execution.
+# The four checks together catch provider/tool-schema regressions, broken
+# tool-call parsing, approval/auto-approve wiring, and sandbox breakage:
+#   1. the exact computed sum round-trips into the answer on stdout;
+#   2. the stderr footer reports at least one tool call;
+#   3. the audit log holds a code_execution result record with outcome "ok" whose
+#      output contains the sum - the sandbox ran, the approval gate approved it,
+#      and it computed the answer;
+#   4. the --verbose per-tool-call notice on stderr names code_execution.
+# 3 is the load-bearing proof (machine-readable JSONL, no TTY/render coupling);
+# the others are independent cross-checks.
+#
+# NOT hermetic: it talks to a real provider and needs real credentials. Skips
+# (exit 0) when no provider is configured, so `make llm-tools-smoke` is a safe
+# no-op. Provider-agnostic: everything is driven by CYNATIVE_LLM_* env.
+#
+# Usage: sh test/llm-tools.smoke.test.sh [BINARY]
+#   BINARY  optional path to a prebuilt cynative binary; default builds from
+#           ./cmd/cynative so the smoke exercises this checkout's code.
+#
+# Env:
+#   CYNATIVE_LLM_PROVIDER, CYNATIVE_LLM_MODEL   required (else skip)
+#   provider creds (e.g. AWS creds for Bedrock, a Vertex service account for
+#                   Vertex - see docs/e2e/live-llm-smoke.md)
+#   SMOKE_TIMEOUT        wall-clock seconds (default 90)
+#   SMOKE_MAX_TOKENS     token ceiling (default 40000; a backstop, not a tight
+#                        budget - a tool turn is two model calls plus the echoed
+#                        script, so the no-tool script's 16000 default is too low
+#                        here and would discard the answer for a budget notice)
+#   SMOKE_MAX_ITERATIONS agent-loop bound (default 6; tool use needs at least 2:
+#                        one turn to call the tool, one to answer)
+#   SMOKE_REQUIRE_RUN    =1 hard-fails (instead of skipping) when provider/model
+#                        are unset, so a misconfigured CI job cannot go green by
+#                        silently skipping
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+
+# Skip cleanly when no provider is configured - unless SMOKE_REQUIRE_RUN=1, where
+# a missing provider/model is a failure (a CI job must never go green by skipping).
+if [ -z "${CYNATIVE_LLM_PROVIDER:-}" ] || [ -z "${CYNATIVE_LLM_MODEL:-}" ]; then
+	if [ "${SMOKE_REQUIRE_RUN:-}" = "1" ]; then
+		printf 'FAIL: CYNATIVE_LLM_PROVIDER/CYNATIVE_LLM_MODEL unset but SMOKE_REQUIRE_RUN=1\n' >&2
+		exit 1
+	fi
+	printf 'skip: llm-tools.smoke (set CYNATIVE_LLM_PROVIDER + CYNATIVE_LLM_MODEL + creds to run)\n' >&2
+	exit 0
+fi
+
+command -v timeout >/dev/null 2>&1 || { printf 'FAIL: timeout not found\n' >&2; exit 1; }
+# python3 parses the audit log below (the load-bearing tool-use check); the repo's
+# other live e2e tests take the same dependency.
+command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found (needed to parse the audit log)\n' >&2; exit 1; }
+
+workdir=$(mktemp -d)
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT INT TERM
+
+# Build the binary (or accept a prebuilt one). go is only needed when building.
+bin=${1:-}
+if [ -z "$bin" ]; then
+	command -v go >/dev/null 2>&1 || { printf 'FAIL: go not found (needed to build cynative)\n' >&2; exit 1; }
+	bin="$workdir/cynative"
+	printf '== BUILD ==\n' >&2
+	( cd "$root" && go build -o "$bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; exit 1; }
+fi
+[ -x "$bin" ] || { printf 'FAIL: binary not executable: %s\n' "$bin" >&2; exit 1; }
+
+# A deterministic, tool-shaped task: sum 40 random 16-bit integers. The model
+# cannot reliably do this in its head, and the tool's own description reserves
+# code_execution for "non-trivial or precision-sensitive math", so a genuine sum
+# steers it to the sandbox; the explicit instruction makes that a requirement.
+# 40 * 65535 = 2,621,400, so the sum stays a small exact integer (no overflow in
+# the shell accumulator below or in the sandbox's float64).
+nums=$(od -An -N80 -tu2 /dev/urandom | tr -s ' ' '\n' | grep -E '^[0-9]+$' | head -n 40)
+count=$(printf '%s\n' "$nums" | grep -c .)
+if [ "$count" -ne 40 ]; then
+	printf 'FAIL: expected 40 random integers, generated %s (od/urandom problem)\n' "$count" >&2
+	exit 1
+fi
+list=$(printf '%s' "$nums" | paste -sd, -)
+sum=0
+for n in $nums; do sum=$((sum + n)); done
+
+prompt="You must use the code_execution tool to compute this; do not compute it \
+yourself. Compute the exact integer sum of the following numbers and reply with \
+only that integer and nothing else: $list"
+
+# Isolate cynative's OWN config/cache/audit without moving HOME, so the provider
+# SDKs can still find file-based credentials on a local run (~/.aws for Bedrock,
+# the gcloud ADC file for Vertex). An empty --config makes cynative ignore the
+# caller's ~/.cynative/config.yaml, and cache/audit go to the temp dir. The audit
+# log is asserted below, so pin it on. Silence connector discovery sources
+# unrelated to any LLM provider (github/gitlab/kube tokens and config-dir
+# overrides are never LLM creds); ambient cloud creds may still register the
+# aws/gcp/azure connectors on a cloud host, which is fine - this test asserts a
+# code_execution call, not the connector set.
+: > "$workdir/config.yaml"
+export CYNATIVE_CACHE_DIR="$workdir/cache"
+export CYNATIVE_AUDIT_ENABLED=true
+export CYNATIVE_AUDIT_PATH="$workdir/audit.log"
+unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
+	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+
+printf '== RUN == %s/%s (sum of %s integers)\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" "$count" >&2
+# timeout returns non-zero on a slow/failed run, which under `set -e` would abort
+# before rc is captured, so wrap it (house pattern, test/llm.smoke.test.sh).
+set +e
+CYNATIVE_MAX_ITERATIONS="${SMOKE_MAX_ITERATIONS:-6}" CYNATIVE_MAX_TOTAL_TOKENS="${SMOKE_MAX_TOKENS:-40000}" \
+	timeout "${SMOKE_TIMEOUT:-90}" "$bin" --config "$workdir/config.yaml" -p "$prompt" --auto-approve --verbose \
+		>"$workdir/out" 2>"$workdir/err" </dev/null
+rc=$?
+set -e
+
+# Failure classification.
+if [ "$rc" -eq 124 ]; then
+	printf 'FAIL: timed out after %ss\n' "${SMOKE_TIMEOUT:-90}" >&2
+	exit 1
+fi
+if [ "$rc" -ne 0 ]; then
+	printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$rc" >&2
+	tail -n 20 "$workdir/err" >&2
+	exit 1
+fi
+
+# 1. The exact computed sum round-tripped into the answer on stdout. Drop thousands
+# separators, then require some run of digits to equal the sum exactly (grep -Fx),
+# so the value is neither missed when a model groups digits (1,401,486) nor matched
+# inside a longer number.
+if ! tr -d ',' < "$workdir/out" | grep -oE '[0-9]+' | grep -Fxq "$sum"; then
+	printf 'FAIL: expected sum %s not found in answer. stdout tail:\n' "$sum" >&2
+	tail -n 20 "$workdir/out" >&2
+	exit 1
+fi
+
+# 2. The footer (always stderr) reports at least one tool call. A positive match
+# (not "not 0") also fails a missing or reshaped footer.
+if ! grep -Eq '(^|[^0-9])[1-9][0-9]* tool call' "$workdir/err"; then
+	printf 'FAIL: expected at least one tool call in the footer. stderr tail:\n' >&2
+	tail -n 20 "$workdir/err" >&2
+	exit 1
+fi
+
+# 3. Load-bearing proof: the audit log holds a code_execution RESULT record whose
+# outcome is "ok" AND whose result (the sandbox's own output) contains the sum -
+# so the sandbox actually executed, the approval gate approved it, and it computed
+# the answer (not the model in its head with an unrelated tool call on the side).
+# Parse the outer JSON fields with python3: substring greps would be fooled by the
+# model-controlled arguments object, which serializes unescaped into the record.
+if ! python3 - "$sum" "$workdir/audit.log" <<'PY'
+import json, re, sys
+
+want = sys.argv[1]
+digit_bounded = re.compile(r"(?<!\d)" + re.escape(want) + r"(?!\d)")
+found = False
+try:
+    with open(sys.argv[2]) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if rec.get("tool") != "code_execution":
+                continue
+            if rec.get("phase") != "result" or rec.get("outcome") != "ok":
+                continue
+            result = rec.get("result")
+            # Strip thousands separators so a toLocaleString-style print still matches.
+            if isinstance(result, str) and digit_bounded.search(result.replace(",", "")):
+                found = True
+                break
+except OSError:
+    found = False
+sys.exit(0 if found else 1)
+PY
+then
+	printf 'FAIL: no successful code_execution result computing the sum in the audit log. audit tail:\n' >&2
+	tail -n 20 "$workdir/audit.log" 2>/dev/null >&2 || printf '(no audit log)\n' >&2
+	exit 1
+fi
+
+# 4. Cross-check on the human-visible path: the --verbose per-tool-call notice on
+# stderr names code_execution. render.go writes "\n<glyph> <tool> <args>\n", so
+# this matches the notice, not the "Tool Call:" approval preview (which is
+# TTY-routed and may not reach stderr).
+if ! grep -Fq '🔧 code_execution' "$workdir/err"; then
+	printf 'FAIL: no verbose code_execution notice on stderr. stderr tail:\n' >&2
+	tail -n 20 "$workdir/err" >&2
+	exit 1
+fi
+
+printf 'llm-tools.smoke: OK (%s/%s, code_execution summed %s integers to %s)\n' \
+	"$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" "$count" "$sum" >&2


### PR DESCRIPTION
## What & why

Adds a live end-to-end smoke that proves a real model can drive Cynative's tool loop through `code_execution`, complementing the existing no-tool smoke (#38). It hands the model a list of random integers and requires it to compute the exact sum in the sandbox, then answer with only that integer.

Where the no-tool smoke asserts that no tool ran, this one asserts a tool did run - specifically `code_execution` - so it catches provider/tool-schema regressions, broken tool-call parsing, approval/auto-approve breakage, and sandbox integration problems that the no-tool smoke cannot.

**What it checks**
- The exact computed sum round-trips into the answer on stdout.
- The stderr footer reports at least one tool call.
- The audit log holds a `code_execution` result record with `outcome: ok` whose output contains the sum, so the sandbox actually executed, the approval gate approved it, and it computed the answer. This is the load-bearing check; it parses the record's outer JSON fields, so it can't be fooled by the model-controlled arguments.
- The `--verbose` per-tool-call notice on stderr names `code_execution`.

**Wiring**
- `make llm-tools-smoke` runs it; skips cleanly when no provider is configured, so it is a safe no-op.
- A `vertex-tools-smoke` job in the live-LLM workflow runs it against Vertex, with the same release-please/dispatch gating, same-repo fork guard, and keyless Workload Identity Federation as the no-tool job. Not a required status check.
- A tool-use section in `docs/e2e/live-llm-smoke.md`.

Not part of `make check`. Deterministic and cheap: one bounded computation, roughly 20k tokens. Verified live end-to-end against a real provider, including the build-from-source, prebuilt-binary, skip, and require-run paths.

Closes #49
Part of #36

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed
