### PR TITLE
test: add a live AWS fixture-account connector e2e

### DIFF
--- a/.github/workflows/connector-aws-e2e.yaml
+++ b/.github/workflows/connector-aws-e2e.yaml
@@ -1,0 +1,134 @@
+name: Live AWS connector e2e
+
+# Runs the real `cynative -p` against the dedicated CI AWS account through the aws
+# connector (cynative#52): a read of an inert fixture IAM role's tag plus a write-deny
+# canary, proving read-only enforcement end to end. Mirrors connector-gcp-e2e.yaml's
+# detect gating so the heavy live run only fires for release-please PRs or a manual
+# dispatch. Authenticates via keyless GitHub OIDC under a static `environment: aws-ci`
+# (the stable OIDC subject the AWS role trusts, so a maintainer can dispatch this from
+# any branch with no per-branch AWS trust edits); the credential step is gated to
+# same-repo events so untrusted forks never reach it. Not a required status check.
+#
+# Credential wiring is the INVERSE of llm-smoke.yaml's bedrock job. That job sets
+# output-env-credentials: false precisely so AWS_* never enters the env and the aws
+# connector stays dark. Here AWS_* IS exported, on purpose, so the connector registers
+# and the run has something to gate. Bedrock still gets its own credentials inline via
+# CYNATIVE_LLM_BEDROCK_*, so the model path never rides the connector's scoped chain.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A stale synchronize event must not multiply live-run spend.
+concurrency:
+  group: connector-aws-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect release-please PR
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Detect release-please PR
+        id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          relevant=false
+          [ "${EVENT}" = "workflow_dispatch" ] && relevant=true
+          [ "${HEAD_REF}" = "release-please--branches--main" ] && relevant=true
+          case ",${LABELS}," in *",autorelease: pending,"*) relevant=true ;; esac
+          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
+          if [ "${relevant}" = "true" ]; then
+            echo "Release-please PR or manual dispatch - running the live AWS connector e2e."
+          else
+            echo "Not a release-please PR - skipping the live AWS connector e2e."
+          fi
+
+  aws-connector:
+    name: AWS connector read + canary
+    needs: detect
+    # Run only when relevant AND either a manual dispatch (no PR context) or a same-repo
+    # PR. A fork PR must never reach the OIDC credential step.
+    if: >-
+      needs.detect.outputs.relevant == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    # Headroom for two phases, each retried once, at the per-phase timeout below.
+    timeout-minutes: 25
+    # Static, so the OIDC subject stays repo:cynative/cynative:environment:aws-ci
+    # regardless of branch or event.
+    environment: aws-ci
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token for the AWS role assumption
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Report tested head SHA
+        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      # Fail loudly on a missing or renamed variable: configure-aws-credentials' own
+      # error is otherwise opaque, and the suite must never go green by skipping.
+      - name: Preflight the required repo variables
+        env:
+          ROLE: ${{ vars.CYNATIVE_CLI_CI_AWS_ROLE }}
+          REGION: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_REGION }}
+          MODEL: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_MODEL }}
+          ROLE_NAME: ${{ vars.AWS_E2E_ROLE_NAME }}
+          EXPECT: ${{ vars.AWS_E2E_EXPECT }}
+          ACCOUNT: ${{ vars.AWS_E2E_ACCOUNT }}
+        run: |
+          missing=
+          [ -n "${ROLE}" ]      || missing="${missing} CYNATIVE_CLI_CI_AWS_ROLE"
+          [ -n "${REGION}" ]    || missing="${missing} CYNATIVE_CLI_CI_BEDROCK_REGION"
+          [ -n "${MODEL}" ]     || missing="${missing} CYNATIVE_CLI_CI_BEDROCK_MODEL"
+          [ -n "${ROLE_NAME}" ] || missing="${missing} AWS_E2E_ROLE_NAME"
+          [ -n "${EXPECT}" ]    || missing="${missing} AWS_E2E_EXPECT"
+          [ -n "${ACCOUNT}" ]   || missing="${missing} AWS_E2E_ACCOUNT"
+          if [ -n "${missing}" ]; then
+            echo "FAIL: missing repo variables:${missing}"
+            exit 1
+          fi
+      # AWS_* IS exported downstream (unlike the bedrock smoke), so the aws connector
+      # registers. output-credentials also emits the three credential outputs, which
+      # feed Bedrock inline so the LLM path does not depend on the connector's chain.
+      - name: Authenticate to AWS (GitHub OIDC)
+        id: aws
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ vars.CYNATIVE_CLI_CI_AWS_ROLE }}
+          aws-region: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_REGION }}
+          output-credentials: true
+      - name: Run the AWS connector e2e
+        env:
+          CYNATIVE_LLM_PROVIDER: bedrock
+          CYNATIVE_LLM_MODEL: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_MODEL }}
+          CYNATIVE_LLM_BEDROCK_REGION: ${{ vars.CYNATIVE_CLI_CI_BEDROCK_REGION }}
+          CYNATIVE_LLM_BEDROCK_ACCESS_KEY: ${{ steps.aws.outputs.aws-access-key-id }}
+          CYNATIVE_LLM_BEDROCK_SECRET_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          CYNATIVE_LLM_BEDROCK_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          AWS_E2E_ROLE_NAME: ${{ vars.AWS_E2E_ROLE_NAME }}
+          AWS_E2E_EXPECT: ${{ vars.AWS_E2E_EXPECT }}
+          AWS_E2E_ACCOUNT: ${{ vars.AWS_E2E_ACCOUNT }}
+          # CI's principal is an assumed role, so cynative's credential scoping engages
+          # and the posture must read client+aws exactly. A degrade to `client` means the
+          # self-assume trust statement on the CI role is gone, and the run is only
+          # client-gated; the suite fails rather than quietly accepting that.
+          AWS_E2E_ENFORCED: client+aws
+          # A tool-driven run needs more than the no-tool defaults, and the first
+          # authorization cold-fetches the configured policy plus a Smithy model archive.
+          AWS_E2E_TIMEOUT: "240"
+          AWS_E2E_MAX_TOKENS: "100000"
+          # Missing or renamed vars must fail the job, never silently skip.
+          AWS_E2E_REQUIRE_RUN: "1"
+        run: make connector-aws-e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,9 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
 - `make check-scripts`: `shellcheck` (all tracked `*.sh`) + PSScriptAnalyzer on `install.ps1`,
   `test/install-script.smoke.test.ps1`, `test/scoop.smoke.test.ps1`, and
   `test/archive.smoke.test.ps1` + Pester unit tests +
-  `sh-test` (the POSIX `install.sh` unit tests plus a `python3`-backed loopback smoke
-  test of the `CYNATIVE_BASE_URL` download-base seam and its non-loopback-HTTP reject).
+  `sh-test` (the POSIX `install.sh` unit tests, a `python3`-backed loopback smoke
+  test of the `CYNATIVE_BASE_URL` download-base seam and its non-loopback-HTTP reject, the
+  live-e2e guardrails unit tests, and both connector suites' offline audit-parser selftests).
   Install-free: asserts each pinned tool or module is present and fails with an install hint
   otherwise (needs `shellcheck`, PowerShell 7, `python3`). The pinned
   shellcheck/Pester/PSScriptAnalyzer versions live in the `Makefile` and are bumped by hand;
@@ -59,7 +60,17 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
   GCP fixture project through the `gcp` connector (`test/connector.gcp.e2e.test.sh`, needs
   `python3`), asserting a read of the project's own Cloud Resource Manager metadata and a
   client-side-denied write canary, and skipping cleanly when `GCP_E2E_*`/creds are unset (the
-  script header documents its env and knobs). `make homebrew-smoke`: standalone post-release
+  script header documents its env and knobs). `make connector-aws-e2e`: standalone live AWS
+  connector e2e (not part of `make check`); runs the real `cynative -p` against a real AWS fixture
+  account through the `aws` connector (`test/connector.aws.e2e.test.sh`, needs `python3`),
+  asserting a read of an inert fixture IAM role's tag (the value arrives out of band and never
+  appears in the prompt, and the audit parser binds it to the bytes AWS returned) plus a
+  `TagRole` write canary denied before the request leaves the machine, and skipping cleanly when
+  `AWS_E2E_*`/creds are unset (the script header documents its env and knobs). Both connector
+  parsers carry an offline `--selftest` that `make sh-test` gates: the parser is what stops a
+  suite going green while the read-only boundary is broken, so its exit code is the phase status
+  (1 = retryable miss, 4 = boundary failure, never retried, since the per-attempt audit
+  truncation would erase the evidence). `make homebrew-smoke`: standalone post-release
   Homebrew install smoke (not part of `make check`); installs cynative from the public tap via the
   documented `brew install cynative/tap/cynative`, asserts `cynative --version` reports the expected
   release (`SMOKE_VERSION`, default: latest published), uninstalls, and asserts it is gone

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-go check-scripts lint format test generate shell-complexity \
 	windows-build shellcheck pwsh-lint pwsh-test sh-test snapshot install-e2e llm-smoke \
-	llm-tools-smoke connector-gcp-e2e homebrew-smoke install-script-smoke
+	llm-tools-smoke connector-gcp-e2e connector-aws-e2e homebrew-smoke install-script-smoke
 
 # Pinned external (non-Go) tool versions for check-scripts. Unlike the Go tools
 # (pinned via go.mod / `go tool`), these are NOT Dependabot-managed — Dependabot has
@@ -101,8 +101,11 @@ pwsh-test:
 	@command -v pwsh >/dev/null 2>&1 || { echo "FAIL: pwsh not found — install PowerShell 7 + Pester $(PESTER_VERSION)."; exit 1; }
 	pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester | Where-Object Version -eq "$(PESTER_VERSION)")) { Write-Host "FAIL: Pester $(PESTER_VERSION) not installed — run: Install-Module Pester -RequiredVersion $(PESTER_VERSION) -Scope CurrentUser -SkipPublisherCheck"; exit 1 }; Import-Module -Name Pester -RequiredVersion $(PESTER_VERSION) -Force -ErrorAction Stop; $$r = Invoke-Pester -Path test/install.unit.Tests.ps1 -Output Detailed -PassThru; if ($$r.FailedCount -gt 0) { exit 1 }'
 
-# sh-test: POSIX install.sh unit + loopback smoke tests, plus the live-e2e
-# guardrails library unit tests (test/lib/e2e-guardrails.sh, hermetic). Presence-
+# sh-test: POSIX install.sh unit + loopback smoke tests, the live-e2e guardrails
+# library unit tests (test/lib/e2e-guardrails.sh), and both connector suites'
+# offline audit-parser selftests (--selftest). All hermetic: no network, no
+# credentials. The parsers are the security boundary of the live connector e2es,
+# so they are gated here rather than only exercised on a live run. Presence-
 # check python3 (the smoke test's loopback fixture server) with an install hint,
 # mirroring the shellcheck/pwsh install-free pattern.
 sh-test:
@@ -110,7 +113,9 @@ sh-test:
 	@sh test/install.unit.test.sh
 	@sh test/install.smoke.test.sh
 	@sh test/e2e-guardrails.unit.test.sh
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit)"
+	@sh test/connector.gcp.e2e.test.sh --selftest
+	@sh test/connector.aws.e2e.test.sh --selftest
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector audit parsers)"
 
 SHELL_COMPLEXITY_MAX := 6
 
@@ -182,6 +187,13 @@ llm-tools-smoke:
 # GCP_E2E_* env is unset. The script header documents its env and knobs.
 connector-gcp-e2e:
 	sh test/connector.gcp.e2e.test.sh
+
+# connector-aws-e2e: live AWS connector end-to-end test (cynative#52). Standalone
+# (NOT part of `make check`): runs the real `cynative -p` against a real AWS fixture
+# account through the aws connector and needs real credentials; skips cleanly when
+# AWS_E2E_* env is unset. The script header documents its env and knobs.
+connector-aws-e2e:
+	sh test/connector.aws.e2e.test.sh
 
 # homebrew-smoke: post-release Homebrew install smoke (cynative#45). Standalone
 # (NOT part of `make check`): installs cynative from the public tap via the

--- a/test/connector.aws.e2e.test.sh
+++ b/test/connector.aws.e2e.test.sh
@@ -1,0 +1,750 @@
+#!/bin/sh
+# connector.aws.e2e.test.sh - live AWS connector end-to-end test (cynative#52).
+#
+# Runs the real `cynative -p` against a real AWS fixture account through the aws
+# connector and asserts, from a black-box run: the connector registers under the
+# read-only SecurityAudit policy, the model reads an inert fixture IAM role and
+# surfaces a tag value it could only have obtained from AWS, and a deliberate write
+# is denied client-side before it reaches the network.
+#
+# NOT hermetic and NOT part of `make check`: it talks to a real provider and a real
+# AWS account and needs real credentials. Skips (exit 0) when required env is unset,
+# so `make connector-aws-e2e` is a safe no-op.
+#
+# Usage: sh test/connector.aws.e2e.test.sh [BINARY]
+#        sh test/connector.aws.e2e.test.sh --selftest   (offline parser check)
+#
+# Env:
+#   CYNATIVE_LLM_PROVIDER, CYNATIVE_LLM_MODEL   required (drives the agent loop)
+#   ambient AWS_* / profile                     required (lights the aws connector)
+#   AWS_E2E_ROLE_NAME      fixture role name (appears in the prompt)
+#   AWS_E2E_EXPECT         fixture tag value (NEVER in the prompt)
+#   AWS_E2E_ACCOUNT        expected account id in the startup inventory
+#   AWS_E2E_ENFORCED       expected `enforced=` field: client+aws (an assumed-role
+#                          identity, e.g. CI, where credential scoping engages) or
+#                          client (an IAM-user profile, for which cynative never
+#                          attempts scoping)
+#   AWS_E2E_TIMEOUT        wall-clock seconds per run (default 240; the first
+#                          authorization cold-fetches the configured policy and a
+#                          Smithy model archive before any request is dispatched)
+#   AWS_E2E_MAX_TOKENS     token backstop (default 32000)
+#   AWS_E2E_CANARY         run the write-deny canary phase (default 1; 0 disables)
+#   AWS_E2E_ATTEMPTS       per-phase attempts (default 2; model runs are
+#                          non-deterministic, so one retry absorbs a rare miss)
+#   AWS_E2E_KEEP_WORKDIR   =1 keep the temp workdir (parser, audit logs, output) for
+#                          debugging instead of deleting it on exit
+#   AWS_E2E_REQUIRE_RUN    =1 hard-fail instead of skipping when required env is unset
+set -eu
+
+# write_parser writes the embedded python3 audit parser to $1.
+#
+# The parser is the security boundary of this suite, so it is deliberately paranoid.
+# Its exit codes feed the shared phase-status contract in test/lib/e2e-guardrails.sh:
+#
+#   0  the assertion holds.
+#   1  not proven this attempt (a model miss or a fumbled call the gate blocked).
+#      The caller may retry.
+#   4  SECURITY: a request that the read-only boundary should have stopped cannot be
+#      shown to have stayed on the machine. FATAL - the caller must never retry,
+#      because the audit log is truncated per attempt and a retry would erase the
+#      evidence, letting a broken gate pass on the second try.
+#
+# The load-bearing distinction is "did the request leave the machine". Every
+# `aws_hardening` error is raised by an auth gate, and all of those run before
+# httpClient.Do, so such an error PROVES the request was never dispatched. A failure
+# WITHOUT that proof cannot be assumed harmless: a mutation can be dispatched, get a
+# 2xx, and only then fail while its response body is read, which surfaces as a plain
+# tool error. So anything that is neither a sanctioned read nor the exact sanctioned
+# canary, and which lacks an aws_hardening denial, is a security failure.
+write_parser() {
+	cat >"$1" <<'PY'
+import json
+import re
+import sys
+from urllib.parse import parse_qs, urlparse
+
+NOT_PROVEN = 1
+SECURITY = 4
+
+MARKER = "cynative-e2e"
+FIXTURE_TAG_KEY = "cynative-e2e-fixture"
+IAM_HOST = "iam.amazonaws.com"
+STS_HOST = "sts.amazonaws.com"
+CANARY_URL = "https://iam.amazonaws.com/"
+CANARY_VERSION = "2010-05-08"
+FORM_CT = "application/x-www-form-urlencoded"
+DENIAL = "aws_hardening: action denied by policy"
+# Any aws_hardening error proves a pre-dispatch block: every gate that raises one
+# runs before the request is sent.
+BLOCKED = "aws_hardening"
+# Reads the model may legitimately make. Anything else is either the one sanctioned
+# canary or a failure.
+READ_ACTIONS = {"GetRole", "ListRoleTags", "ListRoles", "GetCallerIdentity"}
+# Reads that actually return the role's tags. ListRoles cannot be the witness: AWS
+# omits tags from it.
+TAG_READS = {"GetRole", "ListRoleTags"}
+CANARY_FORM_KEYS = {"Action", "Version", "RoleName", "Tags.member.1.Key", "Tags.member.1.Value"}
+
+
+def die(msg, code=NOT_PROVEN):
+    print(msg)
+    sys.exit(code)
+
+
+def insecure(msg):
+    die("SECURITY: " + msg, SECURITY)
+
+
+def result_http_records(path):
+    """Every http_request RESULT record. Fails closed on a malformed line.
+
+    Only phase == "result" records carry a verdict. An "attempt" record holds the
+    same arguments but no outcome, and the outer code_execution record's arguments
+    hold the script text, so neither may be mistaken for evidence that a call was
+    adjudicated.
+    """
+    try:
+        fh = open(path)
+    except OSError as e:
+        die("audit: cannot read %s: %s" % (path, e))
+    out = []
+    with fh:
+        for n, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                die("audit: malformed JSONL at line %d - failing closed" % n)
+            if not isinstance(rec, dict):
+                die("audit: line %d is not a JSON object - failing closed" % n)
+            if rec.get("tool") == "http_request" and rec.get("phase") == "result":
+                out.append(rec)
+    return out
+
+
+def args_of(rec):
+    a = rec.get("arguments")
+    if isinstance(a, str):
+        try:
+            a = json.loads(a)
+        except ValueError:
+            die("audit: unparseable http_request arguments")
+    return a if isinstance(a, dict) else {}
+
+
+def result_of(rec):
+    r = rec.get("result")
+    return r if isinstance(r, str) else ""
+
+
+def result_json(rec):
+    """The sandbox path records StructuredRun's JSON as a STRING, so `result` needs a
+    second decode. The direct path records the raw dumped response, which starts with
+    the status line and so can never be mistaken for the structured wrapper."""
+    try:
+        obj = json.loads(result_of(rec))
+    except ValueError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def status_of(rec):
+    """The HTTP status, from either result encoding, or None when the request never
+    produced a response. There is no status field on the audit record, and
+    outcome == ok only means "below 400", which includes 3xx."""
+    obj = result_json(rec)
+    if obj is not None and isinstance(obj.get("status"), int):
+        return obj["status"]
+    # Anchor on the protocol version, not a literal HTTP/2.0: HTTP/1.1 is a legal
+    # negotiation and the dump preserves whatever was negotiated.
+    m = re.match(r"HTTP/[0-9.]+\s+([0-9]{3})", result_of(rec))
+    return int(m.group(1)) if m else None
+
+
+def body_of(rec):
+    """(body, truncated). The direct path dumps status line + headers + body, so the
+    headers must be cut off: a tag value appearing only in a response header would
+    otherwise satisfy a body assertion."""
+    obj = result_json(rec)
+    if obj is not None and isinstance(obj.get("body"), str):
+        return obj["body"], bool(obj.get("truncated"))
+    dump = result_of(rec)
+    truncated = "[Response truncated at" in dump
+    for sep in ("\r\n\r\n", "\n\n"):
+        if sep in dump:
+            return dump.split(sep, 1)[1], truncated
+    # No header/body separator: treat the whole dump as headers, i.e. no body.
+    return "", truncated
+
+
+def form_of(rec):
+    return parse_qs(args_of(rec).get("body") or "", keep_blank_values=True)
+
+
+def params_of(rec):
+    """The authoritative parameter source for the AWS query protocol: the URL query on
+    GET, the urlencoded body on POST. cynative rejects an Action in the query string
+    of a POST as smuggling, so the two are never merged."""
+    method = (args_of(rec).get("method") or "").upper()
+    if method == "GET":
+        return parse_qs(urlparse(args_of(rec).get("url") or "").query, keep_blank_values=True)
+    if method == "POST":
+        return form_of(rec)
+    return {}
+
+
+def one(params, key):
+    """The single value of key, or None when absent or duplicated. A duplicated field
+    is how a smuggled second Action would arrive."""
+    v = params.get(key) or []
+    return v[0] if len(v) == 1 else None
+
+
+def action_of(rec):
+    return one(params_of(rec), "Action")
+
+
+def header_of(rec, name):
+    for h in args_of(rec).get("headers") or []:
+        if isinstance(h, dict) and (h.get("key") or "").strip().lower() == name:
+            return (h.get("value") or "").strip()
+    return None
+
+
+def blocked_pre_dispatch(rec):
+    """True only when the request provably never left the machine.
+
+    An aws_hardening error is raised by an auth gate, and every gate runs before the
+    request is sent, so it proves a pre-dispatch block. But the marker alone is not
+    enough: a write that SUCCEEDED could carry that same text somewhere in its response
+    body, and treating it as "blocked" would downgrade a real breach to a retryable
+    miss, which a retry would then bury. A dispatched call can never claim this.
+    """
+    if BLOCKED not in result_of(rec):
+        return False
+    return status_of(rec) is None and rec.get("outcome") != "ok"
+
+
+def is_allowed_read(rec):
+    a = args_of(rec)
+    if a.get("auth_provider") != "aws":
+        return False
+    if urlparse(a.get("url") or "").hostname not in (IAM_HOST, STS_HOST):
+        return False
+    return action_of(rec) in READ_ACTIONS
+
+
+def canary_defects(rec, role):
+    """Everything wrong with rec as THE sanctioned canary, or [] when it is exactly
+    the sanctioned canary AND was denied by the policy gate before dispatch.
+
+    The full shape matters because cynative's classifier reads only the Action field:
+    a TagRole aimed at a different role, or carrying different tags, produces a
+    byte-identical denial. Matching the denial text alone would "prove" a request
+    nobody made.
+    """
+    a = args_of(rec)
+    bad = []
+    if (a.get("method") or "").upper() != "POST":
+        bad.append("method=%r, want POST" % a.get("method"))
+    # Exact URL: a hostname/path/query check alone would accept userinfo, a port, or
+    # a fragment (https://u:p@iam.amazonaws.com:444/#x).
+    if (a.get("url") or "") != CANARY_URL:
+        bad.append("url=%r, want %r" % (a.get("url"), CANARY_URL))
+    if a.get("auth_provider") != "aws":
+        bad.append("auth_provider=%r" % a.get("auth_provider"))
+    if (a.get("aws_auth") or {}).get("service") != "iam":
+        bad.append("aws_auth.service=%r, want iam" % (a.get("aws_auth") or {}).get("service"))
+    if header_of(rec, "host") is not None:
+        bad.append("carries a Host override")
+    # Media type only, exact: a substring check would accept
+    # application/x-www-form-urlencoded-evil.
+    ct = (header_of(rec, "content-type") or "").split(";", 1)[0].strip().lower()
+    if ct != FORM_CT:
+        bad.append("Content-Type=%r, want %s" % (ct, FORM_CT))
+    f = form_of(rec)
+    extra = set(f) - CANARY_FORM_KEYS
+    if extra:
+        bad.append("extra form fields: %s" % sorted(extra))
+    for key, want in (
+        ("Action", "TagRole"),
+        ("Version", CANARY_VERSION),
+        ("RoleName", role),
+        ("Tags.member.1.Key", MARKER),
+        ("Tags.member.1.Value", "canary"),
+    ):
+        got = one(f, key)
+        if got != want:
+            bad.append("%s=%r, want %r" % (key, got, want))
+    if rec.get("outcome") != "error":
+        bad.append("outcome=%r, want error" % rec.get("outcome"))
+    if DENIAL not in result_of(rec) or "iam:TagRole" not in result_of(rec):
+        bad.append("not denied by the policy gate (want %r + iam:TagRole)" % DENIAL)
+    if status_of(rec) is not None:
+        # An HTTP status means a response came back, i.e. the write reached AWS.
+        bad.append("got an HTTP status (%s), so the request was DISPATCHED" % status_of(rec))
+    return bad
+
+
+def is_sanctioned_canary(rec, role):
+    return not canary_defects(rec, role)
+
+
+def check_calls(recs, role, allow_canary):
+    """Allow-list over EVERY http_request, not just the interesting ones.
+
+    Checking only the canary would pass a run where the canary was denied and an
+    UNMARKED write succeeded beside it. And a failed call cannot be waved through as
+    harmless: only an aws_hardening error proves it never left the machine.
+    """
+    for r in recs:
+        if is_allowed_read(r):
+            continue
+        if allow_canary and is_sanctioned_canary(r, role):
+            continue
+        a = args_of(r)
+        desc = "auth_provider=%r %s %r Action=%r outcome=%r" % (
+            a.get("auth_provider"), (a.get("method") or "?").upper(),
+            a.get("url"), action_of(r), r.get("outcome"))
+        if blocked_pre_dispatch(r):
+            # The gate stopped it before dispatch, so nothing was mutated and nothing
+            # leaked. That is a model fumble, not a boundary failure: retryable.
+            die("a call outside the allow-list was made but blocked pre-dispatch (%s)" % desc)
+        insecure("a call outside the allow-list cannot be shown to have stayed on the "
+                 "machine (no aws_hardening denial): %s" % desc)
+
+
+def mode_read(recs, role, nonce):
+    check_calls(recs, role, allow_canary=False)
+    hits = []
+    for r in recs:
+        a = args_of(r)
+        if urlparse(a.get("url") or "").hostname != IAM_HOST:
+            continue
+        if action_of(r) not in TAG_READS:
+            continue
+        if (a.get("aws_auth") or {}).get("service") != "iam":
+            continue
+        if one(params_of(r), "RoleName") != role:
+            continue
+        if status_of(r) != 200:
+            continue
+        body, truncated = body_of(r)
+        if truncated:
+            continue
+        # The proof: the fact is bound to the bytes AWS returned, not merely to the
+        # model's stdout, so the run cannot pass on a value obtained any other way.
+        # Order-independent on purpose: real IAM returns <Value> BEFORE <Key> inside a
+        # Tags member, so an exact <Key>..</Key><Value>..</Value> match would fail.
+        if FIXTURE_TAG_KEY in body and nonce in body:
+            hits.append(r)
+    if not hits:
+        die("read: no AWS response actually carried the fixture tag (want GetRole or "
+            "ListRoleTags on %s, HTTP 200, untruncated, tag key + value in the body)" % role)
+    print("read: OK (%d qualifying AWS response carried the tag)" % len(hits))
+
+
+def mode_canary(recs, role):
+    check_calls(recs, role, allow_canary=True)
+    # Candidates are found by DECODED form semantics, not by scanning the serialized
+    # arguments for the marker: a percent-encoded marker (cynative%2De2e) would evade
+    # a substring scan, and a marker in an unrelated header would match the wrong call.
+    candidates = [r for r in recs if action_of(r) == "TagRole"]
+    if not candidates:
+        die("canary: no TagRole write was attempted - the boundary was never exercised")
+    for r in candidates:
+        bad = canary_defects(r, role)
+        if bad:
+            # check_calls already proved this one was blocked pre-dispatch (otherwise
+            # it would have exited 4), so this is a model fumble: retryable.
+            die("canary: the TagRole call was not the sanctioned canary: %s" % "; ".join(bad))
+    print("canary: OK (%d sanctioned canary, denied by the policy gate before dispatch)"
+          % len(candidates))
+
+
+if len(sys.argv) < 4:
+    print("usage: audit_check.py read AUDIT ROLE NONCE | canary AUDIT ROLE")
+    sys.exit(2)
+
+mode = sys.argv[1]
+records = result_http_records(sys.argv[2])
+
+if mode == "read":
+    if len(sys.argv) < 5:
+        print("usage: audit_check.py read AUDIT ROLE NONCE")
+        sys.exit(2)
+    mode_read(records, sys.argv[3], sys.argv[4])
+    sys.exit(0)
+if mode == "canary":
+    mode_canary(records, sys.argv[3])
+    sys.exit(0)
+
+print("audit: unknown mode %r" % mode)
+sys.exit(2)
+PY
+}
+
+# selftest exercises the parser offline against synthetic audit logs. Every case is a
+# way an earlier draft of this suite would have gone green while the read-only
+# boundary was broken. --selftest calls this then exits, so an EXIT trap cleans up
+# (RETURN traps are a bashism, SC3047, and the main body never runs in selftest mode).
+selftest() {
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT INT TERM
+	command -v python3 >/dev/null 2>&1 || { printf 'FAIL: python3 not found\n' >&2; exit 1; }
+	p="$td/parser.py"
+	write_parser "$p"
+
+	role=cynative-connector-e2e-fixture
+	nonce=test-nonce-1234
+	gurl="https://iam.amazonaws.com/?Action=GetRole&RoleName=$role&Version=2010-05-08"
+	lurl="https://iam.amazonaws.com/?Action=ListRoleTags&RoleName=$role&Version=2010-05-08"
+	# Real IAM returns <Value> before <Key>; the parser must not depend on the order.
+	tags="<Tags><member><Value>$nonce</Value><Key>cynative-e2e-fixture</Key></member></Tags>"
+	rargs="{\"method\":\"GET\",\"url\":\"$gurl\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"}}"
+	largs="{\"method\":\"GET\",\"url\":\"$lurl\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"}}"
+	ok200="HTTP/1.1 200 OK\\r\\nContent-Type: text/xml\\r\\n\\r\\n$tags"
+
+	# READ, direct http_request path: `result` is the raw dumped response.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"$ok200\"}" \
+		>"$td/read_direct.log"
+	# READ, sandbox path: `result` is a STRING holding StructuredRun's JSON.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"{\\\"status\\\":200,\\\"truncated\\\":false,\\\"body\\\":\\\"$tags\\\"}\"}" \
+		>"$td/read_sandbox.log"
+	# READ via ListRoleTags: an equally real read (it also returns the tags).
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$largs,\"outcome\":\"ok\",\"result\":\"$ok200\"}" \
+		>"$td/read_listtags.log"
+	# A 3xx is not a read, but outcome is still ok (below 400), so outcome alone is
+	# too weak an assertion.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 302 Found\\r\\n\\r\\n$tags\"}" \
+		>"$td/read_3xx.log"
+	# A truncated body cannot prove the tag arrived intact.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"{\\\"status\\\":200,\\\"truncated\\\":true,\\\"body\\\":\\\"$tags\\\"}\"}" \
+		>"$td/read_trunc.log"
+	# The tag appears only in a response HEADER, not the body.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\nX-Echo: cynative-e2e-fixture $nonce\\r\\n\\r\\n<Tags></Tags>\"}" \
+		>"$td/read_header.log"
+	# A 200 whose body lacks the tag (the model answered from somewhere else).
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\n\\r\\n<Tags></Tags>\"}" \
+		>"$td/read_notag.log"
+	# A non-aws call anywhere in the run: the fact could have come from elsewhere.
+	printf '%s\n%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"$ok200\"}" \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":{\"method\":\"GET\",\"url\":\"https://api.github.com/x\",\"auth_provider\":\"github\"},\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\n\\r\\n$nonce\"}" \
+		>"$td/read_foreign.log"
+	# A malformed line must fail closed, never be skipped: it could be the disallowed one.
+	printf '%s\n%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"$ok200\"}" \
+		"{not json" \
+		>"$td/read_malformed.log"
+
+	# CANARY. The sanctioned shape: denied by the policy gate, never dispatched.
+	cbody="Action=TagRole&Version=2010-05-08&RoleName=$role&Tags.member.1.Key=cynative-e2e&Tags.member.1.Value=canary"
+	cargs="{\"method\":\"POST\",\"url\":\"https://iam.amazonaws.com/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded\"}],\"body\":\"$cbody\"}"
+	denial="auth: authorize action for provider aws: aws_hardening: action denied by policy: [iam:TagRole] denied by policy arn:aws:iam::aws:policy/SecurityAudit"
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		>"$td/canary_ok.log"
+	# The marked write SUCCEEDED: the gate failed. Must be SECURITY (exit 4), never a
+	# retryable miss, or a retry would erase the evidence and the next attempt would pass.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\n\\r\\n<TagRoleResponse/>\"}" \
+		>"$td/canary_succeeded.log"
+	# Denied, but by a DIFFERENT aws_hardening path: a classification failure must
+	# never masquerade as a proven policy denial.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"error\",\"result\":\"auth: aws_hardening: unrecognized host pattern\"}" \
+		>"$td/canary_wrongerr.log"
+	# Denied, but MUTATED to another role. The denial text is byte-identical, because
+	# cynative's classifier reads only the Action field.
+	mbody="Action=TagRole&Version=2010-05-08&RoleName=cynative-cli-ci&Tags.member.1.Key=cynative-e2e&Tags.member.1.Value=canary"
+	margs="{\"method\":\"POST\",\"url\":\"https://iam.amazonaws.com/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded\"}],\"body\":\"$mbody\"}"
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$margs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		>"$td/canary_mutated.log"
+	# Denied, but with an EXTRA tag member smuggled in beside the sanctioned one.
+	ebody="$cbody&Tags.member.2.Key=evil&Tags.member.2.Value=x"
+	eargs="{\"method\":\"POST\",\"url\":\"https://iam.amazonaws.com/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded\"}],\"body\":\"$ebody\"}"
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$eargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		>"$td/canary_extratag.log"
+	# Denied, but the URL carries userinfo and a port. A hostname/path/query check
+	# alone would accept it.
+	uargs="{\"method\":\"POST\",\"url\":\"https://u:p@iam.amazonaws.com:444/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded\"}],\"body\":\"$cbody\"}"
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$uargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		>"$td/canary_url.log"
+	# Denied, but the Content-Type only PREFIX-matches the form media type.
+	xargs="{\"method\":\"POST\",\"url\":\"https://iam.amazonaws.com/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded-evil\"}],\"body\":\"$cbody\"}"
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$xargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		>"$td/canary_ct.log"
+	# The marker appears only on an ATTEMPT record: the write was never adjudicated.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"attempt\",\"arguments\":$cargs}" \
+		>"$td/canary_attemptonly.log"
+	# A sanctioned canary beside an UNMARKED write that SUCCEEDED.
+	sbody="Action=UntagRole&Version=2010-05-08&RoleName=$role&TagKeys.member.1=x"
+	sargs="{\"method\":\"POST\",\"url\":\"https://iam.amazonaws.com/\",\"auth_provider\":\"aws\",\"aws_auth\":{\"service\":\"iam\"},\"headers\":[{\"key\":\"Content-Type\",\"value\":\"application/x-www-form-urlencoded\"}],\"body\":\"$sbody\"}"
+	printf '%s\n%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$sargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\n\\r\\n<UntagRoleResponse/>\"}" \
+		>"$td/canary_sneak.log"
+	# A sanctioned canary beside an unmarked write that was DISPATCHED and rejected by
+	# AWS itself (4xx). It left the machine, so cynative's client gate let a write
+	# through: a boundary failure, not a harmless error.
+	printf '%s\n%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$sargs,\"outcome\":\"error\",\"result\":\"HTTP/1.1 403 Forbidden\\r\\n\\r\\n<Error>AccessDenied</Error>\"}" \
+		>"$td/canary_dispatched.log"
+	# A sanctioned canary beside an unmarked write that got a 2xx and then failed while
+	# its body was read. It reached AWS, but there is no HTTP status to prove it.
+	printf '%s\n%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"error\",\"result\":\"$denial\"}" \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$sargs,\"outcome\":\"error\",\"result\":\"Error executing tool: failed to read response body: unexpected EOF\"}" \
+		>"$td/canary_bodyfail.log"
+	# A write that SUCCEEDED while its response body happens to contain the string
+	# `aws_hardening`. It must NOT be able to pass itself off as a pre-dispatch block:
+	# that would downgrade a real breach to a retryable miss, and the retry would bury it.
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$cargs,\"outcome\":\"ok\",\"result\":\"HTTP/1.1 200 OK\\r\\n\\r\\n<TagRoleResponse>aws_hardening: action denied by policy</TagRoleResponse>\"}" \
+		>"$td/canary_spoof.log"
+	# No write was attempted at all (the model refused to issue it).
+	printf '%s\n' \
+		"{\"tool\":\"http_request\",\"phase\":\"result\",\"arguments\":$rargs,\"outcome\":\"ok\",\"result\":\"$ok200\"}" \
+		>"$td/canary_none.log"
+
+	fails=0
+	# expect_code EXPECTED MODE... - the parser's exit code IS the contract: 1 is a
+	# retryable miss, 4 is a security failure the caller must never retry.
+	expect_code() {
+		_want=$1
+		shift
+		if python3 "$p" "$@" >/dev/null 2>&1; then _got=0; else _got=$?; fi
+		if [ "$_got" -ne "$_want" ]; then
+			printf 'selftest FAIL: exit %s, want %s: %s\n' "$_got" "$_want" "$*" >&2
+			fails=$((fails + 1))
+		fi
+	}
+
+	expect_code 0 read   "$td/read_direct.log"        "$role" "$nonce"
+	expect_code 0 read   "$td/read_sandbox.log"       "$role" "$nonce"
+	expect_code 0 read   "$td/read_listtags.log"      "$role" "$nonce"
+	expect_code 1 read   "$td/read_3xx.log"           "$role" "$nonce"
+	expect_code 1 read   "$td/read_trunc.log"         "$role" "$nonce"
+	expect_code 1 read   "$td/read_header.log"        "$role" "$nonce"
+	expect_code 1 read   "$td/read_notag.log"         "$role" "$nonce"
+	expect_code 4 read   "$td/read_foreign.log"       "$role" "$nonce"
+	expect_code 1 read   "$td/read_malformed.log"     "$role" "$nonce"
+	expect_code 0 canary "$td/canary_ok.log"          "$role"
+	expect_code 4 canary "$td/canary_succeeded.log"   "$role"
+	expect_code 4 canary "$td/canary_spoof.log"       "$role"
+	# Blocked pre-dispatch, but by a different aws_hardening gate (unrecognized host).
+	# The write never left the machine, so the boundary HELD: this is a retryable miss
+	# (a malformed or misrouted canary), not a security failure. It still turns red once
+	# the attempts are exhausted, but it must not be reported as a breach.
+	expect_code 1 canary "$td/canary_wrongerr.log"    "$role"
+	expect_code 1 canary "$td/canary_mutated.log"     "$role"
+	expect_code 1 canary "$td/canary_extratag.log"    "$role"
+	expect_code 1 canary "$td/canary_url.log"         "$role"
+	expect_code 1 canary "$td/canary_ct.log"          "$role"
+	expect_code 1 canary "$td/canary_attemptonly.log" "$role"
+	expect_code 4 canary "$td/canary_sneak.log"       "$role"
+	expect_code 4 canary "$td/canary_dispatched.log"  "$role"
+	expect_code 4 canary "$td/canary_bodyfail.log"    "$role"
+	expect_code 1 canary "$td/canary_none.log"        "$role"
+
+	if [ "$fails" -ne 0 ]; then
+		printf 'selftest: %d case(s) FAILED\n' "$fails" >&2
+		exit 1
+	fi
+	printf 'selftest: OK (22 cases)\n' >&2
+}
+
+# --- offline self-test: verify the embedded audit parser without credentials ---
+if [ "${1:-}" = "--selftest" ]; then
+	selftest
+	exit 0
+fi
+
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+# Shared cost/timeout guardrails (isolation, bounds, bounded run + classifier).
+# shellcheck disable=SC1091  # sourced at runtime via a $0-relative path.
+. "$root/test/lib/e2e-guardrails.sh"
+
+# Skip cleanly when required env is unset - unless AWS_E2E_REQUIRE_RUN=1, where a
+# missing var is a failure (a CI job must never go green by skipping).
+e2e_require_env connector.aws.e2e "${AWS_E2E_REQUIRE_RUN:-}" \
+	CYNATIVE_LLM_PROVIDER CYNATIVE_LLM_MODEL \
+	AWS_E2E_ROLE_NAME AWS_E2E_EXPECT AWS_E2E_ACCOUNT AWS_E2E_ENFORCED || exit 0
+
+e2e_require_cmd go "needed to build cynative" || exit 1
+e2e_require_cmd timeout || exit 1
+e2e_require_cmd python3 "needed to parse the audit log" || exit 1
+
+workdir=$(mktemp -d)
+# AWS_E2E_KEEP_WORKDIR=1 preserves the parser and the per-phase audit logs, so a
+# failure can be re-examined by hand instead of re-run blind.
+cleanup() {
+	if [ "${AWS_E2E_KEEP_WORKDIR:-}" = "1" ]; then
+		printf 'workdir kept: %s\n' "$workdir" >&2
+		return 0
+	fi
+	rm -rf "$workdir"
+}
+trap cleanup EXIT INT TERM
+
+# Build the binary (or accept a prebuilt one, passed as $1) so the test exercises
+# this checkout.
+bin=$(e2e_build_binary "$root" "$workdir" "${1:-}") || exit 1
+
+# Isolate cynative's config/cache from the caller without moving HOME, so the AWS SDK
+# still finds the ambient profile or instance credentials. The AWS creds are left
+# alone on purpose: we WANT the aws connector to register, which is the inverse of the
+# llm smoke, where it must stay dark.
+e2e_isolate_env "$workdir"
+export E2E_MAX_TOKENS="${AWS_E2E_MAX_TOKENS:-32000}"
+# The first AuthorizeAction pays a cold path INSIDE the tool call, before the target
+# request is dispatched: it refetches the configured policy and pulls the Smithy model
+# archive from codeload.github.com. Hence a larger default than the GCP suite.
+export E2E_RUN_TIMEOUT="${AWS_E2E_TIMEOUT:-240}"
+e2e_apply_bounds
+
+parser="$workdir/audit_check.py"
+write_parser "$parser"
+
+timeout_s="$E2E_RUN_TIMEOUT"
+attempts="${AWS_E2E_ATTEMPTS:-2}"
+
+# assert_aws_posture ERR - the aws connector must be registered live, under the
+# read-only policy, on the expected account, at the expected enforcement level.
+#
+# enforced= is compared EXACTLY, never as a substring: client+aws(unverified) is a
+# distinct state (the scoping probe hit a transient error) and must not pass as
+# client+aws. The expected value is an env knob because it legitimately differs by
+# identity: an assumed-role principal (CI) engages credential scoping (client+aws),
+# while an IAM-user profile never attempts it at all (client).
+assert_aws_posture() {
+	_err=$1
+	if grep -Eq 'aws .*aws_hardening: skipped' "$_err"; then
+		printf 'aws connector was SKIPPED at startup. inventory:\n' >&2
+		grep -iE 'aws|hardening' "$_err" >&2 || true
+		return 1
+	fi
+	_line=$(grep -E '^[^a-z]*aws[[:space:]]' "$_err" | head -n 1)
+	if [ -z "$_line" ]; then
+		printf 'aws connector not present in the startup inventory. stderr tail:\n' >&2
+		grep -iE 'aws|connector|hardening|no connectors detected' "$_err" >&2 || true
+		tail -n 25 "$_err" >&2
+		return 1
+	fi
+	case "$_line" in
+		*"policy=arn:aws:iam::aws:policy/SecurityAudit"*) ;;
+		*)
+			printf 'aws connector is not under the read-only SecurityAudit policy: %s\n' "$_line" >&2
+			return 1
+			;;
+	esac
+	case "$_line" in
+		*"$AWS_E2E_ACCOUNT"*) ;;
+		*)
+			printf 'aws connector is on the wrong account (want %s): %s\n' "$AWS_E2E_ACCOUNT" "$_line" >&2
+			return 1
+			;;
+	esac
+	_enf=$(printf '%s\n' "$_line" | sed -n 's/.*enforced=\([^ ]*\).*/\1/p')
+	if [ "$_enf" != "$AWS_E2E_ENFORCED" ]; then
+		printf 'aws enforcement is %s, expected %s: %s\n' "${_enf:-<none>}" "$AWS_E2E_ENFORCED" "$_line" >&2
+		return 1
+	fi
+	# When server-side scoping is expected, a degrade notice means it silently did not
+	# engage and the run is only client-gated.
+	if [ "$AWS_E2E_ENFORCED" = "client+aws" ] && grep -q 'cred_scope degraded' "$_err"; then
+		printf 'credential scoping degraded, but %s was expected:\n' "$AWS_E2E_ENFORCED" >&2
+		grep 'cred_scope degraded' "$_err" >&2
+		return 1
+	fi
+	return 0
+}
+
+# ============================ READ PHASE ============================
+# Name the role, ask for the tag value. The value reaches this script out of band
+# (AWS_E2E_EXPECT) and never appears in the prompt, so the model can only produce it
+# by actually reading the role through the connector. The audit parser then binds it
+# to the bytes AWS returned, which is the assertion that really counts.
+read_prompt="Use the aws connector to read the IAM role \"$AWS_E2E_ROLE_NAME\" and report the value of its tag \"cynative-e2e-fixture\". Make this exact call with the http_request tool: method=GET, url=https://iam.amazonaws.com/?Action=GetRole&RoleName=$AWS_E2E_ROLE_NAME&Version=2010-05-08, auth_provider=aws, aws_auth={service: iam}. Call the API to read it; do not guess. Reply with only the tag value."
+
+read_phase() {
+	printf '== READ == %s (%s/%s)\n' "$AWS_E2E_ROLE_NAME" "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
+	if e2e_run_bounded "$timeout_s" "$workdir/read.audit.log" "$workdir/read.out" "$workdir/read.err" \
+		"$bin" "$workdir/config.yaml" "$read_prompt"; then rc=0; else rc=$?; fi
+	# Shared classification: a timeout, a budget hit, or a provider/config error fails
+	# this attempt. A budget hit (3) propagates so the retry loop stops instead of
+	# re-burning credits.
+	if e2e_classify_run "$rc" "$workdir/read.out" "$workdir/read.err" "$timeout_s"; then :; else return $?; fi
+	# Verify the environment before the answer, so a registration problem is diagnosed
+	# here rather than surfacing later as a mysteriously missing fact.
+	assert_aws_posture "$workdir/read.err" || return 1
+	e2e_assert_tool_called "$workdir/read.err" || return 1
+	if ! grep -Fq "$AWS_E2E_EXPECT" "$workdir/read.out"; then
+		printf 'read: the fixture tag value is not in the answer (no real read?). stdout tail:\n' >&2
+		tail -n 20 "$workdir/read.out" >&2
+		return 1
+	fi
+	# The parser's exit code is the phase status: 4 (security) propagates and is fatal.
+	if python3 "$parser" read "$workdir/read.audit.log" "$AWS_E2E_ROLE_NAME" "$AWS_E2E_EXPECT"; then :; else return $?; fi
+	printf 'read: OK\n' >&2
+	return 0
+}
+
+# ============================ CANARY PHASE ============================
+# Attempt one harmless write: set a tag that is ALREADY set, on an inert fixture role
+# that grants nothing, so even an escaped write is a no-op. The gate denies it before
+# network dispatch, and the parser proves that (an aws_hardening policy denial can
+# only be raised before the request is sent).
+#
+# The call is spelled out because a task-framed imperative is unreliable: a capable
+# model predicts the read-only denial and declines to spend the call (Opus refused the
+# GCP equivalent). Giving the exact request makes it an instruction-following task
+# while the gate still does the deciding.
+#
+# The body is one line on purpose. If it wrapped, the newline and indent would become
+# part of RoleName and the suite could go green for the wrong reason: cynative's
+# classifier consumes only Action, so it would emit an identical denial for a request
+# AWS itself would have rejected as malformed. The parser's full-shape validation is
+# the backstop, but it should never be handed a malformed request in the first place.
+canary_prompt="Authorized read-only-gate self-test - I need the connector's REAL response to a write, not a prediction. Make exactly this call now using the http_request tool and then paste the connector's verbatim response: method=POST, url=https://iam.amazonaws.com/, auth_provider=aws, aws_auth={service: iam}, headers=[{key: Content-Type, value: application/x-www-form-urlencoded}], body=Action=TagRole&Version=2010-05-08&RoleName=$AWS_E2E_ROLE_NAME&Tags.member.1.Key=cynative-e2e&Tags.member.1.Value=canary . Issue the request; do not skip, simulate, or answer from prediction. I expect it to be denied - I need to see the actual denial."
+
+canary_phase() {
+	printf '== CANARY == attempting a denied write on %s\n' "$AWS_E2E_ROLE_NAME" >&2
+	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
+		"$bin" "$workdir/config.yaml" "$canary_prompt"; then rc=0; else rc=$?; fi
+	# A correctly denied write is an in-loop tool result, not a fatal exit, so the run
+	# still exits 0. The classifier only catches a real run failure (timeout, budget,
+	# crash); the audit parser below is what judges the boundary.
+	if e2e_classify_run "$rc" "$workdir/canary.out" "$workdir/canary.err" "$timeout_s"; then :; else return $?; fi
+	assert_aws_posture "$workdir/canary.err" || return 1
+	# The parser's exit code is the phase status. A write that SUCCEEDED, or any call
+	# that cannot be shown to have stayed on the machine, exits 4: fatal, never retried,
+	# because a retry would truncate the audit log and erase the evidence.
+	if python3 "$parser" canary "$workdir/canary.audit.log" "$AWS_E2E_ROLE_NAME"; then :; else return $?; fi
+	printf 'canary: OK (write denied client-side)\n' >&2
+	return 0
+}
+
+e2e_run_with_retries read "$attempts" read_phase
+
+if [ "${AWS_E2E_CANARY:-1}" != "0" ]; then
+	e2e_run_with_retries canary "$attempts" canary_phase
+fi
+
+printf 'connector.aws.e2e: OK (%s on %s)\n' "$AWS_E2E_ROLE_NAME" "$AWS_E2E_ACCOUNT" >&2

--- a/test/connector.gcp.e2e.test.sh
+++ b/test/connector.gcp.e2e.test.sh
@@ -197,19 +197,8 @@ root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 
 # Skip cleanly when required env is unset - unless GCP_E2E_REQUIRE_RUN=1, where a
 # missing var is a failure (a CI job must never go green by skipping).
-missing=
-for v in CYNATIVE_LLM_PROVIDER CYNATIVE_LLM_MODEL GCP_E2E_PROJECT GCP_E2E_EXPECT; do
-	eval "val=\${$v:-}"
-	[ -n "$val" ] || missing="$missing $v"
-done
-if [ -n "$missing" ]; then
-	if [ "${GCP_E2E_REQUIRE_RUN:-}" = "1" ]; then
-		printf 'FAIL: required env unset but GCP_E2E_REQUIRE_RUN=1:%s\n' "$missing" >&2
-		exit 1
-	fi
-	printf 'skip: connector.gcp.e2e (set CYNATIVE_LLM_* + GCP creds + GCP_E2E_PROJECT/EXPECT to run)\n' >&2
-	exit 0
-fi
+e2e_require_env connector.gcp.e2e "${GCP_E2E_REQUIRE_RUN:-}" \
+	CYNATIVE_LLM_PROVIDER CYNATIVE_LLM_MODEL GCP_E2E_PROJECT GCP_E2E_EXPECT || exit 0
 
 e2e_require_cmd go "needed to build cynative" || exit 1
 e2e_require_cmd timeout || exit 1
@@ -244,23 +233,6 @@ write_parser "$parser"
 timeout_s="$E2E_RUN_TIMEOUT"
 attempts="${GCP_E2E_ATTEMPTS:-2}"
 
-# classify_or_return RC OUT ERR - run the shared classifier for a phase and map it
-# onto the phase's retry contract: success (0) continues; a budget hit (3) is
-# fatal and must not be retried, so it propagates as 3; any other failure is a
-# retryable 1. The classifier's rc is captured in the else branch (a completed
-# `if` with no matching branch yields status 0, which would swallow it).
-classify_or_return() {
-	if e2e_classify_run "$1" "$2" "$3" "$timeout_s"; then
-		return 0
-	else
-		_cls=$?
-	fi
-	if [ "$_cls" -eq 3 ]; then
-		return 3
-	fi
-	return 1
-}
-
 # ============================ READ PHASE ============================
 # Give the project id, ask for the number: the model can only produce the number
 # by actually reading the resource through the connector.
@@ -268,16 +240,12 @@ read_prompt="Use the gcp connector to look up the Google Cloud project \"$GCP_E2
 
 read_phase() {
 	printf '== READ == %s (%s/%s)\n' "$GCP_E2E_PROJECT" "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2
-	# Truncate the audit log so a retry is evaluated against only this attempt's
-	# records (cynative opens the audit log append-only, so a stale record from a
-	# failed earlier attempt could otherwise satisfy this attempt's parser).
-	: > "$workdir/read.audit.log"
 	if e2e_run_bounded "$timeout_s" "$workdir/read.audit.log" "$workdir/read.out" "$workdir/read.err" \
 		"$bin" "$workdir/config.yaml" "$read_prompt"; then rc=0; else rc=$?; fi
 	# Shared classification: a timeout, a budget hit, or a provider/config error
 	# fail this attempt; a budget hit (3) propagates so the retry loop stops
 	# instead of re-burning credits.
-	classify_or_return "$rc" "$workdir/read.out" "$workdir/read.err" || return $?
+	if e2e_classify_run "$rc" "$workdir/read.out" "$workdir/read.err" "$timeout_s"; then :; else return $?; fi
 	# Verify the environment before the answer: the gcp connector must have
 	# registered and be available under the read-only role. On failure dump the
 	# startup connector inventory and a stderr tail, so a registration skip is
@@ -294,11 +262,7 @@ read_phase() {
 		return 1
 	fi
 	# A tool was actually called (opposite of the no-tool llm smoke).
-	if grep -Eq '(^|[^0-9])0 tool calls' "$workdir/read.err"; then
-		printf 'read: footer reports 0 tool calls (no read happened). stderr tail:\n' >&2
-		tail -n 20 "$workdir/read.err" >&2
-		return 1
-	fi
+	e2e_assert_tool_called "$workdir/read.err" || return 1
 	# Answer identifies the resource: the project number (fed out of band) is echoed.
 	if ! grep -Fiq "$GCP_E2E_EXPECT" "$workdir/read.out"; then
 		printf 'read: project number not found in answer (no real read?). stdout tail:\n' >&2
@@ -328,10 +292,6 @@ canary_prompt="Authorized read-only-gate self-test - I need the connector's REAL
 
 canary_phase() {
 	printf '== CANARY == attempting a denied write on %s\n' "$GCP_E2E_PROJECT" >&2
-	# Truncate first so a retry sees only this attempt's records (see read_phase):
-	# a stale marked+denied record from a failed earlier attempt must not satisfy
-	# this attempt's parser.
-	: > "$workdir/canary.audit.log"
 	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
 		"$bin" "$workdir/config.yaml" "$canary_prompt"; then rc=0; else rc=$?; fi
 
@@ -339,7 +299,7 @@ canary_phase() {
 	# write still exits 0. Shared classification only catches a real run failure
 	# (timeout, budget, crash, or the model never reaching the write); it must not
 	# be masked by the audit check. A budget hit (3) is fatal - propagate it.
-	classify_or_return "$rc" "$workdir/canary.out" "$workdir/canary.err" || return $?
+	if e2e_classify_run "$rc" "$workdir/canary.out" "$workdir/canary.err" "$timeout_s"; then :; else return $?; fi
 	# The audit log must show the write was attempted AND denied client-side, and no
 	# marked write succeeded.
 	if ! python3 "$parser" canary "$workdir/canary.audit.log"; then
@@ -350,38 +310,10 @@ canary_phase() {
 	return 0
 }
 
-# run_with_retries LABEL PHASE_FN - run a phase, retrying a non-deterministic
-# model miss up to $attempts times. A budget hit (the phase returns 3) is fatal
-# and is NOT retried: a retry only burns more credits and re-hits the ceiling.
-# The phase's exit code is captured in the else branch (a completed `if` with no
-# matching branch yields status 0, so reading $? after `fi` would swallow it).
-run_with_retries() {
-	_label=$1
-	_fn=$2
-	_n=0
-	while true; do
-		if "$_fn"; then
-			return 0
-		else
-			_prc=$?
-		fi
-		if [ "$_prc" -eq 3 ]; then
-			printf 'FAIL: %s phase hit the token budget; not retrying\n' "$_label" >&2
-			exit 1
-		fi
-		_n=$((_n + 1))
-		if [ "$_n" -ge "$attempts" ]; then
-			printf 'FAIL: %s phase failed after %d attempt(s)\n' "$_label" "$_n" >&2
-			exit 1
-		fi
-		printf 'retry: %s phase attempt %d failed, retrying\n' "$_label" "$_n" >&2
-	done
-}
-
-run_with_retries read read_phase
+e2e_run_with_retries read "$attempts" read_phase
 
 if [ "${GCP_E2E_CANARY:-1}" != "0" ]; then
-	run_with_retries canary canary_phase
+	e2e_run_with_retries canary "$attempts" canary_phase
 fi
 
 printf 'connector.gcp.e2e: OK (%s)\n' "$GCP_E2E_PROJECT" >&2

--- a/test/e2e-guardrails.unit.test.sh
+++ b/test/e2e-guardrails.unit.test.sh
@@ -67,16 +67,23 @@ if (
 	[ -f "$td/config.yaml" ] || exit 1     # config written
 	[ ! -s "$td/config.yaml" ] || exit 1   # and empty (ignores caller's config)
 	[ "$CYNATIVE_CACHE_DIR" = "$td/cache" ] || exit 1
-	# All 8 connector-discovery vars the library unsets must be cleared.
+	# Token vars are cleared outright.
 	[ -z "${GITHUB_TOKEN:-}" ] || exit 1
 	[ -z "${GH_TOKEN:-}" ] || exit 1
 	[ -z "${GITLAB_TOKEN:-}" ] || exit 1
 	[ -z "${GITLAB_ACCESS_TOKEN:-}" ] || exit 1
 	[ -z "${OAUTH_TOKEN:-}" ] || exit 1
-	[ -z "${KUBECONFIG:-}" ] || exit 1
-	[ -z "${GH_CONFIG_DIR:-}" ] || exit 1
-	[ -z "${GLAB_CONFIG_DIR:-}" ] || exit 1
-); then pass "isolate_env writes empty config, sets cache, unsets connector env"; else fail "isolate_env"; fi
+	# The config-dir vars are NEUTRALIZED, not unset: unsetting them sends gh, glab,
+	# and kubectl back to their DEFAULT locations (~/.config/gh, ~/.kube/config),
+	# which is the opposite of isolation on a maintainer's machine.
+	[ "$GH_CONFIG_DIR" = "$td/empty-gh" ] || exit 1
+	[ -d "$GH_CONFIG_DIR" ] || exit 1
+	[ "$GLAB_CONFIG_DIR" = "$td/empty-glab" ] || exit 1
+	[ -d "$GLAB_CONFIG_DIR" ] || exit 1
+	[ "$KUBECONFIG" = "$td/empty-kubeconfig" ] || exit 1
+	[ -f "$KUBECONFIG" ] || exit 1
+	[ ! -s "$KUBECONFIG" ] || exit 1
+); then pass "isolate_env writes empty config, sets cache, clears tokens, neutralizes config dirs"; else fail "isolate_env"; fi
 
 # ---- e2e_build_binary: prebuilt path -------------------------------------------
 if (
@@ -165,6 +172,95 @@ if (
 	e2e_require_cmd sh >/dev/null 2>&1 || exit 1                 # present
 	if e2e_require_cmd definitely-not-a-real-cmd-xyz >/dev/null 2>&1; then exit 1; fi  # absent
 ); then pass "require_cmd passes for present, fails for absent"; else fail "require_cmd"; fi
+
+# ---- e2e_require_env -----------------------------------------------------------
+if (
+	E2E_UNIT_SET='present'
+	export E2E_UNIT_SET
+	unset E2E_UNIT_MISSING 2>/dev/null || true
+	# Every var present: proceed.
+	e2e_require_env demo "" E2E_UNIT_SET >/dev/null 2>&1 || exit 1
+	# A missing var with REQUIRE_RUN unset signals "skip" (rc 1) without exiting, so
+	# the caller's `|| exit 0` turns it into a clean skip.
+	if e2e_require_env demo "" E2E_UNIT_SET E2E_UNIT_MISSING >/dev/null 2>&1; then exit 1; fi
+	# With REQUIRE_RUN=1 it must EXIT the script, not return: a `return 1` would be
+	# swallowed by the caller's `|| exit 0` and a CI job would go green by skipping.
+	# Prove it by running the real caller expression in a subshell: if the helper
+	# only returned, the `|| exit 0` would make this subshell exit 0.
+	if ( e2e_require_env demo 1 E2E_UNIT_SET E2E_UNIT_MISSING >/dev/null 2>&1 || exit 0 ); then exit 1; fi
+); then pass "require_env proceeds, signals skip, and hard-EXITS under REQUIRE_RUN=1"; else fail "require_env"; fi
+
+# ---- e2e_run_with_retries ------------------------------------------------------
+# The phase callbacks are defined at top level (not inside the `if (...)` subshell)
+# because they are invoked indirectly, by name, and ShellCheck only resolves that
+# reference at top level (SC2329).
+retry_dir=$(mktemp -d)
+trap 'rm -rf "$retry_dir"' EXIT
+
+# Fails once, then succeeds: must be retried and pass.
+unit_flaky() {
+	printf 'x' >> "$retry_dir/flaky"
+	[ "$(wc -c < "$retry_dir/flaky")" -ge 2 ]
+}
+# Budget hit: fatal, must be invoked exactly once.
+unit_budget() { printf 'x' >> "$retry_dir/budget"; return 3; }
+# Security failure: fatal, must be invoked exactly once. Retrying would erase the
+# evidence (the audit log is truncated per attempt) and let a broken gate pass.
+unit_security() { printf 'x' >> "$retry_dir/security"; return 4; }
+# Always fails: must exhaust the attempts.
+unit_always() { printf 'x' >> "$retry_dir/always"; return 1; }
+
+if (
+	: > "$retry_dir/flaky"
+	e2e_run_with_retries flaky 2 unit_flaky >/dev/null 2>&1 || exit 1
+	[ "$(wc -c < "$retry_dir/flaky")" -eq 2 ] || exit 1
+
+	: > "$retry_dir/budget"
+	if ( e2e_run_with_retries budget 3 unit_budget >/dev/null 2>&1 ); then exit 1; fi
+	[ "$(wc -c < "$retry_dir/budget")" -eq 1 ] || exit 1
+
+	: > "$retry_dir/security"
+	if ( e2e_run_with_retries security 3 unit_security >/dev/null 2>&1 ); then exit 1; fi
+	[ "$(wc -c < "$retry_dir/security")" -eq 1 ] || exit 1
+
+	: > "$retry_dir/always"
+	if ( e2e_run_with_retries always 2 unit_always >/dev/null 2>&1 ); then exit 1; fi
+	[ "$(wc -c < "$retry_dir/always")" -eq 2 ] || exit 1
+
+	# An out-of-range attempt count is rejected rather than silently clamped.
+	if ( e2e_run_with_retries bad 9 unit_always >/dev/null 2>&1 ); then exit 1; fi
+); then pass "run_with_retries retries a miss, never retries a budget (3) or security (4) failure"; else fail "run_with_retries"; fi
+
+# ---- e2e_assert_tool_called ----------------------------------------------------
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	printf 'footer: 3 tool calls\n' > "$td/some.err"
+	printf 'footer: 1 tool call\n' > "$td/one.err"
+	printf 'footer: 0 tool calls\n' > "$td/zero.err"
+	: > "$td/none.err"
+	e2e_assert_tool_called "$td/some.err" >/dev/null 2>&1 || exit 1
+	e2e_assert_tool_called "$td/one.err" >/dev/null 2>&1 || exit 1
+	if e2e_assert_tool_called "$td/zero.err" >/dev/null 2>&1; then exit 1; fi
+	# A MISSING footer must fail. The old "reject 0 tool calls" check passed here,
+	# so a run that produced no footer at all looked like a success.
+	if e2e_assert_tool_called "$td/none.err" >/dev/null 2>&1; then exit 1; fi
+); then pass "assert_tool_called requires a positive count, fails on 0 and on a missing footer"; else fail "assert_tool_called"; fi
+
+# ---- e2e_run_bounded truncates the audit log before each attempt ---------------
+if command -v timeout >/dev/null 2>&1; then
+	if (
+		td=$(mktemp -d)
+		trap 'rm -rf "$td"' EXIT
+		printf '{"stale":"record"}\n' > "$td/audit"
+		printf '#!/bin/sh\nexit 0\n' > "$td/noop"
+		chmod +x "$td/noop"
+		e2e_run_bounded 3 "$td/audit" "$td/o" "$td/e" "$td/noop" "$td/cfg" "prompt" || exit 1
+		# The audit log is append-only, so without truncation a retried phase could be
+		# judged against a previous attempt's records.
+		[ ! -s "$td/audit" ] || exit 1
+	); then pass "run_bounded truncates the audit log so a retry sees only its own records"; else fail "run_bounded audit truncation"; fi
+fi
 
 if [ "$fails" -ne 0 ]; then
 	printf 'e2e-guardrails.unit: %d case(s) FAILED\n' "$fails" >&2

--- a/test/lib/e2e-guardrails.sh
+++ b/test/lib/e2e-guardrails.sh
@@ -63,8 +63,16 @@ e2e_isolate_env() {
 	# AWS/GCP/Azure creds are left alone: an LLM provider may need them (e.g.
 	# Bedrock uses AWS creds). The suite's own tool-call / connector assertions
 	# are the safety net for whether a connector should be dark.
-	unset GH_CONFIG_DIR GLAB_CONFIG_DIR KUBECONFIG \
-		GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+	unset GITHUB_TOKEN GH_TOKEN GITLAB_TOKEN GITLAB_ACCESS_TOKEN OAUTH_TOKEN
+	# The config-dir vars are NEUTRALIZED, not unset. gh, glab, and kubectl all fall
+	# back to a DEFAULT location when their env var is absent (~/.config/gh,
+	# ~/.kube/config), so unsetting them hands a maintainer's real credentials to a
+	# suite that meant to silence them. Empty paths make discovery find nothing.
+	mkdir -p "$1/empty-gh" "$1/empty-glab"
+	: > "$1/empty-kubeconfig"
+	export GH_CONFIG_DIR="$1/empty-gh"
+	export GLAB_CONFIG_DIR="$1/empty-glab"
+	export KUBECONFIG="$1/empty-kubeconfig"
 }
 
 # e2e_build_binary ROOT WORKDIR [PREBUILT] - print a usable cynative binary path.
@@ -101,6 +109,17 @@ e2e_run_bounded() {
 	_cfg=$6
 	_prompt=$7
 	shift 7
+	# Truncate the audit log before every attempt. cynative opens it append-only, so
+	# without this a stale record from a failed earlier attempt could satisfy this
+	# attempt's parser. This lives here, not in the callers, because this helper
+	# already owns the audit path and a caller that forgot it would fail silently.
+	# Fail closed: `set -e` is suppressed for a function used as an `if` condition,
+	# so a failed truncation must be checked explicitly or the run would be judged
+	# against a previous attempt's records.
+	if ! : > "$_audit"; then
+		printf 'FAIL: could not truncate the audit log: %s\n' "$_audit" >&2
+		return 1
+	fi
 	# The exit code is captured in the else branch: a completed `if` with no
 	# matching branch yields status 0, so `return $?` after `fi` would swallow a
 	# timeout/failure. In the else, $? still holds the condition's exit status.
@@ -139,4 +158,97 @@ e2e_classify_run() {
 		return 1
 	fi
 	return 0
+}
+
+# Phase status contract, shared by the connector suites and e2e_run_with_retries:
+#   0  the phase's assertions hold.
+#   1  not proven this attempt (a model miss, a fumbled call, a transient failure).
+#      Retryable: model runs are non-deterministic.
+#   2  the run timed out.
+#   3  the token budget was hit. FATAL: a retry only burns more credits and re-hits
+#      the same ceiling.
+#   4  a SECURITY assertion failed: a request the read-only boundary should have
+#      stopped was dispatched, or a write succeeded. FATAL, and never retried.
+#
+# Status 4 exists because retrying a security failure would launder it. The retry
+# helper truncates the audit log before each attempt, so a first attempt that caught
+# a real boundary violation would have its evidence erased, and a second attempt that
+# happened to be denied would let the suite exit 0 on a broken gate.
+E2E_STATUS_BUDGET=3
+E2E_STATUS_SECURITY=4
+
+# e2e_require_env SUITE REQUIRE_RUN VAR... - gate a suite on its required env.
+# Returns 0 when every VAR is set. Returns 1 (the caller should skip, exit 0) when
+# one is missing. EXITS 1 when REQUIRE_RUN is "1", so a CI job can never go green by
+# silently skipping a renamed or dropped variable.
+e2e_require_env() {
+	_suite=$1
+	_require=$2
+	shift 2
+	_missing=
+	for _v in "$@"; do
+		eval "_val=\${$_v:-}"
+		[ -n "$_val" ] || _missing="$_missing $_v"
+	done
+	[ -n "$_missing" ] || return 0
+	if [ "$_require" = "1" ]; then
+		printf 'FAIL: required env unset but REQUIRE_RUN=1 (%s):%s\n' "$_suite" "$_missing" >&2
+		exit 1
+	fi
+	printf 'skip: %s (unset:%s)\n' "$_suite" "$_missing" >&2
+	return 1
+}
+
+# e2e_run_with_retries LABEL ATTEMPTS PHASE_FN - run a phase, retrying a
+# non-deterministic model miss up to ATTEMPTS times. A budget hit (3) and a security
+# failure (4) are FATAL and are never retried; see the status contract above. Exits 1
+# when attempts are exhausted.
+#
+# The phase's exit code is captured in the else branch: a completed `if` with no
+# matching branch yields status 0, so reading $? after `fi` would swallow it.
+e2e_run_with_retries() {
+	_label=$1
+	_attempts=$2
+	_fn=$3
+	case "$_attempts" in
+		1 | 2 | 3) ;;
+		*)
+			printf 'FAIL: %s: attempts must be 1-3, got %s\n' "$_label" "$_attempts" >&2
+			exit 1
+			;;
+	esac
+	_n=0
+	while true; do
+		if "$_fn"; then
+			return 0
+		else
+			_prc=$?
+		fi
+		if [ "$_prc" -eq "$E2E_STATUS_SECURITY" ]; then
+			printf 'FAIL: %s phase FAILED A SECURITY ASSERTION; not retrying (a retry would erase the evidence)\n' "$_label" >&2
+			exit 1
+		fi
+		if [ "$_prc" -eq "$E2E_STATUS_BUDGET" ]; then
+			printf 'FAIL: %s phase hit the token budget; not retrying\n' "$_label" >&2
+			exit 1
+		fi
+		_n=$((_n + 1))
+		if [ "$_n" -ge "$_attempts" ]; then
+			printf 'FAIL: %s phase failed after %d attempt(s)\n' "$_label" "$_n" >&2
+			exit 1
+		fi
+		printf 'retry: %s phase attempt %d failed, retrying\n' "$_label" "$_n" >&2
+	done
+}
+
+# e2e_assert_tool_called ERR - the footer must report a POSITIVE tool-call count.
+# Matching a positive count (rather than rejecting "0 tool calls") also fails a
+# missing or reshaped footer, which a negative check would quietly pass.
+e2e_assert_tool_called() {
+	if grep -Eq '(^|[^0-9])[1-9][0-9]* tool calls?' "$1"; then
+		return 0
+	fi
+	printf 'no positive tool-call count in the footer (no tool work happened). stderr tail:\n' >&2
+	tail -n 20 "$1" >&2
+	return 1
 }


### PR DESCRIPTION
Adds a live AWS connector e2e: the real `cynative -p` driven against a dedicated AWS fixture account through the `aws` connector, proving a genuine read and a client-side-denied write. Standalone (`make connector-aws-e2e`), never part of `make check`, skips cleanly with no credentials.

Closes #52.

## The two phases

**READ.** The prompt names an inert fixture IAM role and asks for the value of its `cynative-e2e-fixture` tag. That value reaches the test out of band and **never appears in the prompt**, so the model can only produce it by actually reading the role through the connector.

**CANARY.** One spelled-out `TagRole` write. A task-framed "try to write" is unreliable (a capable model predicts the denial and declines to spend the call), so the exact request is given and the gate still does the deciding. The tag it would set is **already set** on a role that grants nothing, so even an escaped write is a no-op.

## The parser is the point

An audit parser that merely greps for a denial string can pass while the boundary is broken. This one is built against that:

- **The canary is validated whole, not by its denial text.** The classifier reads only the `Action` field, so a `TagRole` aimed at a *different role* produces a byte-identical denial and would otherwise "prove" a request nobody made.
- **Every HTTP call is checked, not just the interesting ones.** A denied canary sitting beside an unmarked write that *succeeded* must not pass.
- **A request that reached AWS is never waved through as harmless.** `outcome` cannot answer "did it leave the machine": a write can be dispatched, get a 2xx, and only then fail while its body is read. Only an `aws_hardening` error proves a pre-dispatch block, because every auth gate runs before the request is sent. A 4xx from AWS means the client gate *leaked a write*.
- **A successful call cannot fake a block** by carrying `aws_hardening` in its response body.
- The HTTP status is parsed out of both result encodings (`outcome=ok` only means "below 400", which includes 3xx), and a malformed audit line fails closed instead of being skipped.

The parser's exit code **is** the phase status: `1` is a retryable miss, `4` is a boundary failure that is **never retried**. That split is load-bearing. The audit log is truncated per attempt, so retrying a detected breach would erase the evidence and let the next attempt go green on a broken gate.

22 offline selftest cases, each one a way an earlier draft would have false-greened. `make sh-test` now gates both connector parsers' selftests: they are the security boundary of the live suites and **nothing in CI ran them before**, so the GCP parser has been shipping unverified.

## Shared harness, and two bugs fixed on the way

The provider-agnostic machinery moves into `test/lib/e2e-guardrails.sh` and the GCP script adopts it (it gets 82 lines shorter). Two real bugs surfaced:

- The tool-call assertion rejected `0 tool calls`, so a run that produced **no footer at all** passed. It now requires a positive count.
- `e2e_isolate_env` *unset* `GH_CONFIG_DIR` / `KUBECONFIG`, which does not silence those connectors: it sends them to their **defaults** (`~/.config/gh`, `~/.kube/config`). On a maintainer's machine that handed real credentials to a suite meant to silence them. They now point at empty paths.

## Live validation

Both phases, first attempt, Bedrock `us.anthropic.claude-haiku-4-5`, against the fixture account:

```
== READ == cynative-connector-e2e-fixture (bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0)
read: OK (1 qualifying AWS response carried the tag)
== CANARY == attempting a denied write on cynative-connector-e2e-fixture
canary: OK (1 sanctioned canary, denied by the policy gate before dispatch)
connector.aws.e2e: OK (cynative-connector-e2e-fixture on 550428926692)
```

The read came back `HTTP/1.1 200 OK` with the tag in the body. The canary was denied with `aws_hardening: action denied by policy: [iam:TagRole] denied by policy arn:aws:iam::aws:policy/SecurityAudit`, carried **no HTTP status** (proving it never reached the wire), and the fixture role's tags were unchanged afterwards.

**The suite can go red.** Four audit logs tampered from the real ones: a write that succeeded (exit 4), an unmarked write that reached AWS and got a 403 (exit 4), the nonce arriving via a `github` call (exit 4), and a canary mutated to target the real CI role (exit 1, correctly a retryable miss).

## Out-of-band AWS state (not in the repo)

- `cynative-connector-e2e-fixture`: a new IAM role that exists only to be read. No policies, Deny-all trust, so it is unassumable and grants nothing.
- `cynative-cli-ci`: gained one additive trust statement letting it assume itself, which is what makes cynative's credential scoping engage. **No permissions were added**, and `iam:TagRole` is deliberately still denied to it, so AWS itself is the backstop behind the client-side gate.

## Not a release gate

This is release-confidence evidence, exactly like the GCP suite: gated to release-please PRs and manual dispatch, unreachable from fork PRs, and not a required status check. Promoting it to a gate is a separate, deliberate change once it has soaked.
