### PR TITLE
test: count only available connectors in the llm-smoke connector assert

### DIFF
--- a/test/e2e-guardrails.unit.test.sh
+++ b/test/e2e-guardrails.unit.test.sh
@@ -247,6 +247,81 @@ if (
 	if e2e_assert_tool_called "$td/none.err" >/dev/null 2>&1; then exit 1; fi
 ); then pass "assert_tool_called requires a positive count, fails on 0 and on a missing footer"; else fail "assert_tool_called"; fi
 
+# ---- e2e_assert_no_available_connectors -----------------------------------------
+# Fixtures reproduce the rendered startup inventory (internal/ui formatConnector +
+# internal/cli/research.go): "  Connectors", a "  ──" rule, then "  ✓/✗/⚠ name …"
+# lines or "  (no connectors detected)". inv() writes the banner + header + rule so
+# each fixture is just its distinguishing section lines; an empty arg is a blank
+# line, and an arg may carry embedded newlines (a multi-line skip reason). The
+# noise fixtures (sdk/footer) mirror real stderr: the AWS SDK logs and the run
+# footer interleave with the inventory and carry no two-space indent.
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	rule='  ────────────────'
+	k8s='  ✗ kubernetes  kubernetes_hardening: skipped: kubernetes: no current-context set'
+	sdk='SDK 2026/07/15 21:19:52 WARN falling back to IMDSv1: operation error ec2imds: getToken'
+	footer='── 0.1s · 1 model call · 0 tool calls · bedrock/model-id'
+	inv() { printf 'banner noise\n\n  Connectors\n%s\n' "$rule"; [ "$#" -eq 0 ] || printf '%s\n' "$@"; }
+
+	# Real CI success shape: only kubernetes loud-skips (explicit-but-empty
+	# KUBECONFIG), and an SDK warning + the run footer interleave before EOF (a
+	# successful `-p` run renders no LLM section). Must pass: no connector is
+	# available, and the non-indented noise lines are not inventory records.
+	inv "$k8s" "$sdk" "$footer" > "$td/ci-eof.err"
+	e2e_assert_no_available_connectors "$td/ci-eof.err" >/dev/null 2>&1 || exit 1
+
+	# Same, with an LLM section after a blank line: its "✓ provider" line reuses
+	# the glyph but must not count, since the scan stops at the "  LLM" header.
+	inv "$k8s" "$sdk" "$footer" "" "  LLM" "$rule" "  ✓ bedrock   model-id" > "$td/ci-llm.err"
+	e2e_assert_no_available_connectors "$td/ci-llm.err" >/dev/null 2>&1 || exit 1
+
+	# The empty-inventory marker passes.
+	inv "  (no connectors detected)" > "$td/marker.err"
+	e2e_assert_no_available_connectors "$td/marker.err" >/dev/null 2>&1 || exit 1
+
+	# A multi-line skip reason (an Azure credential-chain error) whose
+	# continuation lines carry no two-space indent must be tolerated, not
+	# fail-closed: a skipped connector is still unavailable.
+	az='  ✗ azure       azure_hardening: skipped (no usable credentials): failed to acquire a token.
+Attempted credentials:
+	EnvironmentCredential: missing environment variable AZURE_TENANT_ID'
+	inv "$k8s" "$az" "$footer" > "$td/multiline.err"
+	e2e_assert_no_available_connectors "$td/multiline.err" >/dev/null 2>&1 || exit 1
+
+	# An available connector (✓) fails, even after a multi-line skip reason (the
+	# scan must not stop early on the reason's blank/continuation lines).
+	inv "$az" "  ✓ aws         access=default(read-only)" > "$td/avail.err"
+	if e2e_assert_no_available_connectors "$td/avail.err" >/dev/null 2>&1; then exit 1; fi
+
+	# A warn-flagged connector (⚠) is still available: fails.
+	inv "  ⚠ github      access=widened" > "$td/warn.err"
+	if e2e_assert_no_available_connectors "$td/warn.err" >/dev/null 2>&1; then exit 1; fi
+
+	# A mixed section fails on the available line even alongside a skip.
+	inv "$k8s" "  ✓ gcp         access=default(read-only)" > "$td/mixed.err"
+	if e2e_assert_no_available_connectors "$td/mixed.err" >/dev/null 2>&1; then exit 1; fi
+
+	# Fail-closed: an empty section body (header + rule then EOF) must fail, not
+	# quietly pass - a truncated or reshaped inventory is not a clean bill.
+	inv > "$td/empty.err"
+	if e2e_assert_no_available_connectors "$td/empty.err" >/dev/null 2>&1; then exit 1; fi
+
+	# Fail-closed: a blank line right after the rule then an available connector.
+	# The blank must not terminate the scan before the ✓ is classified.
+	inv "" "  ✓ gcp         access=default(read-only)" > "$td/blank-then-avail.err"
+	if e2e_assert_no_available_connectors "$td/blank-then-avail.err" >/dev/null 2>&1; then exit 1; fi
+
+	# Fail-closed: no Connectors header at all (a missing or reshaped inventory).
+	printf 'banner noise\nno inventory here\n' > "$td/nohdr.err"
+	if e2e_assert_no_available_connectors "$td/nohdr.err" >/dev/null 2>&1; then exit 1; fi
+
+	# Fail-closed: an unrecognized two-space-indented line inside the section
+	# (e.g. a changed glyph convention) must fail, not quietly pass.
+	inv "  OK gcp        access=default(read-only)" > "$td/drift.err"
+	if e2e_assert_no_available_connectors "$td/drift.err" >/dev/null 2>&1; then exit 1; fi
+); then pass "assert_no_available_connectors passes dark inventories with interleaved noise, anchors to the section, fails on ✓/⚠ and fails closed on empty/missing/reshaped"; else fail "assert_no_available_connectors"; fi
+
 # ---- e2e_run_bounded truncates the audit log before each attempt ---------------
 if command -v timeout >/dev/null 2>&1; then
 	if (

--- a/test/lib/e2e-guardrails.sh
+++ b/test/lib/e2e-guardrails.sh
@@ -241,6 +241,65 @@ e2e_run_with_retries() {
 	done
 }
 
+# e2e_assert_no_available_connectors ERR - the startup connector inventory must
+# show no AVAILABLE connector. Available renders as a "✓" (ok) or "⚠" (warn)
+# line inside the "Connectors" section; an unavailable "✗ ... skipped"
+# diagnostic is not a registration, so it passes - e2e_isolate_env's
+# explicit-but-empty KUBECONFIG makes the kubernetes connector emit exactly
+# that on a host with no other credentials.
+#
+# Every inventory record is one line that starts with two spaces (a glyph line,
+# the "  ──" rule, or "  (no connectors detected)"), rendered by internal/ui
+# formatConnector and internal/cli/research.go. The scan begins at the
+# "  Connectors" header and ends at the "  LLM" header (whose section reuses the
+# same glyphs) or at EOF (a successful `-p` run prints no LLM section). Lines
+# without the two-space indent are NOT records - the AWS SDK's logs and the run
+# footer interleave with the inventory on real stderr, and a multi-line skip
+# reason's continuation lines wrap unindented - so they are ignored rather than
+# treated as drift. A blank line is one such non-record line and does not end
+# the scan (the footer and the multi-line reasons both sit before the blank that
+# precedes the LLM section).
+#
+# Fail-closed: a two-space-indented line that matches no known record shape is
+# drift and fails; and the section must contain the rule plus at least one record
+# line, so a missing header, a truncated inventory, or a reshape that empties the
+# scan window fails loudly instead of quietly passing.
+e2e_assert_no_available_connectors() {
+	_rc=0
+	_hdr=0
+	_in=0
+	_rule=0
+	_records=0
+	while IFS= read -r _line || [ -n "$_line" ]; do
+		case $_line in
+			'  Connectors') _hdr=1; _in=1; continue ;;
+			'  LLM') _in=0; continue ;; # next section (same glyphs): stop scanning.
+		esac
+		[ "$_in" -eq 1 ] || continue
+		case $_line in
+			'  ──'*) _rule=1 ;; # the section's horizontal rule
+			'  (no connectors detected)') _records=$((_records + 1)) ;;
+			'  ✗ '*) _records=$((_records + 1)) ;; # unavailable (skipped/invalid): not a registration
+			'  ✓ '* | '  ⚠ '*)
+				printf 'available connector in the startup inventory: %s\n' "$_line" >&2
+				_records=$((_records + 1))
+				_rc=1
+				;;
+			'  '*)
+				printf 'unrecognized connector-inventory line (fail closed): %s\n' "$_line" >&2
+				_rc=1
+				;;
+			*) ;; # no two-space indent: SDK log, run footer, blank, or a wrapped skip reason.
+		esac
+	done < "$1"
+	if [ "$_hdr" -eq 0 ] || [ "$_rule" -eq 0 ] || [ "$_records" -eq 0 ]; then
+		printf 'no well-formed "Connectors" inventory in stderr (missing, empty, or reshaped). stderr tail:\n' >&2
+		tail -n 20 "$1" >&2
+		return 1
+	fi
+	return "$_rc"
+}
+
 # e2e_assert_tool_called ERR - the footer must report a POSITIVE tool-call count.
 # Matching a positive count (rather than rejecting "0 tool calls") also fails a
 # missing or reshaped footer, which a negative check would quietly pass.

--- a/test/llm.smoke.test.sh
+++ b/test/llm.smoke.test.sh
@@ -22,7 +22,9 @@
 #                               gemini-2.5-flash spends a few thousand tokens, and
 #                               the budget is checked after the response, so too
 #                               low a value discards the answer for a budget notice)
-#   SMOKE_REQUIRE_NO_CONNECTORS =1 hard-fails unless no connector registers
+#   SMOKE_REQUIRE_NO_CONNECTORS =1 hard-fails when an AVAILABLE connector
+#                               registers (an unavailable "skipped" inventory
+#                               line is fine: it cannot serve a request)
 #   SMOKE_REQUIRE_RUN          =1 hard-fails (instead of skipping) when provider/
 #                               model are unset, so a misconfigured CI job that
 #                               would silently skip is caught as a failure
@@ -103,12 +105,16 @@ if ! grep -Eq '(^|[^0-9])0 tool calls' "$workdir/err"; then
 fi
 
 # Connector check: soft warn by default, hard when SMOKE_REQUIRE_NO_CONNECTORS=1.
-if ! grep -Fq '(no connectors detected)' "$workdir/err"; then
+# Only an AVAILABLE connector counts as registered: e2e_isolate_env's
+# explicit-but-empty KUBECONFIG makes the kubernetes connector print a loud
+# "✗ ... skipped" inventory line even on a credential-less CI runner, and an
+# unavailable connector cannot serve a request.
+if ! e2e_assert_no_available_connectors "$workdir/err"; then
 	if [ "${SMOKE_REQUIRE_NO_CONNECTORS:-}" = "1" ]; then
-		printf 'FAIL: a connector registered (SMOKE_REQUIRE_NO_CONNECTORS=1)\n' >&2
+		printf 'FAIL: an available connector registered (SMOKE_REQUIRE_NO_CONNECTORS=1)\n' >&2
 		exit 1
 	fi
-	printf 'warn: a connector registered (expected none); the 0-tool-calls assertion still holds\n' >&2
+	printf 'warn: an available connector registered (expected none); the 0-tool-calls assertion still holds\n' >&2
 fi
 
 printf 'llm.smoke: OK (%s/%s)\n' "$CYNATIVE_LLM_PROVIDER" "$CYNATIVE_LLM_MODEL" >&2


### PR DESCRIPTION
## What & why

The two no-tool live LLM smokes (`vertex-notool`, `bedrock-notool`) fail on the release-please PR (#112) with `FAIL: a connector registered (SMOKE_REQUIRE_NO_CONNECTORS=1)`, even though nothing usable lit up.

The smoke keyed its connector check off the `(no connectors detected)` marker line, but any inventory line suppresses that marker, including an unavailable one. Since #111 points `KUBECONFIG` at an empty file (isolation hardening), the kubernetes connector prints a loud `✗ ... skipped: no current-context set` on a credential-less CI runner, because a set `KUBECONFIG` is an explicit signal. That single line breaks the assertion.

This replaces the marker grep with `e2e_assert_no_available_connectors`, which scans the Connectors inventory section and fails only on an available (`✓`/`⚠`) connector. An unavailable skip cannot serve a request, so it passes. `verify_findings`-style intent unchanged: the isolation guarantee is still enforced, just correctly.

Real stderr interleaves the AWS SDK's logs and the run footer with the inventory, and a multi-line skip reason (e.g. an Azure credential-chain error) wraps onto unindented continuation lines. The helper keys off the two-space indent every rendered inventory record carries: non-indented lines are ignored, the scan ends at the `LLM` section header (which reuses the same glyphs) or EOF, and it fails closed unless the section holds the rule plus at least one record line, so a missing, truncated, or reshaped inventory breaks the assertion loudly instead of passing quietly.

## Checklist
- [x] `make check-scripts` passes locally (shellcheck + Pester + PSScriptAnalyzer + sh-test); pre-commit `check-go` gate passed
- [x] Tests added/updated for the change (11-fixture unit section modeling the real interleaved stderr, both directions and the fail-closed cases)
- [x] Docs updated if behavior changed (n/a: internal test harness only)
