### PR TITLE
ci: refresh the release PR on a schedule and on demand

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,22 @@ on:
   push:
     branches:
       - main
+  # Manual refresh. Re-run release-please on demand to fold newly merged
+  # commits into the release PR and rebase its branch onto current main
+  # (handy right before cutting a release, since a strict up-to-date ruleset
+  # blocks merging a BEHIND branch).
+  workflow_dispatch:
+  # Safety net for commits that land via a GITHUB_TOKEN push. A Dependabot PR
+  # auto-merged by dependabot-auto-merge.yaml is merged under the default
+  # GITHUB_TOKEN, and pushes made by GITHUB_TOKEN do NOT trigger `on: push`
+  # (GitHub's recursion guard). Release-please would therefore never see those
+  # merges and the release PR would drift stale (missing merged fixes) and
+  # BEHIND main. This periodic run re-derives the release PR from repository
+  # state regardless of how commits arrived. Every heavy/publish step is gated
+  # on release_created, so a run with nothing to release only refreshes the
+  # candidate PR (release-please phase 2); it never publishes.
+  schedule:
+    - cron: "17 */6 * * *"
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,7 +682,12 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
   version bump, enforced by `semantic-pr.yaml`. `.goreleaser.yaml` handles binary builds for
-  release tags. The Release Pipeline splits at the publish boundary: the `release` job builds,
+  release tags. The Release Pipeline (`release.yaml`) runs `on: push` to `main`, plus a 6-hourly
+  `schedule` and `workflow_dispatch`, so release-please re-derives the release PR from repository
+  state even when commits arrive via a GITHUB_TOKEN push (e.g. a Dependabot auto-merge), which
+  does not trigger `on: push`; every heavy/publish step stays gated on `release_created`, so a
+  non-release trigger only refreshes the candidate PR. The Release Pipeline splits at the publish
+  boundary: the `release` job builds,
   signs, and statically asserts everything, then hands the draft's exact asset set (pkgs,
   archives, manifests) to downstream jobs as the `release-artifacts` workflow artifact; the
   `macos-pkg-smoke` job (pinned `macos-26` + `macos-26-intel`, no secrets) runs


### PR DESCRIPTION
## What & why

PR #112 (the release-please `release 1.5.2` PR) went stale: its changelog was missing merged `fix(deps)` commits (#124, #128) and its branch fell `BEHIND` `main`, which the strict up-to-date ruleset blocks from merging.

Root cause: the Release Pipeline runs release-please only `on: push` to `main`. Dependabot PRs are auto-merged by `dependabot-auto-merge.yaml` under the default `GITHUB_TOKEN`, and pushes made by `GITHUB_TOKEN` do not trigger `on: push` (GitHub's recursion guard). So release-please never re-runs for those merges, and the release PR neither picks up the new commits nor gets rebased onto current `main`. Confirmed live: the two Dependabot merge SHAs have only "dynamic" Dependabot runs, no `push`/CI/Release Pipeline run.

This adds two triggers to `release.yaml`:
- `workflow_dispatch` - refresh the release PR on demand (handy right before cutting a release).
- `schedule` (every 6h, at `:17`) - re-derive the release PR from repository state regardless of how commits landed.

Both are safe: every heavy/publish step is gated on `release_created` (only true when a `chore(main): release` commit is at HEAD), so a run with nothing to release just refreshes the candidate PR via release-please phase 2 and never publishes.

### Optional follow-up (not in this PR)
For zero-latency instead of up-to-6h: switch `dependabot-auto-merge.yaml` to enable auto-merge via a GitHub App token so each Dependabot merge triggers the pipeline immediately. That needs the App id + private key in the repo's **Dependabot** secrets store (Dependabot-triggered workflows cannot read Actions/org secrets), which is currently empty. The schedule covers the gap without provisioning that secret.

## Checklist
- [x] `make check` passes locally - N/A: workflow-YAML-only change, not covered by `make check`; validated `release.yaml` parses and the `on:` triggers resolve correctly.
- [x] Tests added/updated for the change - N/A: no code change.
- [x] Docs updated if behavior changed - `AGENTS.md` release-pipeline note updated to describe the new triggers.