### PR TITLE
fix(deps): pin go-msix to v0.3.1 to keep the release snapshot building

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,16 @@ updates:
       # when that happens.
       - dependency-name: "github.com/denis-tingaikin/go-header"
         update-types: ["version-update:semver-major"]
+      # go-msix v1 is a breaking API rewrite (Builder became an interface,
+      # Build takes a context, the Manifest/Identity/Resource types were
+      # removed) that goreleaser's nfpm (v2.47.0, the latest release) still
+      # calls with the v0.3.x API, so forcing the major bump on this indirect
+      # module breaks `make snapshot` (the goreleaser Windows MSIX packager).
+      # Minor/patch updates stay allowed, and once nfpm adopts the v1 API the
+      # module graph will follow without Dependabot's help. Drop this entry
+      # when that happens.
+      - dependency-name: "go.digitalxero.dev/go-msix"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns: ["*"]

--- a/go.mod
+++ b/go.mod
@@ -507,7 +507,7 @@ require (
 	go-simpler.org/sloglint v0.12.0 // indirect
 	go.augendre.info/arangolint v0.4.0 // indirect
 	go.augendre.info/fatcontext v0.10.0 // indirect
-	go.digitalxero.dev/go-msix v1.0.0 // indirect
+	go.digitalxero.dev/go-msix v0.3.1 // indirect
 	go.mozilla.org/pkcs7 v0.9.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1320,8 +1320,8 @@ go.augendre.info/arangolint v0.4.0 h1:xSCZjRoS93nXazBSg5d0OGCi9APPLNMmmLrC995tR5
 go.augendre.info/arangolint v0.4.0/go.mod h1:l+f/b4plABuFISuKnTGD4RioXiCCgghv2xqst/xOvAA=
 go.augendre.info/fatcontext v0.10.0 h1:HhFopmivh8U1+AU7f0kuwUeg2eiIns7YsGQOMHwSJ90=
 go.augendre.info/fatcontext v0.10.0/go.mod h1:pqpGvA9GlrXy+aXkp8L2dKz12Zp4g2FhzcAtwToU+2w=
-go.digitalxero.dev/go-msix v1.0.0 h1:9qaOqvAgjgVswPEmrcynroo6/GEdGpQXLU/rDsxTz+0=
-go.digitalxero.dev/go-msix v1.0.0/go.mod h1:lsGjKne37diRcY+7cyuAWFtFF2itmzJNUVbVoDH3saw=
+go.digitalxero.dev/go-msix v0.3.1 h1:V5E8PuFkA3Fr3VFYX6pTUutriogYC9sgxIWhzf9sSKw=
+go.digitalxero.dev/go-msix v0.3.1/go.mod h1:QbUpFs0AUd1zk7e9fy17suiqEAF90TR3jZY+LCI2K+c=
 go.mozilla.org/pkcs7 v0.9.0 h1:yM4/HS9dYv7ri2biPtxt8ikvB37a980dg69/pKmS+eI=
 go.mozilla.org/pkcs7 v0.9.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## What & why

The release-please PR (`chore(main): release 1.5.2`, #112) fails its **Build release snapshot** check. `make snapshot` fails to compile the `go tool goreleaser` binary:

```
github.com/goreleaser/nfpm/v2@v2.47.0/msix/msix.go:130:10: builder.Manifest undefined
(type "go.digitalxero.dev/go-msix".Builder has no field or method Manifest)
```

Dependabot's indirect-dependency updates (enabled in #123) bumped the transitive module `go.digitalxero.dev/go-msix` from `v0.3.1` to `v1.0.0` in #128. v1 is a breaking API rewrite (Builder became an interface, `Build` takes a context, and the `Manifest`/`Identity`/`Resource` types were removed), but goreleaser's `nfpm` still calls the v0.3.x API in its Windows MSIX packager. `nfpm v2.47.0` is the latest release and still requires `go-msix v0.3.1`, so there is no newer nfpm/goreleaser to move to.

This is why only the release PR went UNSTABLE: `Lint & Test` doesn't build goreleaser, so it stayed green; only the release snapshot build compiles the tool and hits the break.

This is the same class as the existing `go-header` ignore: an indirect module a pinned tool's own source imports cannot be bumped past what that tool supports.

## Fix

- **`go.mod` / `go.sum`**: pin `go.digitalxero.dev/go-msix` back to `v0.3.1` (the version nfpm requires).
- **`.github/dependabot.yml`**: ignore `go-msix` `version-update:semver-major`, mirroring the `go-header` entry, so v1 is not reintroduced. Drop the ignore once nfpm adopts the v1 API.

Once merged, release-please regenerates #112 and its snapshot build passes.

## Verification

- `go build github.com/goreleaser/nfpm/v2/msix` -> exit 0 (the exact package that failed in CI).
- `go build github.com/goreleaser/goreleaser/v2` -> exit 0 (the tool binary `go tool goreleaser` compiles).
- `go build ./...` and `go mod verify` clean.
- `make snapshot` now compiles the tool and builds every target binary (a full local run needs several GB of free disk, which the CI runner has).

## Checklist
- [x] Verified the previously-failing snapshot compile (see above); no change to the `make check` gate surface (indirect release-tool dep + Dependabot config only)
- [ ] Tests added/updated - N/A, dependency pin with no code or test surface
- [ ] Docs updated - N/A, no behavior change
