### PR TITLE
test: share cost and timeout guardrails across live e2e suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,14 +101,16 @@ pwsh-test:
 	@command -v pwsh >/dev/null 2>&1 || { echo "FAIL: pwsh not found — install PowerShell 7 + Pester $(PESTER_VERSION)."; exit 1; }
 	pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester | Where-Object Version -eq "$(PESTER_VERSION)")) { Write-Host "FAIL: Pester $(PESTER_VERSION) not installed — run: Install-Module Pester -RequiredVersion $(PESTER_VERSION) -Scope CurrentUser -SkipPublisherCheck"; exit 1 }; Import-Module -Name Pester -RequiredVersion $(PESTER_VERSION) -Force -ErrorAction Stop; $$r = Invoke-Pester -Path test/install.unit.Tests.ps1 -Output Detailed -PassThru; if ($$r.FailedCount -gt 0) { exit 1 }'
 
-# sh-test: POSIX install.sh unit + loopback smoke tests. Presence-check python3
-# (the smoke test's loopback fixture server) with an install hint, mirroring the
-# shellcheck/pwsh install-free pattern.
+# sh-test: POSIX install.sh unit + loopback smoke tests, plus the live-e2e
+# guardrails library unit tests (test/lib/e2e-guardrails.sh, hermetic). Presence-
+# check python3 (the smoke test's loopback fixture server) with an install hint,
+# mirroring the shellcheck/pwsh install-free pattern.
 sh-test:
 	@command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 not found — needed by the install.sh loopback smoke test (test/install.smoke.test.sh)."; exit 1; }
 	@sh test/install.unit.test.sh
 	@sh test/install.smoke.test.sh
-	@echo "OK: sh-test (install.sh unit + loopback smoke)"
+	@sh test/e2e-guardrails.unit.test.sh
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/docs/e2e/e2e-guardrails.md
+++ b/docs/e2e/e2e-guardrails.md
@@ -1,0 +1,100 @@
+# Live e2e guardrails
+
+The live e2e suites talk to real providers and cost real credits, so they share
+one bounded configuration. The goal is narrow: make it hard for a broken live
+run to burn credits, hang a runner, or leave a maintainer guessing what
+happened. The shared library is `test/lib/e2e-guardrails.sh`; every live suite
+sources it:
+
+- `test/llm.smoke.test.sh` - the no-tool LLM smoke (`make llm-smoke`).
+- `test/llm-tools.smoke.test.sh` - the `code_execution` tool-use smoke (`make llm-tools-smoke`).
+- `test/connector.gcp.e2e.test.sh` - the GCP connector e2e (`make connector-gcp-e2e`).
+
+## What the guardrails bound
+
+Every live run gets the same isolation and the same bounds. Isolation
+(`e2e_isolate_env`) writes an empty `--config` so the caller's
+`~/.cynative/config.yaml` is ignored, points the cache at a temp dir, and
+silences connector-discovery env unrelated to the LLM provider
+(`GH_*`/`GLAB_*`/`KUBECONFIG` and the token vars). Cloud credentials
+(`AWS`/`GCP`/`Azure`) are left alone, because an LLM provider may need them (for
+example Bedrock).
+
+`e2e_apply_bounds` exports the first five bounds onto a cynative knob; the
+per-run wall-clock (`E2E_RUN_TIMEOUT`) is applied by `e2e_run_bounded`, not
+exported. A suite overrides a default by setting the matching `E2E_*` variable
+first.
+
+| Guardrail | Default | Applied as |
+| --- | --- | --- |
+| `E2E_MAX_TOKENS` | `16000` | `CYNATIVE_MAX_TOTAL_TOKENS` - per-session token ceiling |
+| `E2E_MAX_ITERATIONS` | `16` | `CYNATIVE_MAX_ITERATIONS` - main-loop cap |
+| `E2E_SUBAGENT_ITERATIONS` | `3` | `CYNATIVE_MAX_SUBAGENT_ITERATIONS` - `task` sub-loop cap |
+| `E2E_SANDBOX_CONCURRENCY` | `4` | `CYNATIVE_SANDBOX_MAX_CONCURRENCY` - concurrent inner tool calls |
+| `E2E_REQUEST_TIMEOUT` | = `E2E_RUN_TIMEOUT` | `CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS` - per-LLM-call timeout |
+
+`E2E_RUN_TIMEOUT` (default `60`; the llm smoke uses `60`, the connector `120`) is
+the shell `timeout` wall-clock for one run - not a cynative env var, and passed
+positionally to `e2e_run_bounded`. The per-LLM-call timeout defaults to it (never
+firing before the run itself would) so a slow reasoning turn is not cut off
+early; cynative's own default is 300s for that reason.
+
+The token ceiling is the real credit guard (cynative halts the turn when it is
+crossed). The per-run wall-clock is the real hang guard. The iteration and
+concurrency caps are secondary bounds against a pathological loop or fan-out.
+
+## Per-suite settings
+
+Each suite keeps its own public knob names; they resolve onto the `E2E_*`
+overrides, so the documented knobs keep working.
+
+- LLM smoke: no tools, so `E2E_MAX_ITERATIONS=1`. `SMOKE_MAX_TOKENS` (default
+  `16000`) sets the token ceiling and `SMOKE_TIMEOUT` (default `60`) the per-run
+  wall-clock.
+- Tool-use smoke: needs at least two iterations (call the tool, then answer), so
+  `SMOKE_MAX_ITERATIONS` (default `6`). `SMOKE_MAX_TOKENS` (default `40000`, a
+  tool turn is two model calls plus the echoed script) sets the token ceiling and
+  `SMOKE_TIMEOUT` (default `90`) the per-run wall-clock. It also passes `--verbose`
+  through `e2e_run_bounded` so it can assert the per-tool-call notice.
+- Connector e2e: does real tool work, so it keeps the shared iteration default
+  (`16`, well under cynative's own default of `32`). `GCP_E2E_MAX_TOKENS`
+  (default `32000`) sets the token ceiling and `GCP_E2E_TIMEOUT` (default `120`)
+  the per-run wall-clock.
+
+## Suite-level timeout
+
+There is no separate whole-script watchdog. The effective wall-clock ceiling is
+the per-run `timeout` times the capped attempts and phases, and a budget hit is
+fatal (never retried). The derived worst case:
+
+- LLM smoke: `SMOKE_TIMEOUT` x 1 run = 60s by default.
+- Tool-use smoke: `SMOKE_TIMEOUT` x 1 run = 90s by default.
+- Connector e2e: `GCP_E2E_TIMEOUT` x `GCP_E2E_ATTEMPTS` x 2 phases (read +
+  canary) = 120 x 2 x 2 = 480s by default.
+
+## Clear failure output
+
+`e2e_run_bounded` runs one bounded `cynative -p`, and `e2e_classify_run` turns
+the outcome into a distinct, actionable failure:
+
+| Outcome | Signal | Reported as |
+| --- | --- | --- |
+| timeout | exit 124 | `FAIL: timed out after <N>s` |
+| token budget hit | `Budget reached` on stdout (the run still exits 0) | `FAIL: token budget reached - raise the token limit ...` |
+| provider/config/access | any other non-zero exit | `FAIL: provider/config/access (exit <rc>)` + stderr tail |
+| ok | exit 0, no budget notice | the suite runs its own assertions |
+
+The budget case matters most: on a budget hit cynative writes
+`⚠️  Budget reached — ...` to **stdout** and exits 0, so the answer never lands.
+Without a dedicated check that would surface as a confusing "answer missing"
+(for the LLM smoke, "nonce not found"). Classifying it directly points the
+maintainer at the token ceiling. A budget hit is treated as fatal and is not
+retried, so a too-low ceiling fails fast instead of re-burning credits.
+
+## Tests
+
+The library's pure logic (the bound exports, the isolation, the bounded-run
+exit-code propagation, and the classifier) is covered by
+`test/e2e-guardrails.unit.test.sh`, which runs hermetically under `make sh-test`.
+The connector script's audit parser has its own offline check:
+`sh test/connector.gcp.e2e.test.sh --selftest`.

--- a/docs/e2e/live-llm-smoke.md
+++ b/docs/e2e/live-llm-smoke.md
@@ -59,6 +59,11 @@ sh test/llm.smoke.test.sh /path/to/cynative
 | `SMOKE_REQUIRE_NO_CONNECTORS` | unset | When `1`, hard-fail unless no connector registers. CI sets this on its clean runner; leave it unset on a cloud host (see the caveat below). |
 | `SMOKE_REQUIRE_RUN` | unset | When `1`, a missing `CYNATIVE_LLM_PROVIDER`/`CYNATIVE_LLM_MODEL` is a hard failure instead of a skip. CI sets this so a misconfigured job (for example a renamed model variable) fails loudly rather than passing green without exercising the model. |
 
+`SMOKE_TIMEOUT` and `SMOKE_MAX_TOKENS` map onto the shared cost/timeout
+guardrails every live suite uses (isolation, token/iteration/request/wall-clock
+bounds, and the budget-hit classifier). See
+[Live e2e guardrails](e2e-guardrails.md) for the full set and defaults.
+
 ## What it asserts
 
 - The process exits 0.
@@ -72,14 +77,18 @@ sh test/llm.smoke.test.sh /path/to/cynative
 
 ## Failure classification
 
-The script separates stdout from stderr and reports a distinct reason per class:
+The script separates stdout from stderr and reports a distinct reason per class.
+The timeout, token-budget, and provider/config classes come from the shared
+guardrail classifier used by every live suite (see
+[Live e2e guardrails](e2e-guardrails.md)):
 
 | Class | Signal | Likely cause |
 | --- | --- | --- |
 | harness/setup | `FAIL:` before any run (build failed, tool missing) | local toolchain, not the provider |
 | provider/config/access | non-zero exit with an LLM status on stderr | bad project/region, invalid or missing credentials, model not found, auth failure |
 | timeout | exit 124 | provider slow or unreachable within `SMOKE_TIMEOUT` |
-| unexpected response | exit 0 but nonce missing | the model did not echo, or the budget was too low and a notice replaced the answer |
+| token budget | `Budget reached` on stdout (the run still exits 0) | `SMOKE_MAX_TOKENS` too low; the notice replaced the answer. Raise it. |
+| unexpected response | exit 0 but nonce missing | the model did not echo the token |
 
 ## Continuous integration
 

--- a/test/connector.gcp.e2e.test.sh
+++ b/test/connector.gcp.e2e.test.sh
@@ -191,6 +191,9 @@ if [ "${1:-}" = "--selftest" ]; then
 fi
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+# Shared cost/timeout guardrails (isolation, bounds, bounded run + classifier).
+# shellcheck disable=SC1091  # sourced at runtime via a $0-relative path.
+. "$root/test/lib/e2e-guardrails.sh"
 
 # Skip cleanly when required env is unset - unless GCP_E2E_REQUIRE_RUN=1, where a
 # missing var is a failure (a CI job must never go green by skipping).
@@ -208,40 +211,55 @@ if [ -n "$missing" ]; then
 	exit 0
 fi
 
-command -v go >/dev/null 2>&1 || { printf 'FAIL: go not found (needed to build cynative)\n' >&2; exit 1; }
-command -v timeout >/dev/null 2>&1 || { printf 'FAIL: timeout not found\n' >&2; exit 1; }
-command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found (needed to parse the audit log)\n' >&2; exit 1; }
+e2e_require_cmd go "needed to build cynative" || exit 1
+e2e_require_cmd timeout || exit 1
+e2e_require_cmd python3 "needed to parse the audit log" || exit 1
 
 workdir=$(mktemp -d)
 cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT INT TERM
 
-# Build the binary (or accept a prebuilt one) so the test exercises this checkout.
-bin=${1:-}
-if [ -z "$bin" ]; then
-	bin="$workdir/cynative"
-	printf '== BUILD ==\n' >&2
-	( cd "$root" && go build -o "$bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; exit 1; }
-fi
-[ -x "$bin" ] || { printf 'FAIL: binary not executable: %s\n' "$bin" >&2; exit 1; }
+# Build the binary (or accept a prebuilt one, passed as $1) so the test exercises
+# this checkout.
+bin=$(e2e_build_binary "$root" "$workdir" "${1:-}") || exit 1
 
-# Isolate cynative's own config/cache/audit without moving HOME, so provider SDKs
-# still find file-based ADC. An empty --config ignores the caller's config.yaml;
-# cache/audit go to the temp dir. Silence connector sources unrelated to gcp
-# (github/gitlab/kube), but KEEP the GCP creds - we want the gcp connector to
-# register (the inverse of the llm smoke).
-: > "$workdir/config.yaml"
-export CYNATIVE_CACHE_DIR="$workdir/cache"
-export CYNATIVE_MAX_TOTAL_TOKENS="${GCP_E2E_MAX_TOKENS:-32000}"
-unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
-	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+# Isolate cynative's config/cache from the caller without moving HOME, so provider
+# SDKs still find file-based ADC. e2e_isolate_env writes an empty --config
+# (ignore the caller's config.yaml), points the cache at the temp dir, and
+# silences connector sources unrelated to gcp (github/gitlab/kube). It leaves the
+# GCP creds alone - we want the gcp connector to register (the inverse of the llm
+# smoke). The per-phase audit path is set by e2e_run_bounded, not here.
+e2e_isolate_env "$workdir"
+# Bounds: the connector run does real tool work, so it keeps the shared iteration
+# default (unlike the no-tool llm smoke). GCP_E2E_* override the token and
+# wall-clock defaults; exported as env-level overrides for e2e_apply_bounds.
+export E2E_MAX_TOKENS="${GCP_E2E_MAX_TOKENS:-32000}"
+export E2E_RUN_TIMEOUT="${GCP_E2E_TIMEOUT:-120}"
+e2e_apply_bounds
 
 # Write the audit parser once; both phases invoke it.
 parser="$workdir/audit_check.py"
 write_parser "$parser"
 
-timeout_s="${GCP_E2E_TIMEOUT:-120}"
+timeout_s="$E2E_RUN_TIMEOUT"
 attempts="${GCP_E2E_ATTEMPTS:-2}"
+
+# classify_or_return RC OUT ERR - run the shared classifier for a phase and map it
+# onto the phase's retry contract: success (0) continues; a budget hit (3) is
+# fatal and must not be retried, so it propagates as 3; any other failure is a
+# retryable 1. The classifier's rc is captured in the else branch (a completed
+# `if` with no matching branch yields status 0, which would swallow it).
+classify_or_return() {
+	if e2e_classify_run "$1" "$2" "$3" "$timeout_s"; then
+		return 0
+	else
+		_cls=$?
+	fi
+	if [ "$_cls" -eq 3 ]; then
+		return 3
+	fi
+	return 1
+}
 
 # ============================ READ PHASE ============================
 # Give the project id, ask for the number: the model can only produce the number
@@ -254,19 +272,12 @@ read_phase() {
 	# records (cynative opens the audit log append-only, so a stale record from a
 	# failed earlier attempt could otherwise satisfy this attempt's parser).
 	: > "$workdir/read.audit.log"
-	if CYNATIVE_AUDIT_PATH="$workdir/read.audit.log" \
-		timeout "$timeout_s" "$bin" --config "$workdir/config.yaml" -p "$read_prompt" --auto-approve \
-		>"$workdir/read.out" 2>"$workdir/read.err" </dev/null; then rc=0; else rc=$?; fi
-
-	if [ "$rc" -eq 124 ]; then
-		printf 'read: timed out after %ss\n' "$timeout_s" >&2
-		return 1
-	fi
-	if [ "$rc" -ne 0 ]; then
-		printf 'read: run failed (provider/config/access, exit %s). stderr tail:\n' "$rc" >&2
-		tail -n 20 "$workdir/read.err" >&2
-		return 1
-	fi
+	if e2e_run_bounded "$timeout_s" "$workdir/read.audit.log" "$workdir/read.out" "$workdir/read.err" \
+		"$bin" "$workdir/config.yaml" "$read_prompt"; then rc=0; else rc=$?; fi
+	# Shared classification: a timeout, a budget hit, or a provider/config error
+	# fail this attempt; a budget hit (3) propagates so the retry loop stops
+	# instead of re-burning credits.
+	classify_or_return "$rc" "$workdir/read.out" "$workdir/read.err" || return $?
 	# Verify the environment before the answer: the gcp connector must have
 	# registered and be available under the read-only role. On failure dump the
 	# startup connector inventory and a stderr tail, so a registration skip is
@@ -321,23 +332,14 @@ canary_phase() {
 	# a stale marked+denied record from a failed earlier attempt must not satisfy
 	# this attempt's parser.
 	: > "$workdir/canary.audit.log"
-	if CYNATIVE_AUDIT_PATH="$workdir/canary.audit.log" \
-		timeout "$timeout_s" "$bin" --config "$workdir/config.yaml" -p "$canary_prompt" --auto-approve \
-		>"$workdir/canary.out" 2>"$workdir/canary.err" </dev/null; then crc=0; else crc=$?; fi
+	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
+		"$bin" "$workdir/config.yaml" "$canary_prompt"; then rc=0; else rc=$?; fi
 
 	# The denial is an in-loop tool result, not a fatal exit, so a correctly denied
-	# write still exits 0. A timeout or any other non-zero exit means the run itself
-	# failed (crash, misconfig, or the model never reaching the write) and must not
-	# be masked by the audit check - fail, like the read phase.
-	if [ "$crc" -eq 124 ]; then
-		printf 'canary: timed out after %ss\n' "$timeout_s" >&2
-		return 1
-	fi
-	if [ "$crc" -ne 0 ]; then
-		printf 'canary: run failed (exit %s). stderr tail:\n' "$crc" >&2
-		tail -n 20 "$workdir/canary.err" >&2
-		return 1
-	fi
+	# write still exits 0. Shared classification only catches a real run failure
+	# (timeout, budget, crash, or the model never reaching the write); it must not
+	# be masked by the audit check. A budget hit (3) is fatal - propagate it.
+	classify_or_return "$rc" "$workdir/canary.out" "$workdir/canary.err" || return $?
 	# The audit log must show the write was attempted AND denied client-side, and no
 	# marked write succeeded.
 	if ! python3 "$parser" canary "$workdir/canary.audit.log"; then
@@ -348,27 +350,38 @@ canary_phase() {
 	return 0
 }
 
-# Run each phase, retrying a non-deterministic model miss up to $attempts times.
-n=0
-while ! read_phase; do
-	n=$((n + 1))
-	if [ "$n" -ge "$attempts" ]; then
-		printf 'FAIL: read phase failed after %d attempt(s)\n' "$n" >&2
-		exit 1
-	fi
-	printf 'retry: read phase attempt %d failed, retrying\n' "$n" >&2
-done
-
-if [ "${GCP_E2E_CANARY:-1}" != "0" ]; then
-	n=0
-	while ! canary_phase; do
-		n=$((n + 1))
-		if [ "$n" -ge "$attempts" ]; then
-			printf 'FAIL: canary phase failed after %d attempt(s)\n' "$n" >&2
+# run_with_retries LABEL PHASE_FN - run a phase, retrying a non-deterministic
+# model miss up to $attempts times. A budget hit (the phase returns 3) is fatal
+# and is NOT retried: a retry only burns more credits and re-hits the ceiling.
+# The phase's exit code is captured in the else branch (a completed `if` with no
+# matching branch yields status 0, so reading $? after `fi` would swallow it).
+run_with_retries() {
+	_label=$1
+	_fn=$2
+	_n=0
+	while true; do
+		if "$_fn"; then
+			return 0
+		else
+			_prc=$?
+		fi
+		if [ "$_prc" -eq 3 ]; then
+			printf 'FAIL: %s phase hit the token budget; not retrying\n' "$_label" >&2
 			exit 1
 		fi
-		printf 'retry: canary phase attempt %d failed, retrying\n' "$n" >&2
+		_n=$((_n + 1))
+		if [ "$_n" -ge "$attempts" ]; then
+			printf 'FAIL: %s phase failed after %d attempt(s)\n' "$_label" "$_n" >&2
+			exit 1
+		fi
+		printf 'retry: %s phase attempt %d failed, retrying\n' "$_label" "$_n" >&2
 	done
+}
+
+run_with_retries read read_phase
+
+if [ "${GCP_E2E_CANARY:-1}" != "0" ]; then
+	run_with_retries canary canary_phase
 fi
 
 printf 'connector.gcp.e2e: OK (%s)\n' "$GCP_E2E_PROJECT" >&2

--- a/test/e2e-guardrails.unit.test.sh
+++ b/test/e2e-guardrails.unit.test.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# e2e-guardrails.unit.test.sh - offline unit tests for the shared live-e2e
+# guardrails library (test/lib/e2e-guardrails.sh, cynative#51).
+#
+# Hermetic: no network, no credentials, no cynative build. It sources the library
+# and exercises the pure helpers - the bound exports, the tmp-dir isolation, the
+# bounded-run exit-code propagation, and the run classifier (including the
+# budget-hit case that must not read as a bogus "answer missing"). Run by
+# `make sh-test` alongside the install.sh unit tests.
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+# shellcheck source=test/lib/e2e-guardrails.sh
+. "$here/lib/e2e-guardrails.sh"
+
+fails=0
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+# ---- e2e_apply_bounds: defaults ------------------------------------------------
+if (
+	e2e_apply_bounds
+	[ "$CYNATIVE_MAX_TOTAL_TOKENS" = "16000" ] || exit 1
+	[ "$CYNATIVE_MAX_ITERATIONS" = "16" ] || exit 1
+	[ "$CYNATIVE_MAX_SUBAGENT_ITERATIONS" = "3" ] || exit 1
+	[ "$CYNATIVE_SANDBOX_MAX_CONCURRENCY" = "4" ] || exit 1
+	[ "$CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS" = "60" ] || exit 1
+); then pass "apply_bounds exports defaults"; else fail "apply_bounds defaults"; fi
+
+# ---- e2e_apply_bounds: overrides -----------------------------------------------
+if (
+	E2E_MAX_TOKENS=32000
+	E2E_MAX_ITERATIONS=1
+	E2E_SUBAGENT_ITERATIONS=2
+	E2E_SANDBOX_CONCURRENCY=8
+	E2E_REQUEST_TIMEOUT=45
+	e2e_apply_bounds
+	[ "$CYNATIVE_MAX_TOTAL_TOKENS" = "32000" ] || exit 1
+	[ "$CYNATIVE_MAX_ITERATIONS" = "1" ] || exit 1
+	[ "$CYNATIVE_MAX_SUBAGENT_ITERATIONS" = "2" ] || exit 1
+	[ "$CYNATIVE_SANDBOX_MAX_CONCURRENCY" = "8" ] || exit 1
+	[ "$CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS" = "45" ] || exit 1
+); then pass "apply_bounds honors E2E_* overrides"; else fail "apply_bounds overrides"; fi
+
+# ---- e2e_apply_bounds: per-request timeout defaults to the run wall-clock ------
+if (
+	# With no explicit E2E_REQUEST_TIMEOUT, the per-LLM-call timeout follows
+	# E2E_RUN_TIMEOUT, so it never fires before the run itself would.
+	E2E_RUN_TIMEOUT=120
+	e2e_apply_bounds
+	[ "$CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS" = "120" ] || exit 1
+	# An explicit request timeout still wins over the run wall-clock.
+	E2E_REQUEST_TIMEOUT=30
+	e2e_apply_bounds
+	[ "$CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS" = "30" ] || exit 1
+); then pass "apply_bounds derives request timeout from run wall-clock, explicit wins"; else fail "apply_bounds request-timeout derivation"; fi
+
+# ---- e2e_isolate_env -----------------------------------------------------------
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	GITHUB_TOKEN=secret GH_TOKEN=secret GITLAB_TOKEN=secret GITLAB_ACCESS_TOKEN=secret OAUTH_TOKEN=secret
+	KUBECONFIG=/tmp/kube GH_CONFIG_DIR=/tmp/gh GLAB_CONFIG_DIR=/tmp/glab
+	export GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+	export KUBECONFIG GH_CONFIG_DIR GLAB_CONFIG_DIR
+	e2e_isolate_env "$td"
+	[ -f "$td/config.yaml" ] || exit 1     # config written
+	[ ! -s "$td/config.yaml" ] || exit 1   # and empty (ignores caller's config)
+	[ "$CYNATIVE_CACHE_DIR" = "$td/cache" ] || exit 1
+	# All 8 connector-discovery vars the library unsets must be cleared.
+	[ -z "${GITHUB_TOKEN:-}" ] || exit 1
+	[ -z "${GH_TOKEN:-}" ] || exit 1
+	[ -z "${GITLAB_TOKEN:-}" ] || exit 1
+	[ -z "${GITLAB_ACCESS_TOKEN:-}" ] || exit 1
+	[ -z "${OAUTH_TOKEN:-}" ] || exit 1
+	[ -z "${KUBECONFIG:-}" ] || exit 1
+	[ -z "${GH_CONFIG_DIR:-}" ] || exit 1
+	[ -z "${GLAB_CONFIG_DIR:-}" ] || exit 1
+); then pass "isolate_env writes empty config, sets cache, unsets connector env"; else fail "isolate_env"; fi
+
+# ---- e2e_build_binary: prebuilt path -------------------------------------------
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	# A non-executable prebuilt is rejected.
+	: > "$td/notexec"
+	if e2e_build_binary "$td/root" "$td" "$td/notexec" >/dev/null 2>&1; then exit 1; fi
+	# An executable prebuilt is echoed back verbatim (no build).
+	printf '#!/bin/sh\n' > "$td/exec"
+	chmod +x "$td/exec"
+	out=$(e2e_build_binary "$td/root" "$td" "$td/exec") || exit 1
+	[ "$out" = "$td/exec" ] || exit 1
+	# With no prebuilt and go unavailable, the build path fails closed (clear msg).
+	if ( PATH='' e2e_build_binary "$td/root" "$td" >/dev/null 2>&1 ); then exit 1; fi
+); then pass "build_binary accepts an executable prebuilt, rejects non-executable, needs go to build"; else fail "build_binary prebuilt"; fi
+
+# ---- e2e_run_bounded: exit-code propagation + stream capture -------------------
+# Needs `timeout` (the wrapper invokes it); skip cleanly if absent.
+if command -v timeout >/dev/null 2>&1; then
+	if (
+		td=$(mktemp -d)
+		trap 'rm -rf "$td"' EXIT
+		runrc() {  # rc of a bounded run against stub "$1"
+			if e2e_run_bounded 3 "$td/audit" "$td/o" "$td/e" "$1" "$td/cfg" "prompt"; then
+				echo 0
+			else
+				echo $?
+			fi
+		}
+		# A non-zero exit must propagate (guards the `return $?` fall-through bug).
+		printf '#!/bin/sh\necho OUT\necho ERR >&2\nexit 7\n' > "$td/exit7"
+		chmod +x "$td/exit7"
+		[ "$(runrc "$td/exit7")" -eq 7 ] || exit 1
+		grep -Fq OUT "$td/o" || exit 1   # stdout captured
+		grep -Fq ERR "$td/e" || exit 1   # stderr captured
+		# A clean exit is 0.
+		printf '#!/bin/sh\nexit 0\n' > "$td/exit0"
+		chmod +x "$td/exit0"
+		[ "$(runrc "$td/exit0")" -eq 0 ] || exit 1
+		# Overrunning the wall-clock yields 124.
+		printf '#!/bin/sh\nsleep 5\n' > "$td/slow"
+		chmod +x "$td/slow"
+		if e2e_run_bounded 1 "$td/audit" "$td/o" "$td/e" "$td/slow" "$td/cfg" "prompt"; then
+			trc=0
+		else
+			trc=$?
+		fi
+		[ "$trc" -eq 124 ] || exit 1
+		# Extra trailing args (e.g. --verbose) are passed through to the binary.
+		printf '#!/bin/sh\nprintf "%%s\\n" "$*"\n' > "$td/echoargs"
+		chmod +x "$td/echoargs"
+		if e2e_run_bounded 3 "$td/audit" "$td/o3" "$td/e3" "$td/echoargs" "$td/cfg" "prompt" --verbose --foo; then :; fi
+		grep -Fq -- '--verbose --foo' "$td/o3" || exit 1
+	); then pass "run_bounded propagates exit 7/0, captures streams, times out to 124, passes extra args"; else fail "run_bounded"; fi
+else
+	printf 'skip: run_bounded case (timeout not found)\n' >&2
+fi
+
+# ---- e2e_classify_run: four cases ----------------------------------------------
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	printf 'answer text\n' > "$td/ok.out"
+	: > "$td/empty.err"
+	printf 'boom\n' > "$td/boom.err"
+	# The agent writes the budget notice to STDOUT and exits 0 on a budget hit;
+	# only the ASCII "Budget reached" substring is load-bearing.
+	printf 'Budget reached - token budget reached: 100 / 50 tokens. Stopping;\n' > "$td/budget.out"
+
+	# Capture classify_run's rc without tripping set -e on its intentional
+	# non-zero returns (the house if/else pattern).
+	classrc() {
+		if e2e_classify_run "$1" "$2" "$3" "$4" >/dev/null 2>&1; then echo 0; else echo $?; fi
+	}
+
+	[ "$(classrc 0   "$td/ok.out"     "$td/empty.err" 60)" -eq 0 ] || exit 1  # ok
+	[ "$(classrc 124 "$td/ok.out"     "$td/empty.err" 60)" -eq 2 ] || exit 1  # timeout
+	[ "$(classrc 0   "$td/budget.out" "$td/empty.err" 60)" -eq 3 ] || exit 1  # budget (rc 0!)
+	[ "$(classrc 1   "$td/ok.out"     "$td/boom.err"  60)" -eq 1 ] || exit 1  # generic
+	[ "$(classrc 124 "$td/budget.out" "$td/empty.err" 60)" -eq 2 ] || exit 1  # timeout dominates
+); then pass "classify_run maps ok/timeout/budget/failure to 0/2/3/1"; else fail "classify_run"; fi
+
+# ---- e2e_require_cmd -----------------------------------------------------------
+if (
+	e2e_require_cmd sh >/dev/null 2>&1 || exit 1                 # present
+	if e2e_require_cmd definitely-not-a-real-cmd-xyz >/dev/null 2>&1; then exit 1; fi  # absent
+); then pass "require_cmd passes for present, fails for absent"; else fail "require_cmd"; fi
+
+if [ "$fails" -ne 0 ]; then
+	printf 'e2e-guardrails.unit: %d case(s) FAILED\n' "$fails" >&2
+	exit 1
+fi
+printf 'e2e-guardrails.unit: OK\n' >&2

--- a/test/lib/e2e-guardrails.sh
+++ b/test/lib/e2e-guardrails.sh
@@ -1,0 +1,142 @@
+# shellcheck shell=sh
+# e2e-guardrails.sh - shared cost/timeout guardrails for the live e2e suites
+# (cynative#51). Sourced, never executed: it defines helpers and has no side
+# effects at source time, so an offline caller (e.g. the connector script's
+# --selftest) can source it safely.
+#
+# It keeps the two live suites - test/llm.smoke.test.sh and
+# test/connector.gcp.e2e.test.sh - on one bounded configuration so a broken live
+# run cannot quietly burn credits, hang a runner, or leave a maintainer guessing.
+#
+# The library reads no suite-specific env. Callers resolve their own public knobs
+# (SMOKE_* / GCP_E2E_*) into the generic E2E_* override vars before calling
+# e2e_apply_bounds, so the library stays generic and the documented per-suite
+# knobs keep working.
+#
+# Guardrail defaults (override by setting the E2E_* var before e2e_apply_bounds):
+#   E2E_MAX_TOKENS          16000  -> CYNATIVE_MAX_TOTAL_TOKENS (token ceiling)
+#   E2E_MAX_ITERATIONS      16     -> CYNATIVE_MAX_ITERATIONS (main loop cap; the
+#                                     no-tool llm smoke overrides down to 1)
+#   E2E_SUBAGENT_ITERATIONS 3      -> CYNATIVE_MAX_SUBAGENT_ITERATIONS
+#   E2E_SANDBOX_CONCURRENCY 4      -> CYNATIVE_SANDBOX_MAX_CONCURRENCY
+#   E2E_REQUEST_TIMEOUT     =E2E_RUN_TIMEOUT (per-LLM-call timeout) ->
+#                                  CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS
+#   E2E_RUN_TIMEOUT         60     -> the shell `timeout` wall-clock per run. Not a
+#                                     cynative knob (passed to e2e_run_bounded);
+#                                     also the default basis for E2E_REQUEST_TIMEOUT.
+# There is no separate whole-script watchdog: the effective ceiling is the
+# per-run timeout times the capped attempts and phases, and a budget hit is
+# fatal (never retried). Each suite documents its derived worst case.
+
+# e2e_require_cmd CMD [HINT] - fail closed if CMD is not on PATH.
+e2e_require_cmd() {
+	command -v "$1" >/dev/null 2>&1 && return 0
+	printf 'FAIL: %s not found%s\n' "$1" "${2:+ ($2)}" >&2
+	return 1
+}
+
+# e2e_apply_bounds - export the guardrail env from the E2E_* overrides (with the
+# documented defaults). Must run in the current shell (it exports), so do NOT
+# call it via command substitution. Idempotent.
+e2e_apply_bounds() {
+	export CYNATIVE_MAX_TOTAL_TOKENS="${E2E_MAX_TOKENS:-16000}"
+	export CYNATIVE_MAX_ITERATIONS="${E2E_MAX_ITERATIONS:-16}"
+	export CYNATIVE_MAX_SUBAGENT_ITERATIONS="${E2E_SUBAGENT_ITERATIONS:-3}"
+	export CYNATIVE_SANDBOX_MAX_CONCURRENCY="${E2E_SANDBOX_CONCURRENCY:-4}"
+	# Per-LLM-call timeout defaults to the per-run wall-clock, so it never fires
+	# before the run itself would - avoiding a spurious cut-off of a legitimately
+	# slow reasoning turn (cynative's own default is 300s for exactly this reason).
+	# Raising the wall-clock knob (SMOKE_TIMEOUT / GCP_E2E_TIMEOUT) raises this too;
+	# a caller can still pin it explicitly via E2E_REQUEST_TIMEOUT.
+	export CYNATIVE_LLM_NETWORK_CONFIG_DEFAULT_REQUEST_TIMEOUT_IN_SECONDS="${E2E_REQUEST_TIMEOUT:-${E2E_RUN_TIMEOUT:-60}}"
+}
+
+# e2e_isolate_env WORKDIR - isolate cynative's config/cache from the caller and
+# silence connector-discovery env unrelated to any LLM provider. Writes an empty
+# WORKDIR/config.yaml (so the caller's ~/.cynative/config.yaml is ignored) and
+# points the cache at WORKDIR. It does NOT set CYNATIVE_AUDIT_PATH: a caller that
+# runs multiple phases sets a per-phase audit path itself. Runs in the current
+# shell (it exports/unsets); do not call via command substitution.
+e2e_isolate_env() {
+	: > "$1/config.yaml"
+	export CYNATIVE_CACHE_DIR="$1/cache"
+	# AWS/GCP/Azure creds are left alone: an LLM provider may need them (e.g.
+	# Bedrock uses AWS creds). The suite's own tool-call / connector assertions
+	# are the safety net for whether a connector should be dark.
+	unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
+		GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+}
+
+# e2e_build_binary ROOT WORKDIR [PREBUILT] - print a usable cynative binary path.
+# With PREBUILT: validate it is executable and echo it. Without: build the
+# current checkout (go build ./cmd/cynative from ROOT) into WORKDIR. Safe to call
+# via command substitution (it only prints the path; no exports).
+e2e_build_binary() {
+	_root=$1
+	_workdir=$2
+	_prebuilt=${3:-}
+	if [ -n "$_prebuilt" ]; then
+		[ -x "$_prebuilt" ] || { printf 'FAIL: binary not executable: %s\n' "$_prebuilt" >&2; return 1; }
+		printf '%s\n' "$_prebuilt"
+		return 0
+	fi
+	_bin="$_workdir/cynative"
+	e2e_require_cmd go "needed to build cynative" || return 1
+	printf '== BUILD ==\n' >&2
+	( cd "$_root" && go build -o "$_bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; return 1; }
+	printf '%s\n' "$_bin"
+}
+
+# e2e_run_bounded RUN_TIMEOUT AUDIT OUT ERR BIN CONFIG PROMPT [EXTRA...] - run one
+# bounded one-shot `cynative -p`. Assumes e2e_apply_bounds already exported the
+# cynative guardrail env; this adds the per-phase audit path and the wall-clock
+# `timeout`. Any args after PROMPT are passed through to cynative (e.g. --verbose).
+# Captures the exit code safely under set -e and returns it (124 == timeout).
+e2e_run_bounded() {
+	_to=$1
+	_audit=$2
+	_out=$3
+	_err=$4
+	_bin=$5
+	_cfg=$6
+	_prompt=$7
+	shift 7
+	# The exit code is captured in the else branch: a completed `if` with no
+	# matching branch yields status 0, so `return $?` after `fi` would swallow a
+	# timeout/failure. In the else, $? still holds the condition's exit status.
+	if CYNATIVE_AUDIT_PATH="$_audit" \
+		timeout "$_to" "$_bin" --config "$_cfg" -p "$_prompt" --auto-approve "$@" \
+		>"$_out" 2>"$_err" </dev/null; then
+		return 0
+	else
+		return $?
+	fi
+}
+
+# e2e_classify_run RC OUT ERR RUN_TIMEOUT - classify a bounded run and print a
+# clear, distinct failure. Returns:
+#   0  success (rc 0 and no budget notice on stdout) - run domain assertions.
+#   2  timeout (rc 124).
+#   3  budget hit: "Budget reached" appears on stdout. The agent writes this to
+#      stdout and exits 0, so the answer never lands; without this branch a
+#      budget hit reads as a bogus "answer missing". Callers treat 3 as fatal and
+#      do NOT retry (a retry only burns more credits and re-hits the ceiling).
+#   1  any other non-zero rc (provider / config / access).
+# Order matters: timeout, then budget (exits 0), then the generic rc branch.
+e2e_classify_run() {
+	if [ "$1" -eq 124 ]; then
+		printf 'FAIL: timed out after %ss\n' "$4" >&2
+		return 2
+	fi
+	if grep -Fq 'Budget reached' "$2" 2>/dev/null; then
+		printf 'FAIL: token budget reached - raise the token limit (E2E_MAX_TOKENS / SMOKE_MAX_TOKENS / GCP_E2E_MAX_TOKENS). Notice:\n' >&2
+		grep -F 'Budget reached' "$2" >&2 || true
+		return 3
+	fi
+	if [ "$1" -ne 0 ]; then
+		printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$1" >&2
+		tail -n 20 "$3" >&2
+		return 1
+	fi
+	return 0
+}

--- a/test/llm-tools.smoke.test.sh
+++ b/test/llm-tools.smoke.test.sh
@@ -44,6 +44,9 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+# Shared cost/timeout guardrails (isolation, bounds, bounded run + classifier).
+# shellcheck disable=SC1091  # sourced at runtime via a $0-relative path.
+. "$root/test/lib/e2e-guardrails.sh"
 
 # Skip cleanly when no provider is configured - unless SMOKE_REQUIRE_RUN=1, where
 # a missing provider/model is a failure (a CI job must never go green by skipping).
@@ -56,24 +59,18 @@ if [ -z "${CYNATIVE_LLM_PROVIDER:-}" ] || [ -z "${CYNATIVE_LLM_MODEL:-}" ]; then
 	exit 0
 fi
 
-command -v timeout >/dev/null 2>&1 || { printf 'FAIL: timeout not found\n' >&2; exit 1; }
+e2e_require_cmd timeout || exit 1
 # python3 parses the audit log below (the load-bearing tool-use check); the repo's
 # other live e2e tests take the same dependency.
-command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found (needed to parse the audit log)\n' >&2; exit 1; }
+e2e_require_cmd python3 "needed to parse the audit log" || exit 1
 
 workdir=$(mktemp -d)
 cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT INT TERM
 
-# Build the binary (or accept a prebuilt one). go is only needed when building.
-bin=${1:-}
-if [ -z "$bin" ]; then
-	command -v go >/dev/null 2>&1 || { printf 'FAIL: go not found (needed to build cynative)\n' >&2; exit 1; }
-	bin="$workdir/cynative"
-	printf '== BUILD ==\n' >&2
-	( cd "$root" && go build -o "$bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; exit 1; }
-fi
-[ -x "$bin" ] || { printf 'FAIL: binary not executable: %s\n' "$bin" >&2; exit 1; }
+# Build the binary (or accept a prebuilt one, passed as $1). go is only needed
+# when building; e2e_build_binary presence-checks it in that branch.
+bin=$(e2e_build_binary "$root" "$workdir" "${1:-}") || exit 1
 
 # A deterministic, tool-shaped task: sum 40 random 16-bit integers. The model
 # cannot reliably do this in its head, and the tool's own description reserves
@@ -95,42 +92,35 @@ prompt="You must use the code_execution tool to compute this; do not compute it 
 yourself. Compute the exact integer sum of the following numbers and reply with \
 only that integer and nothing else: $list"
 
-# Isolate cynative's OWN config/cache/audit without moving HOME, so the provider
-# SDKs can still find file-based credentials on a local run (~/.aws for Bedrock,
-# the gcloud ADC file for Vertex). An empty --config makes cynative ignore the
-# caller's ~/.cynative/config.yaml, and cache/audit go to the temp dir. The audit
-# log is asserted below, so pin it on. Silence connector discovery sources
-# unrelated to any LLM provider (github/gitlab/kube tokens and config-dir
-# overrides are never LLM creds); ambient cloud creds may still register the
+# Isolate cynative's config/cache from the caller without moving HOME, so the
+# provider SDKs can still find file-based credentials on a local run (~/.aws for
+# Bedrock, the gcloud ADC file for Vertex). e2e_isolate_env writes an empty
+# --config, points the cache at the temp dir, and silences connector discovery
+# unrelated to any LLM provider; ambient cloud creds may still register the
 # aws/gcp/azure connectors on a cloud host, which is fine - this test asserts a
-# code_execution call, not the connector set.
-: > "$workdir/config.yaml"
-export CYNATIVE_CACHE_DIR="$workdir/cache"
+# code_execution call, not the connector set. The audit log is asserted below, so
+# enable it and route it into the temp dir.
+e2e_isolate_env "$workdir"
 export CYNATIVE_AUDIT_ENABLED=true
-export CYNATIVE_AUDIT_PATH="$workdir/audit.log"
-unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
-	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+
+# Bounds: tool use needs a few iterations (at least 2 - call the tool, then
+# answer), a larger token budget than the no-tool smoke (a tool turn is two model
+# calls plus the echoed script), and a longer wall-clock. The public SMOKE_* knobs
+# override the shared defaults; the rest take the guardrail defaults.
+export E2E_MAX_ITERATIONS="${SMOKE_MAX_ITERATIONS:-6}"
+export E2E_MAX_TOKENS="${SMOKE_MAX_TOKENS:-40000}"
+export E2E_RUN_TIMEOUT="${SMOKE_TIMEOUT:-90}"
+e2e_apply_bounds
 
 printf '== RUN == %s/%s (sum of %s integers)\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" "$count" >&2
-# timeout returns non-zero on a slow/failed run, which under `set -e` would abort
-# before rc is captured, so wrap it (house pattern, test/llm.smoke.test.sh).
-set +e
-CYNATIVE_MAX_ITERATIONS="${SMOKE_MAX_ITERATIONS:-6}" CYNATIVE_MAX_TOTAL_TOKENS="${SMOKE_MAX_TOKENS:-40000}" \
-	timeout "${SMOKE_TIMEOUT:-90}" "$bin" --config "$workdir/config.yaml" -p "$prompt" --auto-approve --verbose \
-		>"$workdir/out" 2>"$workdir/err" </dev/null
-rc=$?
-set -e
+# --verbose is passed through so check 4 can see the per-tool-call notice.
+if e2e_run_bounded "$E2E_RUN_TIMEOUT" "$workdir/audit.log" "$workdir/out" "$workdir/err" \
+	"$bin" "$workdir/config.yaml" "$prompt" --verbose; then rc=0; else rc=$?; fi
 
-# Failure classification.
-if [ "$rc" -eq 124 ]; then
-	printf 'FAIL: timed out after %ss\n' "${SMOKE_TIMEOUT:-90}" >&2
-	exit 1
-fi
-if [ "$rc" -ne 0 ]; then
-	printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$rc" >&2
-	tail -n 20 "$workdir/err" >&2
-	exit 1
-fi
+# Shared classification: a timeout, a budget hit (clear message, not a bogus
+# "sum not found"), or a provider/config/access error. A clean rc 0 falls through
+# to the tool-use assertions below.
+e2e_classify_run "$rc" "$workdir/out" "$workdir/err" "$E2E_RUN_TIMEOUT" || exit 1
 
 # 1. The exact computed sum round-tripped into the answer on stdout. Drop thousands
 # separators, then require some run of digits to equal the sum exactly (grep -Fx),

--- a/test/llm.smoke.test.sh
+++ b/test/llm.smoke.test.sh
@@ -29,6 +29,9 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+# Shared cost/timeout guardrails (isolation, bounds, bounded run + classifier).
+# shellcheck disable=SC1091  # sourced at runtime via a $0-relative path.
+. "$root/test/lib/e2e-guardrails.sh"
 
 # Skip cleanly when no provider is configured - unless SMOKE_REQUIRE_RUN=1, where
 # a missing provider/model is a failure (a CI job must never go green by skipping).
@@ -41,62 +44,48 @@ if [ -z "${CYNATIVE_LLM_PROVIDER:-}" ] || [ -z "${CYNATIVE_LLM_MODEL:-}" ]; then
 	exit 0
 fi
 
-command -v go >/dev/null 2>&1 || { printf 'FAIL: go not found (needed to build cynative)\n' >&2; exit 1; }
-command -v timeout >/dev/null 2>&1 || { printf 'FAIL: timeout not found\n' >&2; exit 1; }
+e2e_require_cmd go "needed to build cynative" || exit 1
+e2e_require_cmd timeout || exit 1
 
 workdir=$(mktemp -d)
 cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT INT TERM
 
-# Build the binary (or accept a prebuilt one).
-bin=${1:-}
-if [ -z "$bin" ]; then
-	bin="$workdir/cynative"
-	printf '== BUILD ==\n' >&2
-	( cd "$root" && go build -o "$bin" ./cmd/cynative ) || { printf 'FAIL: go build failed\n' >&2; exit 1; }
-fi
-[ -x "$bin" ] || { printf 'FAIL: binary not executable: %s\n' "$bin" >&2; exit 1; }
+# Build the binary (or accept a prebuilt one, passed as $1).
+bin=$(e2e_build_binary "$root" "$workdir" "${1:-}") || exit 1
 
 # Long, contiguous, no-whitespace nonce that survives markdown reflow.
 nonce="SMOKE-$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
 prompt="Reply with exactly this token and nothing else: $nonce"
 
-# Isolate cynative's OWN config/cache/audit without moving HOME, so the provider
-# SDKs can still find file-based credentials on a local run (~/.aws for Bedrock,
-# the gcloud ADC file for Vertex, ~/.azure for Azure). An empty --config makes
-# cynative ignore the caller's ~/.cynative/config.yaml, and cache/audit go to the
-# temp dir. Silence connector discovery sources unrelated to any LLM provider
-# (github/gitlab/kube tokens and config-dir overrides are never LLM creds). Do
-# NOT unset AWS/GCP/Azure creds: the LLM provider may need them (e.g. Bedrock uses
-# AWS creds), so the aws/gcp connectors can still register on a cloud host - the
-# 0-tool-calls assertion is the real safety net, and SMOKE_REQUIRE_NO_CONNECTORS
-# is opt-in (CI only, where the runner is clean).
-: > "$workdir/config.yaml"
-export CYNATIVE_CACHE_DIR="$workdir/cache"
-export CYNATIVE_AUDIT_PATH="$workdir/audit.log"
-unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
-	GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+# Isolate cynative's config/cache from the caller without moving HOME, so the
+# provider SDKs can still find file-based credentials on a local run (~/.aws for
+# Bedrock, the gcloud ADC file for Vertex, ~/.azure for Azure). e2e_isolate_env
+# writes an empty --config (ignore the caller's ~/.cynative/config.yaml), points
+# the cache at the temp dir, and silences connector discovery unrelated to any
+# LLM provider (github/gitlab/kube tokens and config-dir overrides). It leaves
+# AWS/GCP/Azure creds alone (the LLM provider may need them, e.g. Bedrock), so
+# the 0-tool-calls assertion is the real safety net and SMOKE_REQUIRE_NO_CONNECTORS
+# is opt-in.
+e2e_isolate_env "$workdir"
+
+# Bounds: this is a no-tool smoke, so cap iterations at 1. The public SMOKE_*
+# knobs override the shared token/wall-clock defaults; the rest (request timeout,
+# subagent iterations, sandbox concurrency) take the shared guardrail defaults.
+# Exported as env-level overrides consumed by e2e_apply_bounds.
+export E2E_MAX_ITERATIONS=1
+export E2E_MAX_TOKENS="${SMOKE_MAX_TOKENS:-16000}"
+export E2E_RUN_TIMEOUT="${SMOKE_TIMEOUT:-60}"
+e2e_apply_bounds
 
 printf '== RUN == %s/%s\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
-# timeout returns non-zero on a slow/failed run, which under `set -e` would abort
-# before rc is captured, so wrap it (house pattern, test/install.e2e.test.sh).
-set +e
-CYNATIVE_MAX_ITERATIONS=1 CYNATIVE_MAX_TOTAL_TOKENS="${SMOKE_MAX_TOKENS:-16000}" \
-	timeout "${SMOKE_TIMEOUT:-60}" "$bin" --config "$workdir/config.yaml" -p "$prompt" --auto-approve \
-		>"$workdir/out" 2>"$workdir/err" </dev/null
-rc=$?
-set -e
+if e2e_run_bounded "$E2E_RUN_TIMEOUT" "$workdir/audit.log" "$workdir/out" "$workdir/err" \
+	"$bin" "$workdir/config.yaml" "$prompt"; then rc=0; else rc=$?; fi
 
-# Failure classification.
-if [ "$rc" -eq 124 ]; then
-	printf 'FAIL: timed out after %ss\n' "${SMOKE_TIMEOUT:-60}" >&2
-	exit 1
-fi
-if [ "$rc" -ne 0 ]; then
-	printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$rc" >&2
-	tail -n 20 "$workdir/err" >&2
-	exit 1
-fi
+# Shared classification: a timeout, a budget hit (clear message, not a bogus
+# "nonce not found"), or a provider/config/access error. A clean rc 0 falls
+# through to the smoke's own assertions below.
+e2e_classify_run "$rc" "$workdir/out" "$workdir/err" "$E2E_RUN_TIMEOUT" || exit 1
 
 # Hard: the model echoed the nonce on stdout.
 if ! grep -Fq "$nonce" "$workdir/out"; then


### PR DESCRIPTION
## What & why

Extract the guardrails that the live e2e scripts each hand-rolled into a shared POSIX-sh library, `test/lib/e2e-guardrails.sh`, so every live suite runs under one bounded configuration by default. Closes #51.

The three live suites now source it: `test/llm.smoke.test.sh` (no-tool), `test/llm-tools.smoke.test.sh` (`code_execution` tool-use), and `test/connector.gcp.e2e.test.sh` (GCP connector).

Each script independently isolated config/cache/audit, silenced connector env, built the binary, and wrapped a bounded run, and they diverged on the settings that matter for cost and hangs (iteration caps, per-request timeout, concurrency). A budget cross was also misreported: cynative prints "Budget reached" to stdout and exits 0, so the old scripts failed downstream with a confusing "nonce not found" / "sum not found".

The library provides:
- `e2e_isolate_env` - empty `--config`, cache/audit in a tmp dir, connector-discovery env silenced, cloud creds left alone.
- `e2e_apply_bounds` - env-overridable bounds mapped to real cynative knobs: token ceiling, main-loop iterations, subagent iterations, sandbox concurrency, and a per-LLM-call timeout that defaults to the per-run wall-clock (so it never cuts off a slow reasoning turn; cynative's own default is 300s for that reason).
- `e2e_build_binary`, `e2e_run_bounded` (with pass-through flags such as `--verbose`), and `e2e_classify_run` - the shared classifier reporting a distinct failure for a timeout, a token-budget hit ("raise the token limit"), or a provider/config error. A budget hit is fatal, so a too-low ceiling fails fast instead of re-burning credits on a retry.

Each suite keeps its own public knobs (`SMOKE_*` / `GCP_E2E_*`) and domain assertions; only the shared scaffolding moved. See `docs/e2e/e2e-guardrails.md`.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed

Additional validation: ran all three live suites against Bedrock. The no-tool and tool-use smokes pass (including the budget-hit path, which now reports the token-limit message instead of a misleading "answer missing"), and the GCP connector e2e passes both its read and write-deny-canary phases against a real project.