### PR TITLE
ci(deps): enable indirect Go dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,29 @@
 version: 2
+
 multi-ecosystem-groups:
   all-dependencies:
     schedule:
       interval: "daily"
     commit-message:
       prefix: "fix(deps)"
+
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "all-dependencies"
+    # dependency-type "all" turns on updates for indirect (transitive) modules,
+    # not just direct ones.
+    allow:
+      - dependency-type: "all"
+    ignore:
+      # Untagged nested modules of the charmbracelet/x monorepo. The root module
+      # is tagged (v0.1.0) but these submodules have no tags, so Dependabot's Go
+      # version discovery mis-resolves them to the root and fails the gomod
+      # update (dependency_file_not_resolvable). Deep terminal-UI transitives
+      # (via glamour and via goreleaser -> fang). Revisit if charmbracelet tags
+      # the x/exp submodules.
+      - dependency-name: "github.com/charmbracelet/x/exp/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns: ["*"]


### PR DESCRIPTION
## What & why

Add `allow: dependency-type: "all"` to the `gomod` Dependabot entry so version updates cover indirect (transitive) modules, not just direct ones. All four ecosystems stay in the single `all-dependencies` multi-ecosystem group (one combined daily PR), so the only change from the previous config is turning on indirect Go updates plus one ignore.

Indirect security vulnerabilities were piling up as alerts that needed manual fixes (for example `sigstore/sigstore-go`, currently open at v1.1.4, first patched 1.2.0). Enabling indirect version updates keeps transitive modules fresh and lets Dependabot bump them automatically. The direct parent cannot fix `sigstore-go` on its own - even the latest `goreleaser` still requires the vulnerable version - so the indirect require line has to move directly, which `dependency-type: "all"` enables.

`github.com/charmbracelet/x/exp/charmtone` and `.../slice` are pinned at pseudo-versions because the `charmbracelet/x` monorepo tags only its root module, not those nested submodules. Under `dependency-type: "all"`, Dependabot's Go version discovery mis-resolves them to the tagged root and fails the gomod update, so they are ignored here. They are deep terminal-UI transitives; revisit the ignore if the submodules get tagged upstream.

The real validation is the next scheduled run: the combined `all-dependencies` PR should include indirect Go bumps with no `dependency_file_not_resolvable` in the gomod update log. If Go resolution fails instead, revert the `allow`/`ignore` blocks (one commit).

## Checklist
- [x] `make check` passes locally (config-only change; `make check` does not read `.github/dependabot.yml`, and CI runs it on this PR)
- [x] Tests added/updated for the change (N/A - Dependabot config; the acceptance test is the next scheduled update run, which cannot run pre-merge)
- [x] Docs updated if behavior changed (N/A - no product behavior change; the config is self-documented in comments)