### PR TITLE
fix: bound the Kubernetes ClusterRole preflight against a stalled cluster

### DIFF
--- a/internal/auth/auth_internal_test.go
+++ b/internal/auth/auth_internal_test.go
@@ -61,6 +61,49 @@ func mockTokenSource(token *oauth2.Token, err error) *tokenSourceMock {
 	}
 }
 
+func TestTokenWithContext_ReturnsToken(t *testing.T) {
+	t.Parallel()
+
+	ts := mockTokenSource(&oauth2.Token{AccessToken: "abc"}, nil) //nolint:exhaustruct // only AccessToken.
+
+	tok, err := tokenWithContext(context.Background(), ts)
+	if err != nil {
+		t.Fatalf("tokenWithContext: %v", err)
+	}
+	if tok.AccessToken != "abc" {
+		t.Fatalf("AccessToken = %q, want abc", tok.AccessToken)
+	}
+}
+
+func TestTokenWithContext_ReturnsWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	// A token source whose refresh stalls (no context to cancel it): only the
+	// caller's context can end the wait.
+	ts := &tokenSourceMock{TokenFunc: func() (*oauth2.Token, error) {
+		<-release
+
+		return &oauth2.Token{AccessToken: "late"}, nil //nolint:exhaustruct // only AccessToken.
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tok, err := tokenWithContext(ctx, ts)
+	if err == nil {
+		t.Fatal("expected a context error from the stalled token refresh, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if tok != nil {
+		t.Fatalf("want nil token on cancellation, got %+v", tok)
+	}
+}
+
 func TestGitHubProvider_NameAndDescription(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/cert_cache.go
+++ b/internal/auth/cert_cache.go
@@ -2,23 +2,36 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
 )
 
-// syncCache is a concurrency-safe, success-only cache for any data.
-// It uses singleflight to coalesce concurrent lookups for the same key and a
-// mutex-protected map to store results. Errors are NOT cached — a transient
-// failure will be retried on the next call.
+// syncCache is a concurrency-safe, success-only cache for K8s bootstrap facts
+// (cluster TLS material, view policies). It uses singleflight to coalesce
+// concurrent lookups for the same key and a mutex-protected map to store
+// results. Errors are NOT cached — a transient failure will be retried on the
+// next call. Each fetch is bounded by timeout (defaulting to
+// k8sBootstrapFetchTimeout when zero): a fixed whole-operation ceiling that keeps
+// a stalled cluster endpoint from wedging the run.
 type syncCache[T any] struct {
-	mu    sync.Mutex
-	items map[string]T
-	sfg   singleflight.Group
+	mu      sync.Mutex
+	items   map[string]T
+	sfg     singleflight.Group
+	timeout time.Duration
 }
 
-// get returns the cached value for key, or calls fetch to populate it.
-// The fetch function is called at most once per key concurrently.
+// get returns the cached value for key, or calls fetch to populate it. The fetch
+// runs at most once per key concurrently, in its own goroutine (singleflight
+// DoChan) under a cache-owned deadline (timeout) that is DETACHED from any single
+// caller's cancellation, so one caller giving up cannot cut short the shared
+// fetch for the others. Each caller then waits under its own deadline plus the
+// same timeout as a backstop: the backstop is what bounds a fetch that ignores
+// its context and blocks (e.g. an oauth2 token refresh inside a cloud SDK call),
+// which a synchronous fetch could not escape. The caller's own deadline, when
+// tighter, still wins.
 func (c *syncCache[T]) get(
 	ctx context.Context,
 	key string,
@@ -37,21 +50,54 @@ func (c *syncCache[T]) get(
 
 	c.mu.Unlock()
 
-	v, err, _ := c.sfg.Do(key, func() (any, error) {
-		return fetch(ctx)
-	})
-	if err != nil {
-		var zero T
+	var zero T
+
+	// Return before launching the detached fetch when the caller is already
+	// cancelled: WithoutCancel would otherwise start a background cluster
+	// resolve / ClusterRole fetch for an interrupted request or probe.
+	if err := ctx.Err(); err != nil {
 		return zero, err
 	}
 
-	data, _ := v.(T)
-
-	c.mu.Lock()
-	if _, ok := c.items[key]; !ok {
-		c.items[key] = data
+	timeout := c.timeout
+	if timeout == 0 {
+		timeout = k8sBootstrapFetchTimeout
 	}
-	c.mu.Unlock()
 
-	return data, nil
+	ch := c.sfg.DoChan(key, func() (any, error) {
+		fctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cancel()
+
+		return fetch(fctx)
+	})
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case <-timer.C:
+		// The fetch exceeded the cache-owned ceiling, so it is ignoring its
+		// context and still running. Forget the key so the next lookup starts a
+		// fresh fetch instead of coalescing onto the stuck one (which would make
+		// every later request for this cluster time out until it unblocks).
+		c.sfg.Forget(key)
+
+		return zero, fmt.Errorf("k8s_hardening: bootstrap fetch %q exceeded %s", key, timeout)
+	case res := <-ch:
+		if res.Err != nil {
+			return zero, res.Err
+		}
+
+		data, _ := res.Val.(T)
+
+		c.mu.Lock()
+		if _, ok := c.items[key]; !ok {
+			c.items[key] = data
+		}
+		c.mu.Unlock()
+
+		return data, nil
+	}
 }

--- a/internal/auth/cert_cache_internal_test.go
+++ b/internal/auth/cert_cache_internal_test.go
@@ -1,0 +1,209 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSyncCache_BoundsStalledFetch pins that get() bounds a fetch that stalls
+// while observing its context: the cache-owned deadline ends it, so a stalled K8s
+// bootstrap fetch cannot wedge the run even under a deadline-free caller context.
+func TestSyncCache_BoundsStalledFetch(t *testing.T) {
+	t.Parallel()
+
+	c := &syncCache[int]{timeout: 60 * time.Millisecond} //nolint:exhaustruct // only timeout.
+
+	start := time.Now()
+	_, err := c.get(context.Background(), "k", func(ctx context.Context) (int, error) {
+		<-ctx.Done() // stalled fetch that observes its context.
+
+		return 0, ctx.Err()
+	})
+	if err == nil {
+		t.Fatal("expected a timeout error from the bounded fetch, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("fetch took %v; syncCache did not bound it", elapsed)
+	}
+}
+
+// TestSyncCache_BoundsContextIgnoringFetch pins the backstop: a fetch that
+// ignores its context and blocks (modelling an oauth2 token refresh inside a
+// cloud-SDK call that a synchronous fetch could not escape) is still cut off, so
+// the caller never wedges.
+func TestSyncCache_BoundsContextIgnoringFetch(t *testing.T) {
+	t.Parallel()
+
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+
+	c := &syncCache[int]{timeout: 60 * time.Millisecond} //nolint:exhaustruct // only timeout.
+
+	start := time.Now()
+	_, err := c.get(context.Background(), "k", func(context.Context) (int, error) {
+		<-stuck // blocks WITHOUT observing the context; only the caller timer can end this.
+
+		return 0, nil
+	})
+	if err == nil {
+		t.Fatal("expected the timer backstop to bound the context-ignoring fetch, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("caller took %v; the timer backstop did not bound the context-ignoring fetch", elapsed)
+	}
+}
+
+// TestSyncCache_TighterCallerDeadlineWins pins that a caller whose own deadline is
+// tighter than the cache timeout returns on its own deadline (the cache timeout is
+// a ceiling, not a floor). This is what keeps the 5s registration probe bounded.
+func TestSyncCache_TighterCallerDeadlineWins(t *testing.T) {
+	t.Parallel()
+
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+
+	c := &syncCache[int]{timeout: time.Hour} //nolint:exhaustruct // only timeout.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.get(ctx, "k", func(context.Context) (int, error) {
+		<-stuck
+
+		return 0, nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want context.DeadlineExceeded from the caller deadline, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("caller took %v; its own (tighter) deadline should have bounded it", elapsed)
+	}
+}
+
+// TestSyncCache_ReturnsFetchError pins that a fetch error propagates and is NOT
+// cached (a later call retries).
+func TestSyncCache_ReturnsFetchError(t *testing.T) {
+	t.Parallel()
+
+	c := &syncCache[int]{} //nolint:exhaustruct // zero value uses the default timeout.
+
+	sentinel := errors.New("boom")
+	var calls int
+	fetch := func(context.Context) (int, error) {
+		calls++
+
+		return 0, sentinel
+	}
+
+	if _, err := c.get(context.Background(), "k", fetch); !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error, got %v", err)
+	}
+	if _, err := c.get(context.Background(), "k", fetch); !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error on retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("fetch called %d times; errors must not be cached (want 2)", calls)
+	}
+}
+
+// TestSyncCache_AlreadyCancelledCallerSkipsFetch pins that an already-cancelled
+// caller returns without launching the detached background fetch (an interrupted
+// request or probe must not start a cluster resolve / ClusterRole fetch).
+func TestSyncCache_AlreadyCancelledCallerSkipsFetch(t *testing.T) {
+	t.Parallel()
+
+	c := &syncCache[int]{timeout: time.Hour} //nolint:exhaustruct // only timeout.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var started atomic.Bool
+	_, err := c.get(ctx, "k", func(context.Context) (int, error) {
+		started.Store(true)
+
+		return 0, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if started.Load() {
+		t.Fatal("fetch must not start for an already-cancelled caller")
+	}
+}
+
+// TestSyncCache_ForgetsTimedOutFetch pins that after a context-ignoring fetch
+// blocks past the cache timeout, a later lookup for the same key starts a FRESH
+// fetch instead of coalescing onto the stuck one, so one stalled fetch cannot
+// poison the connector for the rest of the process.
+func TestSyncCache_ForgetsTimedOutFetch(t *testing.T) {
+	t.Parallel()
+
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+
+	c := &syncCache[int]{timeout: 60 * time.Millisecond} //nolint:exhaustruct // only timeout.
+
+	var starts atomic.Int32
+	fetch := func(context.Context) (int, error) {
+		starts.Add(1)
+		<-stuck // ignores context and blocks past the timeout.
+
+		return 0, nil
+	}
+
+	if _, err := c.get(context.Background(), "k", fetch); err == nil {
+		t.Fatal("first call should time out")
+	}
+	if _, err := c.get(context.Background(), "k", fetch); err == nil {
+		t.Fatal("second call should time out")
+	}
+
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("fetch started %d times; a timed-out fetch must be forgotten so the retry starts fresh (want 2)", got)
+	}
+}
+
+// TestSyncCache_CallerGivingUpDoesNotFailPeer pins the coalescing isolation: when
+// two callers miss the same key, one giving up on a tight deadline must not make
+// the other (with a longer budget) fail. The shared fetch is detached from any
+// single caller.
+func TestSyncCache_CallerGivingUpDoesNotFailPeer(t *testing.T) {
+	t.Parallel()
+
+	c := &syncCache[int]{timeout: time.Hour} //nolint:exhaustruct // only timeout.
+
+	leaderStarted := make(chan struct{})
+	release := make(chan struct{})
+	//nolint:unparam // the error result is fixed by syncCache.get's fetch signature; this stub always succeeds.
+	fetch := func(context.Context) (int, error) {
+		close(leaderStarted)
+		<-release
+
+		return 42, nil
+	}
+
+	// The leader (long budget) starts the shared fetch and blocks on release.
+	leaderResult := make(chan int, 1)
+	go func() {
+		v, _ := c.get(context.Background(), "k", fetch)
+		leaderResult <- v
+	}()
+	<-leaderStarted
+
+	// A peer with a tight deadline coalesces onto the in-flight fetch and gives up.
+	peerCtx, peerCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer peerCancel()
+	if _, err := c.get(peerCtx, "k", fetch); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("peer should have timed out with DeadlineExceeded, got %v", err)
+	}
+
+	// The peer gave up; the leader must still receive the successful result.
+	close(release)
+	if v := <-leaderResult; v != 42 {
+		t.Fatalf("leader got %d, want 42 (a peer giving up must not fail the leader)", v)
+	}
+}

--- a/internal/auth/gke.go
+++ b/internal/auth/gke.go
@@ -68,6 +68,31 @@ func newGKEProvider(tokenSource oauth2.TokenSource) *gkeProvider {
 	return p
 }
 
+// tokenWithContext mints a token from ts under the caller's context. oauth2's
+// TokenSource.Token takes no context, so a stalled refresh would otherwise be
+// uncancellable and could wedge the preflight; the goroutine + select makes the
+// wait honor ctx (the abandoned refresh drains into the buffered channel and the
+// goroutine exits when it finally returns).
+func tokenWithContext(ctx context.Context, ts oauth2.TokenSource) (*oauth2.Token, error) {
+	type result struct {
+		tok *oauth2.Token
+		err error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		tok, err := ts.Token()
+		ch <- result{tok: tok, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("gke: token refresh cancelled: %w", ctx.Err())
+	case r := <-ch:
+		return r.tok, r.err
+	}
+}
+
 func (p *gkeProvider) Name() string {
 	return gkeProviderName
 }

--- a/internal/auth/gke_shell.go
+++ b/internal/auth/gke_shell.go
@@ -16,7 +16,7 @@ func (p *gkeProvider) defaultFetchView(ctx context.Context, args *GKEAuthArgs) (
 		return nil, err
 	}
 
-	token, err := p.tokenSource.Token()
+	token, err := tokenWithContext(ctx, p.tokenSource)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/k8s_fetch.go
+++ b/internal/auth/k8s_fetch.go
@@ -1,0 +1,50 @@
+package auth
+
+import "time"
+
+// k8sFetchTimeouts bounds each phase of the bootstrap ClusterRole fetch so a
+// cluster endpoint that accepts the connection and then stalls cannot wedge the
+// fetch even under a deadline-free context. dial/tlsHandshake/responseHeader cap
+// connection setup and time-to-first-response-header; overall is the whole-request
+// backstop (http.Client.Timeout, which also covers the body read the phase
+// timeouts do not). The caller's context deadline (the registration probe
+// timeout, or the request's clamped timeout at dispatch) is normally tighter and
+// does the real bounding; these are defense-in-depth for any unbounded caller.
+type k8sFetchTimeouts struct {
+	dial           time.Duration
+	tlsHandshake   time.Duration
+	responseHeader time.Duration
+	overall        time.Duration
+}
+
+// Production phase timeouts for the bootstrap ClusterRole fetch. The
+// connection-setup caps mirror the request transport's, and the overall backstop
+// covers the whole fetch including the body read the phase timeouts do not.
+const (
+	k8sFetchDialTimeout           = 10 * time.Second
+	k8sFetchTLSHandshakeTimeout   = 10 * time.Second
+	k8sFetchResponseHeaderTimeout = 15 * time.Second
+	k8sFetchOverallTimeout        = 30 * time.Second
+)
+
+// k8sBootstrapFetchTimeout is the default whole-operation bound syncCache applies
+// to each K8s bootstrap fetch (cluster resolve, token mint, ClusterRole read). It
+// is deliberately the cache's OWN fixed timeout, not the per-request timeout, so
+// (1) a stalled cluster endpoint cannot wedge the run even when the caller's
+// context has no deadline, and (2) a short-deadline caller cannot cut short a
+// concurrent, longer-budget caller coalesced onto the same singleflight fetch. It
+// is a ceiling: a caller with a tighter deadline (e.g. the registration probe)
+// still wins. It sits slightly above k8sFetchOverallTimeout so the pinnedHTTPClient
+// phase timeouts surface a precise error before this coarse backstop fires.
+const k8sBootstrapFetchTimeout = 35 * time.Second
+
+// defaultK8sFetchTimeouts are the production phase timeouts for the bootstrap
+// ClusterRole fetch.
+func defaultK8sFetchTimeouts() k8sFetchTimeouts {
+	return k8sFetchTimeouts{
+		dial:           k8sFetchDialTimeout,
+		tlsHandshake:   k8sFetchTLSHandshakeTimeout,
+		responseHeader: k8sFetchResponseHeaderTimeout,
+		overall:        k8sFetchOverallTimeout,
+	}
+}

--- a/internal/auth/k8s_fetch_internal_test.go
+++ b/internal/auth/k8s_fetch_internal_test.go
@@ -2,14 +2,30 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/pem"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	k8sauthz "github.com/cynative/cynative/internal/auth/k8s"
 )
+
+// tlsServerCABase64 returns the base64-PEM leaf certificate of an httptest TLS
+// server, in the form BuildTLSConfig expects, so a pinnedHTTPClient can trust it.
+func tlsServerCABase64(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+
+	return base64.StdEncoding.EncodeToString(pemBytes)
+}
+
+func noInject(*http.Request) error { return nil }
 
 func reqInfoListPods() k8sauthz.RequestInfo {
 	return k8sauthz.RequestInfo{ //nolint:exhaustruct // only the fields the matcher reads.
@@ -98,6 +114,149 @@ func TestClusterHTTPClient_PropagatesBuildError(t *testing.T) {
 	_, err := pinnedHTTPClient("not-base64-!!", "", "", "", nil)
 	if err == nil || !strings.Contains(err.Error(), "failed to decode CA certificate") {
 		t.Fatalf("want decode cluster CA error, got %v", err)
+	}
+}
+
+func TestFetchViewPolicy_StalledTLSHandshakeIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// A raw TCP listener that accepts and never speaks TLS: the dial succeeds, the
+	// TLS handshake stalls. With a deadline-free context, only the client's
+	// TLSHandshakeTimeout can end it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serverDone := make(chan struct{})
+	t.Cleanup(func() { close(serverDone); _ = ln.Close() })
+
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		<-serverDone // hold the connection open, stalling the handshake.
+	}()
+
+	to := k8sFetchTimeouts{
+		dial: time.Second, tlsHandshake: 150 * time.Millisecond, responseHeader: time.Second, overall: 5 * time.Second,
+	}
+	hc, err := pinnedHTTPClientWithTimeouts("", "", "", "", to, nil)
+	if err != nil {
+		t.Fatalf("pinnedHTTPClientWithTimeouts: %v", err)
+	}
+
+	// The backstop deadline is far longer than the timeout under test, so a
+	// regression that drops TLSHandshakeTimeout fails fast here instead of hanging.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = fetchViewPolicy(ctx, hc, "https://"+ln.Addr().String(), "view", noInject)
+	if err == nil {
+		t.Fatal("expected a TLS-handshake timeout on the stalled connection, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stalled TLS handshake took %v; TLSHandshakeTimeout did not bound the fetch", elapsed)
+	}
+}
+
+func TestFetchViewPolicy_StalledResponseHeadersAreBounded(t *testing.T) {
+	t.Parallel()
+
+	// A TLS server that completes the handshake and reads the request but never
+	// responds: only the client's ResponseHeaderTimeout can end it.
+	block := make(chan struct{})
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { <-block }))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	to := k8sFetchTimeouts{
+		dial: 2 * time.Second, tlsHandshake: 2 * time.Second,
+		responseHeader: 150 * time.Millisecond, overall: 5 * time.Second,
+	}
+	hc, err := pinnedHTTPClientWithTimeouts(tlsServerCABase64(t, srv), "", "", "", to, nil)
+	if err != nil {
+		t.Fatalf("pinnedHTTPClientWithTimeouts: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = fetchViewPolicy(ctx, hc, srv.URL, "view", noInject)
+	if err == nil {
+		t.Fatal("expected a response-header timeout on the stalled response, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stalled headers took %v; ResponseHeaderTimeout did not bound the fetch", elapsed)
+	}
+}
+
+func TestFetchViewPolicy_StalledResponseBodyIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// A TLS server that flushes the response headers and then stalls mid-body: the
+	// phase timeouts do not cover the body read, so only the overall Client.Timeout
+	// backstop can end it.
+	block := make(chan struct{})
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-block
+	}))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	to := k8sFetchTimeouts{
+		dial: 2 * time.Second, tlsHandshake: 2 * time.Second,
+		responseHeader: 2 * time.Second, overall: 200 * time.Millisecond,
+	}
+	hc, err := pinnedHTTPClientWithTimeouts(tlsServerCABase64(t, srv), "", "", "", to, nil)
+	if err != nil {
+		t.Fatalf("pinnedHTTPClientWithTimeouts: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = fetchViewPolicy(ctx, hc, srv.URL, "view", noInject)
+	if err == nil {
+		t.Fatal("expected an overall-timeout on the stalled body, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stalled body took %v; the overall Client.Timeout did not bound the fetch", elapsed)
+	}
+}
+
+func TestPinnedHTTPClient_SetsPhaseTimeouts(t *testing.T) {
+	t.Parallel()
+
+	// Without explicit dial/TLS/response-header/overall timeouts a stalled cluster
+	// endpoint wedges the bootstrap fetch even under a deadline-free context.
+	hc, err := pinnedHTTPClient("", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("pinnedHTTPClient: %v", err)
+	}
+
+	want := defaultK8sFetchTimeouts()
+	if hc.Timeout != want.overall {
+		t.Errorf("Client.Timeout = %v, want overall backstop %v", hc.Timeout, want.overall)
+	}
+
+	tr, ok := hc.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", hc.Transport)
+	}
+	if tr.TLSHandshakeTimeout != want.tlsHandshake {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", tr.TLSHandshakeTimeout, want.tlsHandshake)
+	}
+	if tr.ResponseHeaderTimeout != want.responseHeader {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", tr.ResponseHeaderTimeout, want.responseHeader)
 	}
 }
 

--- a/internal/auth/k8s_fetch_shell.go
+++ b/internal/auth/k8s_fetch_shell.go
@@ -19,9 +19,22 @@ const maxViewRoleBytes = 1 << 20 // 1 MiB.
 // (base64 PEM), optionally presenting a client certificate (base64 PEM cert+key)
 // for mTLS clusters, via [BuildTLSConfig] (the same builder the transport
 // request path uses). control, when non-nil, is installed as the [net.Dialer]
-// ControlContext hook so the bootstrap fetch runs through the dial guard.
+// ControlContext hook so the bootstrap fetch runs through the dial guard. The
+// client carries the production phase timeouts so a stalled cluster endpoint is
+// bounded even when the caller supplies no context deadline.
 func pinnedHTTPClient(
 	caData, clientCert, clientKey, serverName string,
+	control func(ctx context.Context, network, address string, c syscall.RawConn) error,
+) (*http.Client, error) {
+	return pinnedHTTPClientWithTimeouts(caData, clientCert, clientKey, serverName, defaultK8sFetchTimeouts(), control)
+}
+
+// pinnedHTTPClientWithTimeouts is pinnedHTTPClient with the phase timeouts made
+// explicit so tests can drive small values against a stalling server; production
+// callers go through pinnedHTTPClient with defaultK8sFetchTimeouts.
+func pinnedHTTPClientWithTimeouts(
+	caData, clientCert, clientKey, serverName string,
+	to k8sFetchTimeouts,
 	control func(ctx context.Context, network, address string, c syscall.RawConn) error,
 ) (*http.Client, error) {
 	tlsCfg, err := BuildTLSConfig(x509.SystemCertPool, caData, clientCert, clientKey, serverName)
@@ -29,14 +42,17 @@ func pinnedHTTPClient(
 		return nil, err
 	}
 
-	tr := &http.Transport{ //nolint:exhaustruct // only TLS + dial control configured.
-		TLSClientConfig: tlsCfg,
-		DialContext: (&net.Dialer{ //nolint:exhaustruct // only ControlContext configured.
+	tr := &http.Transport{ //nolint:exhaustruct // only TLS, dial control, and phase timeouts configured.
+		TLSClientConfig:       tlsCfg,
+		TLSHandshakeTimeout:   to.tlsHandshake,
+		ResponseHeaderTimeout: to.responseHeader,
+		DialContext: (&net.Dialer{ //nolint:exhaustruct // only Timeout + ControlContext configured.
+			Timeout:        to.dial,
 			ControlContext: control,
 		}).DialContext,
 	}
 
-	return &http.Client{Transport: tr}, nil //nolint:exhaustruct // only Transport set.
+	return &http.Client{Transport: tr, Timeout: to.overall}, nil //nolint:exhaustruct // Transport + Timeout set.
 }
 
 // fetchClusterRoleRaw GETs the named cluster-scoped ClusterRole and returns the

--- a/internal/auth/kubernetes.go
+++ b/internal/auth/kubernetes.go
@@ -467,6 +467,17 @@ func (p *kubernetesProvider) AuthorizesAddr(ctx context.Context, ip netip.Addr, 
 	return p.authorizesDialIP(ctx, ip)
 }
 
+// probeAndSeedView validates at registration that the configured ClusterRole is
+// fetchable and parseable AND seeds the runtime view-policy cache, so the first
+// request skips the redundant fetch through the same lazy path. It resolves
+// through resolveViewPolicy (which caches on success) rather than a bare fetch,
+// so the eager validation and the cache seed are one call.
+func (p *kubernetesProvider) probeAndSeedView(ctx context.Context) error {
+	_, err := p.resolveViewPolicy(ctx, nil)
+
+	return err
+}
+
 // AuthorizeAction enforces the read-only ClusterRole posture via the shared k8sGate.
 func (p *kubernetesProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
 	args, err := parseKubernetesArgs(rawArgs)

--- a/internal/auth/kubernetes_internal_test.go
+++ b/internal/auth/kubernetes_internal_test.go
@@ -898,6 +898,36 @@ func TestKubernetesProvider_bearerToken(t *testing.T) {
 	})
 }
 
+func TestKubernetesProbeAndSeedView_SeedsViewPolicyCache(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	vp := k8sauthz.BuildViewPolicy(nil)
+	p := newKubernetesProvider(resolvedCluster{mode: credBearer, token: "t"})
+	p.fetchView = func(context.Context, *KubernetesAuthArgs) (*k8sauthz.ViewPolicy, error) {
+		calls++
+
+		return vp, nil
+	}
+
+	// The registration probe validates the ClusterRole live AND must seed the
+	// runtime cache, so the first request does not repeat the fetch.
+	if err := p.probeAndSeedView(context.Background()); err != nil {
+		t.Fatalf("probeAndSeedView: %v", err)
+	}
+
+	if _, err := p.resolveViewPolicy(context.Background(), nil); err != nil {
+		t.Fatalf("resolveViewPolicy: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf(
+			"fetchView called %d times; the probe should have seeded the cache so the request skips the fetch",
+			calls,
+		)
+	}
+}
+
 func TestKubernetesFetchViewBearerContract(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/provider_shell.go
+++ b/internal/auth/provider_shell.go
@@ -222,9 +222,7 @@ func buildRegistrationDeps(cfg HardeningConfig) *registrationDeps {
 			return p
 		},
 		probeKube: func(ctx context.Context, p *kubernetesProvider) error {
-			_, err := p.defaultFetchView(ctx, nil)
-
-			return err
+			return p.probeAndSeedView(ctx)
 		},
 		k8sClusterRole: cfg.Kubernetes.ClusterRole,
 	}


### PR DESCRIPTION
## What & why

The four Kubernetes connectors (eks/gke/aks/kubernetes) resolve their ClusterRole lazily the first time a request hits `AuthorizeAction`, and `pinnedHTTPClient` (the bootstrap HTTPS client) set only `Transport`: no dial, TLS-handshake, response-header, or overall timeout. The lazy resolution also ran under the deadline-free session context. So a configured cluster endpoint that accepted the connection and then stalled (TLS handshake, response headers, or body) wedged the run until something external cancelled it. An interactive run can Ctrl-C; a one-shot `-p` or a CI run hangs.

Impact is availability only: host, IP, and CA pinning mean only the configured cluster endpoint can trigger it, and there is no authorization bypass, credential exposure, or write path. But it broke the expectation that a tool call is bounded.

This change bounds the whole Kubernetes bootstrap path at its own chokepoints, without touching the other connectors:

- `pinnedHTTPClient` now sets explicit dial, TLS-handshake, and response-header timeouts plus an overall `Client.Timeout`, so the ClusterRole HTTPS fetch is bounded even for a caller with no context deadline.
- `syncCache` (the success-only cache all four K8s providers use for cluster TLS facts and view policies, and nothing else) now bounds each fetch with a fixed 35s ceiling. That covers the whole preflight - cloud cluster-resolve SDK calls, the token mint, and the ClusterRole read - so none of them can hang forever. A caller with a tighter deadline (the 5s registration probe) still wins. Using the cache's own fixed bound rather than the request's `timeout_seconds` also keeps a short-timeout request from cutting short a concurrent, longer-budget request coalesced onto the same fetch.
- The GKE token refresh is now cancellable: `oauth2`'s `TokenSource.Token` takes no context, so a stalled refresh is wrapped so the bounded context can end the wait.
- The self-managed `kubernetes` provider seeds its view-policy cache from the registration probe, so the first request skips the redundant ClusterRole fetch.

Deliberately not done: bounding the generic auth gates by the per-request `timeout_seconds` at the transport layer. That would let a small `timeout_seconds` truncate another connector's first-use catalog fetch; in particular it would cache a partial GCP discovery catalog fail-closed for its whole TTL, silently denying the dropped services. The Kubernetes bootstrap fetches are bounded at their own cache instead.

Regression tests cover stalled TLS handshake, stalled response headers, and stalled body on the bootstrap fetch; the cache's fixed-timeout bound and its tighter-caller-deadline ceiling; the cancellable token refresh; and the seeded self-managed cache.

Fixes #120.

## Checklist
- [x] `make check-go` passes locally (100% core coverage, lint, shell-complexity, windows cross-compile); `make check-scripts` unaffected (no scripts changed)
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed (no user-facing behavior change)
