### PR TITLE
test: drive the live LLM smoke from a provider manifest

### DIFF
--- a/.github/live-llm-manifest.json
+++ b/.github/live-llm-manifest.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "vertex-notool",
+    "enabled": true,
+    "provider": "vertex",
+    "auth": "gcp-wif",
+    "suite": "llm-smoke",
+    "model_var": "CYNATIVE_CLI_CI_VERTEX_MODEL",
+    "required": true,
+    "require_no_connectors": true,
+    "note": "Vertex/Gemini no-tool nonce echo (cynative#38)."
+  },
+  {
+    "id": "vertex-tools",
+    "enabled": true,
+    "provider": "vertex",
+    "auth": "gcp-wif",
+    "suite": "llm-tools-smoke",
+    "model_var": "CYNATIVE_CLI_CI_VERTEX_MODEL",
+    "required": true,
+    "require_no_connectors": false,
+    "note": "code_execution tool-use asserts a tool call, not the connector set (cynative#49)."
+  },
+  {
+    "id": "bedrock-notool",
+    "enabled": true,
+    "provider": "bedrock",
+    "auth": "aws-oidc",
+    "suite": "llm-smoke",
+    "model_var": "CYNATIVE_CLI_CI_BEDROCK_MODEL",
+    "role_var": "CYNATIVE_CLI_CI_AWS_ROLE",
+    "required": true,
+    "require_no_connectors": true,
+    "note": "aws-ci binds the stable OIDC subject; role_var preflight fails loud (cynative#48)."
+  }
+]

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -1,17 +1,23 @@
 name: Live LLM smoke
 
-# Runs the real `cynative -p` against live LLM providers in three jobs: a
-# Vertex/Gemini no-tool nonce-echo smoke (cynative#38) proving the CLI + config +
-# Bifrost wiring + response handling work against a real provider, a Vertex/Gemini
-# code_execution tool-use smoke (cynative#49) proving the model can drive the tool
-# loop end to end, and a Bedrock no-tool nonce-echo smoke (cynative#48) proving the
-# same round-trip against a second provider on a different credential path.
-# Mirrors install-e2e.yaml's detect gating, so the heavy live runs only fire for
-# release-please PRs or a manual dispatch. The Vertex jobs authenticate to GCP
-# project cynative-cli-ci via keyless Workload Identity Federation; the Bedrock job
-# authenticates to AWS via keyless GitHub OIDC role assumption. Every credential
-# step is gated to same-repo events so untrusted forks never reach it. Not a
-# required status check.
+# Runs the real `cynative -p` against live LLM providers, driven by the checked-in
+# manifest .github/live-llm-manifest.json (cynative#50). Each enabled manifest row
+# is one matrix job: a provider x suite pair. The manifest carries the provider
+# details (id, model variable, suite, required-or-optional, auth family) so adding
+# or disabling a same-family provider is a one-row manifest edit, not a workflow
+# rewrite; internal/llm/livellm_manifest_test.go validates it fail-closed under the
+# required `Lint & Test` check, so a malformed row blocks merge.
+#
+# The `plan` job turns the manifest into two per-family matrices; the smoke jobs
+# consume them. Credential mechanics genuinely differ per family and cannot be
+# expressed as data, so each auth family has its own job: `gcp-smoke` authenticates
+# to GCP project cynative-cli-ci via keyless Workload Identity Federation, and
+# `aws-smoke` authenticates to AWS via keyless GitHub OIDC role assumption under a
+# static `environment: aws-ci` (the stable OIDC subject the AWS role trusts). A new
+# auth family is the one deliberate case that adds a job. Mirrors install-e2e.yaml's
+# detect gating, so the heavy live runs only fire for release-please PRs or a manual
+# dispatch, and every credential step is gated to same-repo events so untrusted
+# forks never reach it. Not a required status check.
 on:
   # Include `labeled` (on top of the opened/synchronize/reopened defaults) so the
   # `autorelease: pending` fallback in the detect job actually fires when that
@@ -51,13 +57,62 @@ jobs:
             echo "Not a release-please PR - skipping the live LLM smoke."
           fi
 
-  vertex-smoke:
-    name: Vertex/Gemini no-tool smoke
+  plan:
+    name: Plan provider matrix
     needs: detect
-    # Run only when relevant AND either a manual dispatch (no PR context) or a
-    # same-repo PR. A fork PR must never reach the WIF/OIDC credential step.
+    if: needs.detect.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    # No credentials and no id-token here: this job only reads the checked-in
+    # manifest with jq, so it is fork-safe on its own. The fork-trust boundary is
+    # enforced on the smoke jobs, which are the only ones that mint credentials.
+    outputs:
+      gcp_matrix: ${{ steps.build.outputs.gcp_matrix }}
+      gcp_has: ${{ steps.build.outputs.gcp_has }}
+      aws_matrix: ${{ steps.build.outputs.aws_matrix }}
+      aws_has: ${{ steps.build.outputs.aws_has }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build per-family matrices from the manifest
+        id: build
+        env:
+          MANIFEST: .github/live-llm-manifest.json
+        run: |
+          # Project only the operational fields each smoke job reads into the matrix
+          # (never `note` or `enabled`). One compact single-line JSON per family (the
+          # name=value GITHUB_OUTPUT contract); a `*_has` boolean guards the
+          # empty-matrix hard-error (a fromJSON matrix with zero entries fails
+          # strategy evaluation instead of skipping).
+          gcp="$(jq -c '{include: [.[] | select(.enabled and .auth == "gcp-wif") | {id, provider, suite, model_var, required, require_no_connectors}]}' "$MANIFEST")"
+          aws="$(jq -c '{include: [.[] | select(.enabled and .auth == "aws-oidc") | {id, provider, suite, model_var, role_var, required, require_no_connectors}]}' "$MANIFEST")"
+          enabled_n="$(jq '[.[] | select(.enabled)] | length' "$MANIFEST")"
+          gcp_n="$(jq '[.[] | select(.enabled and .auth == "gcp-wif")] | length' "$MANIFEST")"
+          aws_n="$(jq '[.[] | select(.enabled and .auth == "aws-oidc")] | length' "$MANIFEST")"
+          # Fail closed: every enabled row must belong to a known auth family, so an
+          # enabled row with an unknown/typo'd auth turns this job red instead of
+          # silently vanishing from every matrix (the Go validator is the merge-time
+          # guard; this is the run-time backstop for a dispatch on unmerged code).
+          if [ "$enabled_n" -ne "$((gcp_n + aws_n))" ]; then
+            echo "::error::$enabled_n enabled rows but only $gcp_n gcp-wif + $aws_n aws-oidc; an enabled row has an unknown auth." >&2
+            exit 1
+          fi
+          {
+            printf 'gcp_matrix=%s\n' "$gcp"
+            printf 'aws_matrix=%s\n' "$aws"
+            printf 'gcp_has=%s\n' "$([ "$gcp_n" -gt 0 ] && echo true || echo false)"
+            printf 'aws_has=%s\n' "$([ "$aws_n" -gt 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+          printf 'enabled: %s | gcp rows: %s | aws rows: %s\n' "$enabled_n" "$gcp_n" "$aws_n"
+
+  gcp-smoke:
+    name: Live LLM / ${{ matrix.id }}
+    needs: [detect, plan]
+    # Run only when relevant, there is at least one enabled gcp-wif row, AND either
+    # a manual dispatch (no PR context) or a same-repo PR. A fork PR must never
+    # reach the WIF credential step. The job-level `if:` references only
+    # github.event / needs, the contexts available to it (matrix and secrets are not).
     if: >-
       needs.detect.outputs.relevant == 'true' &&
+      needs.plan.outputs.gcp_has == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
@@ -65,17 +120,45 @@ jobs:
     permissions:
       contents: read
       id-token: write # mint the OIDC token for Workload Identity Federation
+    strategy:
+      fail-fast: false # one provider's failure must not cancel the others
+      max-parallel: 4 # bound simultaneous live token spend as the matrix grows
+      matrix: ${{ fromJSON(needs.plan.outputs.gcp_matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Resolve the model variable before minting credentials: a required row with an
+      # unset model fails here (loud, no wasted credential mint); an optional row with
+      # an unset model skips the credentialed steps (run=false) so it never
+      # authenticates. Matrix values (model_var, required) go through env, never into
+      # the run script text.
+      - name: Resolve model
+        id: model
+        env:
+          MODEL: ${{ vars[matrix.model_var] }}
+          MODEL_VAR: ${{ matrix.model_var }}
+          REQUIRED: ${{ matrix.required }}
+        run: |
+          if [ -n "$MODEL" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$REQUIRED" = "true" ]; then
+            echo "::error::required row has unset model variable $MODEL_VAR" >&2
+            exit 1
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "optional row with no model configured ($MODEL_VAR unset); skipping"
+          fi
       - name: Report tested head SHA
         run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       # Keyless WIF into cynative-cli-ci. export_environment_variables:false keeps
       # GOOGLE_APPLICATION_CREDENTIALS out of the process env, so the gcp connector
       # stays dark; the minted credentials JSON is fed to cynative inline instead.
       - name: Authenticate to GCP (Workload Identity Federation)
+        if: steps.model.outputs.run == 'true'
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -84,133 +167,122 @@ jobs:
           service_account: ${{ vars.CYNATIVE_CLI_CI_SA }}
           create_credentials_file: true
           export_environment_variables: false
-      - name: Run the Vertex/Gemini no-tool smoke
+      - name: Run the smoke
+        if: steps.model.outputs.run == 'true'
         env:
-          CYNATIVE_LLM_PROVIDER: vertex
-          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_VERTEX_MODEL }}
+          CYNATIVE_LLM_PROVIDER: ${{ matrix.provider }}
+          CYNATIVE_LLM_MODEL: ${{ vars[matrix.model_var] }}
           CYNATIVE_LLM_VERTEX_PROJECT_ID: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
           CYNATIVE_LLM_VERTEX_REGION: ${{ vars.CYNATIVE_CLI_CI_VERTEX_REGION }}
-          SMOKE_REQUIRE_NO_CONNECTORS: "1"
-          # Missing/renamed provider vars must fail the job, never silently skip.
-          SMOKE_REQUIRE_RUN: "1"
+          # required -> hard-fail on an unset/renamed model var (never a silent skip);
+          # require_no_connectors -> hard-fail unless the runner stays connector-dark.
+          SMOKE_REQUIRE_RUN: ${{ matrix.required && '1' || '' }}
+          SMOKE_REQUIRE_NO_CONNECTORS: ${{ matrix.require_no_connectors && '1' || '' }}
+          SUITE: ${{ matrix.suite }}
           CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
+        # Literal suite dispatch (fail-closed): the suite is a validated enum, but a
+        # `make ${{ matrix.suite }}` would interpolate a matrix value into the run
+        # script; this keeps the target selection a literal case.
         run: |
-          CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-smoke
+          creds="$(cat "$CREDS_FILE")"
+          export CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$creds"
+          case "$SUITE" in
+            llm-smoke) make llm-smoke ;;
+            llm-tools-smoke) make llm-tools-smoke ;;
+            *) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;
+          esac
 
-  vertex-tools-smoke:
-    name: Vertex/Gemini code_execution smoke
-    needs: detect
-    # Same gating and trust boundary as vertex-smoke: relevant, and a manual
-    # dispatch or same-repo PR only. A fork PR must never reach the credential step.
+  aws-smoke:
+    name: Live LLM / ${{ matrix.id }}
+    needs: [detect, plan]
+    # Same gating and trust boundary as gcp-smoke. A fork PR must never reach the
+    # AWS OIDC step (the same-repo head check is what excludes forks, not the role's
+    # trust policy).
     if: >-
       needs.detect.outputs.relevant == 'true' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write # mint the OIDC token for Workload Identity Federation
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Report tested head SHA
-        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-      # Keyless WIF into cynative-cli-ci. export_environment_variables:false keeps
-      # GOOGLE_APPLICATION_CREDENTIALS out of the process env, so the gcp connector
-      # stays dark; the minted credentials JSON is fed to cynative inline instead.
-      - name: Authenticate to GCP (Workload Identity Federation)
-        id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          project_id: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
-          workload_identity_provider: ${{ vars.CYNATIVE_CLI_CI_WIF_PROVIDER }}
-          service_account: ${{ vars.CYNATIVE_CLI_CI_SA }}
-          create_credentials_file: true
-          export_environment_variables: false
-      - name: Run the Vertex/Gemini code_execution smoke
-        env:
-          CYNATIVE_LLM_PROVIDER: vertex
-          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_VERTEX_MODEL }}
-          CYNATIVE_LLM_VERTEX_PROJECT_ID: ${{ vars.CYNATIVE_CLI_CI_PROJECT }}
-          CYNATIVE_LLM_VERTEX_REGION: ${{ vars.CYNATIVE_CLI_CI_VERTEX_REGION }}
-          # No SMOKE_REQUIRE_NO_CONNECTORS here: this smoke asserts a code_execution
-          # tool call, not the connector set (inline creds keep the runner dark anyway).
-          # Missing/renamed provider vars must fail the job, never silently skip.
-          SMOKE_REQUIRE_RUN: "1"
-          CREDS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
-        run: |
-          CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS="$(cat "$CREDS_FILE")" make llm-tools-smoke
-
-  bedrock-smoke:
-    name: Bedrock no-tool smoke
-    needs: detect
-    # Same gating and trust boundary as the Vertex jobs: relevant, and a manual
-    # dispatch or same-repo PR only. A fork PR must never reach the AWS OIDC step
-    # (the same-repo head check is what excludes forks, not the role's trust
-    # policy). The job always starts for a relevant same-repo PR or a dispatch; the
-    # preflight step below is the single guard that fails loud when the AWS role
-    # variable is unset - so a broken or renamed CYNATIVE_CLI_CI_AWS_ROLE surfaces
-    # as a red check on release-please PRs too, never a silent skip that greens CI
-    # without exercising the live Bedrock path.
-    if: >-
-      needs.detect.outputs.relevant == 'true' &&
+      needs.plan.outputs.aws_has == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     # Bind to the aws-ci GitHub Environment so the OIDC subject is the stable
-    # repo:cynative/cynative:environment:aws-ci regardless of branch or event.
-    # The AWS role's trust policy pins that one subject, so a manual dispatch from
-    # any branch (e.g. to vet a risky PR) needs no per-branch trust-policy change,
-    # and the environment can carry a required-reviewer gate before creds are minted.
+    # repo:cynative/cynative:environment:aws-ci regardless of branch or event. The
+    # AWS role's trust policy pins that one subject, so a manual dispatch from any
+    # branch needs no per-branch trust-policy change, and the environment can carry a
+    # required-reviewer gate before creds are minted. A static literal (not a matrix
+    # expression), so the OIDC subject can never drift.
     environment: aws-ci
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
       id-token: write # mint the OIDC token for the AWS role assumption
+    strategy:
+      fail-fast: false # one provider's failure must not cancel the others
+      max-parallel: 4 # bound simultaneous live token spend as the matrix grows
+      matrix: ${{ fromJSON(needs.plan.outputs.aws_matrix) }}
     steps:
-      # Fail loud when the AWS role variable is unset (unprovisioned, renamed, or
-      # deleted), for both a dispatch and a relevant same-repo PR - so a broken
-      # variable can never green CI by skipping the live Bedrock path.
-      - name: Preflight - AWS role variable must be set
+      # Resolve the model before minting credentials (see gcp-smoke). A required row
+      # with an unset model fails here; an optional row with an unset model skips the
+      # credentialed steps.
+      - name: Resolve model
+        id: model
         env:
-          AWS_ROLE: ${{ vars.CYNATIVE_CLI_CI_AWS_ROLE }}
+          MODEL: ${{ vars[matrix.model_var] }}
+          MODEL_VAR: ${{ matrix.model_var }}
+          REQUIRED: ${{ matrix.required }}
+        run: |
+          if [ -n "$MODEL" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$REQUIRED" = "true" ]; then
+            echo "::error::required row has unset model variable $MODEL_VAR" >&2
+            exit 1
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "optional row with no model configured ($MODEL_VAR unset); skipping"
+          fi
+      # Fail loud when the row's AWS role variable is unset (unprovisioned, renamed,
+      # or deleted), so a broken variable can never green CI by skipping the live
+      # Bedrock path; configure-aws-credentials' own error is otherwise opaque.
+      - name: Preflight - AWS role variable must be set
+        if: steps.model.outputs.run == 'true'
+        env:
+          AWS_ROLE: ${{ vars[matrix.role_var] }}
+          ROLE_VAR: ${{ matrix.role_var }}
         run: |
           if [ -z "$AWS_ROLE" ]; then
-            echo "::error::CYNATIVE_CLI_CI_AWS_ROLE is not set. Provision the AWS OIDC role and the Bedrock repo variables before running the Bedrock smoke." >&2
+            echo "::error::AWS role variable $ROLE_VAR is not set. Provision the AWS OIDC role variable before running the Bedrock smoke." >&2
             exit 1
           fi
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Report tested head SHA
         run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      # Keyless GitHub OIDC into the CI AWS account, no long-lived key. Like the
-      # Vertex jobs, the assumed creds are fed to the provider inline (below) and kept
-      # out of the process env, so cynative's `aws` connector's default credential
-      # chain finds nothing and stays dark - this is a genuinely no-tool, no-connector
-      # smoke (SMOKE_REQUIRE_NO_CONNECTORS=1 below hard-fails on any connector,
-      # catching CI role/credential drift before anything reaches the tool loop). The
-      # CI role also carries SecurityAudit (read-only) for the AWS connector e2e,
-      # which drives the connector via the ambient chain instead.
+      # Keyless GitHub OIDC into the CI AWS account, no long-lived key. Like the gcp
+      # job, the assumed creds are fed to the provider inline (below) and kept out of
+      # the process env, so cynative's `aws` connector's default credential chain
+      # finds nothing and stays dark - a genuinely no-tool, no-connector smoke
+      # (SMOKE_REQUIRE_NO_CONNECTORS below hard-fails on any connector, catching CI
+      # role/credential drift before anything reaches the tool loop).
       - name: Authenticate to AWS (GitHub OIDC)
+        if: steps.model.outputs.run == 'true'
         id: aws
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
-          role-to-assume: ${{ vars.CYNATIVE_CLI_CI_AWS_ROLE }}
+          role-to-assume: ${{ vars[matrix.role_var] }}
           aws-region: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_REGION }}
-          role-session-name: cynative-bedrock-smoke
+          role-session-name: cynative-live-llm-smoke
           # Expose the assumed creds as step outputs only, not AWS_* env vars, so the
           # aws connector cannot discover them (they go to Bedrock inline below).
           output-env-credentials: false
           output-credentials: true
-      - name: Run the Bedrock no-tool smoke
+      - name: Run the smoke
+        if: steps.model.outputs.run == 'true'
         env:
-          CYNATIVE_LLM_PROVIDER: bedrock
-          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_MODEL }}
+          CYNATIVE_LLM_PROVIDER: ${{ matrix.provider }}
+          CYNATIVE_LLM_MODEL: ${{ vars[matrix.model_var] }}
           CYNATIVE_LLM_BEDROCK_REGION: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_REGION }}
           # Feed the assumed creds to Bedrock inline (not via AWS_*): Bifrost's bedrock
           # provider uses these explicit keys and only falls back to the AWS default
@@ -219,8 +291,15 @@ jobs:
           CYNATIVE_LLM_BEDROCK_ACCESS_KEY: ${{ steps.aws.outputs.aws-access-key-id }}
           CYNATIVE_LLM_BEDROCK_SECRET_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
           CYNATIVE_LLM_BEDROCK_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
-          # Clean runner has no ambient connector creds, so require the dark state.
-          SMOKE_REQUIRE_NO_CONNECTORS: "1"
-          # Missing/renamed provider vars must fail the job, never silently skip.
-          SMOKE_REQUIRE_RUN: "1"
-        run: make llm-smoke
+          # required -> hard-fail on an unset/renamed model var (never a silent skip);
+          # require_no_connectors -> hard-fail unless the runner stays connector-dark.
+          SMOKE_REQUIRE_RUN: ${{ matrix.required && '1' || '' }}
+          SMOKE_REQUIRE_NO_CONNECTORS: ${{ matrix.require_no_connectors && '1' || '' }}
+          SUITE: ${{ matrix.suite }}
+        # Literal suite dispatch (fail-closed); see gcp-smoke.
+        run: |
+          case "$SUITE" in
+            llm-smoke) make llm-smoke ;;
+            llm-tools-smoke) make llm-tools-smoke ;;
+            *) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -650,6 +650,16 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   `install.ps1` floor), hermetic via a stubbed `gh` and a loopback fixture server. None is a
   required status check, so they gate release-please PRs and on-demand runs, never normal
   merges.
+- `.github/workflows/llm-smoke.yaml` runs the live LLM smoke against real providers for release
+  confidence, driven by the checked-in manifest `.github/live-llm-manifest.json`: each enabled
+  row (a provider x suite pair, carrying the model variable, required-or-optional, and auth
+  family) becomes one matrix job, so adding or disabling a same-auth-family provider is a manifest
+  edit, not a workflow change. A `plan` job splits the manifest into per-family matrices; a
+  `gcp-smoke` job (Vertex via Workload Identity Federation) and an `aws-smoke` job (Bedrock via
+  GitHub OIDC under a static `environment: aws-ci`) consume them. Same `detect` gating and
+  fork-trust boundary as `install-e2e.yaml`, and `internal/llm/livellm_manifest_test.go` validates
+  the manifest fail-closed under `Lint & Test`, so a malformed row blocks merge. A new auth family
+  is the one case that adds a job. Not a required status check.
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
   version bump, enforced by `semantic-pr.yaml`. `.goreleaser.yaml` handles binary builds for

--- a/internal/llm/livellm_manifest_test.go
+++ b/internal/llm/livellm_manifest_test.go
@@ -1,0 +1,347 @@
+package llm_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cynative/cynative/internal/llm"
+)
+
+// The live-LLM manifest is the single source of truth for which providers the
+// release-confidence "Live LLM smoke" workflow runs (cynative#50). The workflow
+// (.github/workflows/llm-smoke.yaml) turns each enabled row into one matrix job,
+// so a malformed row would either silently drop a provider from release coverage
+// or break the run. This test is the fail-closed guard: it rides `make test` ->
+// the required `Lint & Test` check and the pre-commit `make check-go`, so a bad
+// manifest blocks merge rather than surfacing as a red live run later.
+//
+// The validator lives here (test-only) rather than in shipped code: nothing in
+// the cynative binary reads this manifest, so keeping it out of the production
+// packages avoids dead surface and the 100% coverage gate while still proving the
+// schema fail-closed against crafted-bad inputs below.
+
+// liveLLMRow mirrors one manifest entry. The three flags are *bool so a MISSING
+// flag is distinguishable from false (DisallowUnknownFields rejects unknown keys,
+// but a decoder leaves an absent known key at its zero value); the validator
+// requires all three to be present.
+type liveLLMRow struct {
+	ID                  string `json:"id"`
+	Enabled             *bool  `json:"enabled"`
+	Provider            string `json:"provider"`
+	Auth                string `json:"auth"`
+	Suite               string `json:"suite"`
+	ModelVar            string `json:"model_var"`
+	RoleVar             string `json:"role_var"`
+	Required            *bool  `json:"required"`
+	RequireNoConnectors *bool  `json:"require_no_connectors"`
+	Note                string `json:"note"`
+}
+
+const (
+	authGCPWIF  = "gcp-wif"
+	authAWSOIDC = "aws-oidc"
+	suiteNoTool = "llm-smoke"
+	suiteTools  = "llm-tools-smoke"
+	// maxRows is a deliberately small cap on live legs (each is a real,
+	// credit-spending provider run), far under GitHub's 256-job matrix limit.
+	maxRows    = 16
+	maxIDLen   = 40
+	maxNoteLen = 200
+)
+
+// providerAuthAdapter pins each provider to the one credential+env-wiring adapter
+// the workflow implements for it: gcp-wif exports only CYNATIVE_LLM_VERTEX_*,
+// aws-oidc only CYNATIVE_LLM_BEDROCK_*. Membership in llm.ChatProviders() means
+// "chat-capable", not "wired for CI", so a row's (provider, auth) pair must be one
+// of these adapters. A genuinely new provider needs a new adapter (a workflow
+// job), which is the deliberate non-data case; a same-adapter model (another
+// Vertex or Bedrock model id) is a pure manifest edit.
+var providerAuthAdapter = map[string]string{ //nolint:gochecknoglobals // stateless test data table.
+	"vertex":  authGCPWIF,
+	"bedrock": authAWSOIDC,
+}
+
+// idPattern and varNamePattern pin the manifest's identifier and variable-name
+// shapes. varNamePattern (plus the GITHUB_ guard) matters because a mis-named
+// ${{ vars[...] }} silently resolves to "" in Actions rather than erroring, so a
+// typo that slips past charset would go unnoticed at run time.
+var (
+	idPattern      = regexp.MustCompile(`^[a-z0-9-]+$`)
+	varNamePattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+)
+
+// validateLiveLLMManifest parses and fully validates the manifest bytes,
+// fail-closed: any unknown field, missing flag, unknown enum value, bad
+// identifier, or auth/role mismatch is an error. validProviders is the set the
+// `provider` field must belong to (the real llm.ChatProviders() catalog for the
+// checked-in file; a fixed set for the negative table).
+func validateLiveLLMManifest(data []byte, validProviders map[string]bool) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var rows []liveLLMRow
+	if err := dec.Decode(&rows); err != nil {
+		return fmt.Errorf("decode manifest: %w", err)
+	}
+	// Reject trailing tokens after the top-level array (strict single-value): a
+	// well-formed manifest decodes to exactly one array, so Token() must hit EOF.
+	if _, terr := dec.Token(); !errors.Is(terr, io.EOF) {
+		return errors.New("unexpected trailing data after the manifest array")
+	}
+
+	if len(rows) == 0 {
+		return errors.New("manifest has no rows")
+	}
+	if len(rows) > maxRows {
+		return fmt.Errorf("manifest has %d rows, exceeding the cap of %d", len(rows), maxRows)
+	}
+
+	seen := make(map[string]bool, len(rows))
+	for i, r := range rows {
+		if err := validateRow(i, r, seen, validProviders); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateRow validates one manifest entry and records its id in seen (so the
+// caller detects duplicates). Split out of validateLiveLLMManifest to keep both
+// functions under the cognitive-complexity budget.
+func validateRow(i int, r liveLLMRow, seen map[string]bool, validProviders map[string]bool) error {
+	if !idPattern.MatchString(r.ID) || len(r.ID) > maxIDLen {
+		return fmt.Errorf("row %d: id %q must match %s and be <= %d chars", i, r.ID, idPattern, maxIDLen)
+	}
+	if seen[r.ID] {
+		return fmt.Errorf("row %d: duplicate id %q", i, r.ID)
+	}
+	seen[r.ID] = true
+
+	if r.Enabled == nil {
+		return fmt.Errorf("row %q: enabled is required", r.ID)
+	}
+	if r.Required == nil {
+		return fmt.Errorf("row %q: required is required", r.ID)
+	}
+	if r.RequireNoConnectors == nil {
+		return fmt.Errorf("row %q: require_no_connectors is required", r.ID)
+	}
+	if len(r.Note) > maxNoteLen {
+		return fmt.Errorf("row %q: note is %d chars, exceeding %d", r.ID, len(r.Note), maxNoteLen)
+	}
+
+	if err := validateRowEnums(r, validProviders); err != nil {
+		return err
+	}
+	if err := validateVarName("model_var", r.ID, r.ModelVar); err != nil {
+		return err
+	}
+	return validateRoleVar(r)
+}
+
+// validateRowEnums checks the closed-set fields and their cross-field invariants:
+// the provider is chat-capable and its (provider, auth) pair is a wired adapter,
+// the suite is a real make target, and require_no_connectors is not set on the
+// tools suite (which never reads it, so true there is a silent no-op footgun).
+func validateRowEnums(r liveLLMRow, validProviders map[string]bool) error {
+	if !validProviders[r.Provider] {
+		return fmt.Errorf("row %q: provider %q is not a known chat provider", r.ID, r.Provider)
+	}
+	if r.Auth != authGCPWIF && r.Auth != authAWSOIDC {
+		return fmt.Errorf("row %q: auth %q must be %q or %q", r.ID, r.Auth, authGCPWIF, authAWSOIDC)
+	}
+	if providerAuthAdapter[r.Provider] != r.Auth {
+		return fmt.Errorf("row %q: provider %q is wired for auth %q, not %q",
+			r.ID, r.Provider, providerAuthAdapter[r.Provider], r.Auth)
+	}
+	if r.Suite != suiteNoTool && r.Suite != suiteTools {
+		return fmt.Errorf("row %q: suite %q must be %q or %q", r.ID, r.Suite, suiteNoTool, suiteTools)
+	}
+	if r.Suite == suiteTools && *r.RequireNoConnectors {
+		return fmt.Errorf("row %q: require_no_connectors must be false for the %q suite", r.ID, suiteTools)
+	}
+	return nil
+}
+
+// validateRoleVar enforces that role_var is present and valid exactly for the
+// aws-oidc family (which needs a role ARN to assume); gcp-wif must not carry one.
+func validateRoleVar(r liveLLMRow) error {
+	switch r.Auth {
+	case authAWSOIDC:
+		return validateVarName("role_var", r.ID, r.RoleVar)
+	case authGCPWIF:
+		if r.RoleVar != "" {
+			return fmt.Errorf("row %q: gcp-wif must not set role_var (got %q)", r.ID, r.RoleVar)
+		}
+	}
+	return nil
+}
+
+// validateVarName enforces the GitHub-variable-name shape and rejects the
+// reserved GITHUB_ prefix (Actions forbids setting GITHUB_*-named variables, so
+// such a name could never resolve).
+func validateVarName(field, id, name string) error {
+	if !varNamePattern.MatchString(name) {
+		return fmt.Errorf("row %q: %s %q must match %s", id, field, name, varNamePattern)
+	}
+	if strings.HasPrefix(name, "GITHUB_") {
+		return fmt.Errorf("row %q: %s %q must not use the reserved GITHUB_ prefix", id, field, name)
+	}
+	return nil
+}
+
+// manifestPath resolves .github/live-llm-manifest.json from this test file's
+// location, so `go test` works regardless of the invoking directory (mirrors
+// providersdocs_test.go).
+func manifestPath(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// internal/llm/livellm_manifest_test.go -> repo root is two dirs up.
+	root := filepath.Join(filepath.Dir(file), "..", "..")
+	return filepath.Join(root, ".github", "live-llm-manifest.json")
+}
+
+// chatProviderSet is the real chat-provider catalog as a lookup set, so the
+// manifest's provider ids stay pinned to what cynative can actually run.
+func chatProviderSet() map[string]bool {
+	m := make(map[string]bool)
+	for _, p := range llm.ChatProviders() {
+		m[string(p)] = true
+	}
+	return m
+}
+
+func TestLiveLLMManifest_CheckedInFileValidates(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(manifestPath(t))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if verr := validateLiveLLMManifest(data, chatProviderSet()); verr != nil {
+		t.Fatalf("checked-in manifest is invalid: %v", verr)
+	}
+
+	var rows []liveLLMRow
+	if uerr := json.Unmarshal(data, &rows); uerr != nil {
+		t.Fatalf("unmarshal manifest: %v", uerr)
+	}
+
+	// Golden: the Vertex + Bedrock starters are still present (guards against an
+	// accidental deletion that would silently drop release coverage), and both
+	// auth families are exercised (so the two-family workflow keeps both jobs live).
+	ids := make(map[string]bool, len(rows))
+	auths := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		ids[r.ID] = true
+		auths[r.Auth] = true
+	}
+	for _, want := range []string{"vertex-notool", "vertex-tools", "bedrock-notool"} {
+		if !ids[want] {
+			t.Errorf("manifest is missing starter row %q", want)
+		}
+	}
+	for _, want := range []string{authGCPWIF, authAWSOIDC} {
+		if !auths[want] {
+			t.Errorf("manifest has no %q row; both auth families must stay covered", want)
+		}
+	}
+}
+
+func TestLiveLLMManifest_AcceptsValid(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]bool{"vertex": true, "bedrock": true}
+	valid := `[
+	  {"id":"vertex-notool","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_VERTEX_MODEL","required":true,"require_no_connectors":true,"note":"ok"},
+	  {"id":"bedrock-notool","enabled":true,"provider":"bedrock","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_BEDROCK_MODEL","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":false,"require_no_connectors":true}
+	]`
+	if err := validateLiveLLMManifest([]byte(valid), providers); err != nil {
+		t.Fatalf("expected valid manifest to pass, got: %v", err)
+	}
+}
+
+func TestLiveLLMManifest_RejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]bool{"vertex": true, "bedrock": true}
+	// Each case is a full manifest that must be rejected for exactly one reason.
+	cases := map[string]string{
+		"unknown field": `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true,"bogus":1}]`,
+		"trailing data": `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}] junk`,
+		"empty array":   `[]`,
+		"not an array":  `{"id":"a"}`,
+		"bad id":        `[{"id":"Bad_ID","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"duplicate id": `[
+		  {"id":"dup","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true},
+		  {"id":"dup","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-tools-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}
+		]`,
+		"unknown provider":     `[{"id":"a","enabled":true,"provider":"nope","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"bad auth":             `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"uppercased auth":      `[{"id":"a","enabled":true,"provider":"vertex","auth":"GCP-WIF","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"bad suite":            `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-run","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"lowercase model_var":  `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"cynative_model","required":true,"require_no_connectors":true}]`,
+		"github model_var":     `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"GITHUB_MODEL","required":true,"require_no_connectors":true}]`,
+		"aws missing role_var": `[{"id":"a","enabled":true,"provider":"bedrock","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"gcp with role_var":    `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":true,"require_no_connectors":true}]`,
+		"missing enabled":      `[{"id":"a","provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"missing required":     `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","require_no_connectors":true}]`,
+		"missing rnc":          `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true}]`,
+		"null required":        `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":null,"require_no_connectors":true}]`,
+		"null manifest":        `null`,
+		"long id":              `[{"id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		// provider is chat-capable but its (provider, auth) pair is not a wired adapter.
+		"vertex with aws auth":  `[{"id":"a","enabled":true,"provider":"vertex","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":true,"require_no_connectors":true}]`,
+		"bedrock with gcp auth": `[{"id":"a","enabled":true,"provider":"bedrock","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		// require_no_connectors is a silent no-op on the tools suite, so true is rejected.
+		"tools with require_no_connectors": `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-tools-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateLiveLLMManifest([]byte(body), providers); err == nil {
+				t.Errorf("expected rejection for %q, got nil", name)
+			}
+		})
+	}
+}
+
+func TestLiveLLMManifest_RejectsBounds(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]bool{"vertex": true, "bedrock": true}
+	row := func(id string) string {
+		return fmt.Sprintf(`{"id":%q,"enabled":true,"provider":"vertex","auth":"gcp-wif",`+
+			`"suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}`, id)
+	}
+
+	// More than maxRows enabled rows is rejected (bounds live token cost).
+	rows := make([]string, 0, maxRows+1)
+	for i := 0; i <= maxRows; i++ {
+		rows = append(rows, row(fmt.Sprintf("row-%d", i)))
+	}
+	tooMany := "[" + strings.Join(rows, ",") + "]"
+	if err := validateLiveLLMManifest([]byte(tooMany), providers); err == nil {
+		t.Errorf("expected rejection of %d rows (cap %d), got nil", maxRows+1, maxRows)
+	}
+
+	// A note longer than maxNoteLen is rejected.
+	longNote := fmt.Sprintf(`[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke",`+
+		`"model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true,"note":%q}]`,
+		strings.Repeat("x", maxNoteLen+1))
+	if err := validateLiveLLMManifest([]byte(longNote), providers); err == nil {
+		t.Errorf("expected rejection of an over-length note, got nil")
+	}
+}


### PR DESCRIPTION
## What & why

The live LLM smoke workflow hardcoded three near-identical jobs (Vertex no-tool, Vertex
`code_execution`, Bedrock no-tool). Adding or disabling a provider meant editing workflow logic.
This makes a checked-in manifest the single source of truth for the live LLM matrix, so that
becomes a data edit instead. Closes #50.

- `.github/live-llm-manifest.json`: one row per provider x suite, carrying the provider id, model
  variable, suite, required-or-optional, and auth family.
- `.github/workflows/llm-smoke.yaml`: a `plan` job splits the manifest into two per-family
  matrices; a `gcp-smoke` job (Vertex via Workload Identity Federation) and an `aws-smoke` job
  (Bedrock via GitHub OIDC under a static `environment: aws-ci`) consume them. Credential mechanics
  differ per family and can't be data, so each auth family is one job; a new auth family is the one
  deliberate case that adds a job. Adding or disabling a same-family provider is a one-row manifest
  edit.
- `internal/llm/livellm_manifest_test.go`: validates the manifest fail-closed under the `Lint &
  Test` check (closed enums, provider-to-auth adapter pinning, variable-name shapes, cross-field
  invariants, bounds, unique ids). The `plan` job also reconciles enabled-row counts, so an unknown
  auth fails the run instead of silently dropping a provider.

Safety is preserved one-to-one with the old jobs: the same `detect` gating and same-repo
fork-trust boundary, per-provider job isolation (`fail-fast: false`, per-job timeout),
required-vs-optional fail-loud/skip, credential isolation (`export_environment_variables: false` /
`output-env-credentials: false`), and the `aws-ci` OIDC gate (now a static literal so the subject
can't drift). Matrix values are kept out of `run:` scripts (literal suite dispatch), and an early
model preflight fails required rows before minting credentials.

Note: the per-provider check-run names change from the old static job names to `Live LLM / <id>`.
`llm-smoke.yaml` is not a required status check, so no branch protection is affected; external
dashboards keyed on the old names would need updating.

Validated end to end by a manual `workflow_dispatch` run on this branch: all legs green, including
the Bedrock leg authenticating through `environment: aws-ci`.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed
