### PR TITLE
fix: bound the GCP token refresh with a client-side HTTP timeout

### DIFF
--- a/internal/auth/gcp_token.go
+++ b/internal/auth/gcp_token.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// Token-refresh transport knobs. [oauth2.TokenSource.Token] takes no context and,
+// over [http.DefaultTransport], is bounded only at dial and TLS handshake: a token
+// endpoint that accepts the connection, completes the handshake, then stalls the
+// response header or body would otherwise block a refresh forever. The dial /
+// keep-alive / TLS / idle-pool / expect-continue values mirror
+// [http.DefaultTransport]'s documented defaults (the transport this replaces);
+// the response-header and overall timeouts are the new bounds this fix adds.
+const (
+	gcpTokenRefreshDialTimeout           = 30 * time.Second
+	gcpTokenRefreshDialKeepAlive         = 30 * time.Second
+	gcpTokenRefreshTLSHandshakeTimeout   = 10 * time.Second
+	gcpTokenRefreshMaxIdleConns          = 100
+	gcpTokenRefreshIdleConnTimeout       = 90 * time.Second
+	gcpTokenRefreshExpectContinueTimeout = 1 * time.Second
+	// gcpTokenRefreshResponseHeaderTimeout bounds time-to-first-response-header.
+	gcpTokenRefreshResponseHeaderTimeout = 15 * time.Second
+	// gcpTokenRefreshOverallTimeout is the whole-request backstop ([http.Client.Timeout],
+	// which also covers a stalled body read the phase timeouts do not). It stays under
+	// the syncCache k8sBootstrapFetchTimeout ceiling (35s) so a refusal surfaces first.
+	gcpTokenRefreshOverallTimeout = 30 * time.Second
+)
+
+// withBoundedTokenRefresh returns ctx carrying a bounded [http.Client] under the
+// [oauth2.HTTPClient] key. A token source constructed with this context (e.g. the
+// long-lived ADC credentials from google.FindDefaultCredentials at registration)
+// issues every OAuth token refresh through this client, so a blackholed token
+// endpoint cannot make an otherwise contextless [oauth2.TokenSource.Token] block
+// forever.
+//
+// The client's Timeout is applied per refresh request, NOT as a fixed context
+// deadline, so it does not poison the retained-context source the way a
+// [context.WithTimeout] would. [context.WithValue] also leaves ctx deadline-free,
+// preserving the "findGCP MUST use the unbounded ctx" invariant in registerGCP.
+//
+// This bounds the [http.DefaultTransport]-backed refresh paths (service-account
+// JSON, authorized-user/gcloud, external-account, impersonated). The GCE/GKE
+// metadata server path uses its own client (already bounded by its own timeout)
+// and is unaffected; it is a link-local hop, not the [http.DefaultTransport] case
+// this guards.
+func withBoundedTokenRefresh(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, boundedTokenRefreshClient())
+}
+
+// boundedTokenRefreshClient is the production token-refresh client.
+func boundedTokenRefreshClient() *http.Client {
+	return boundedTokenRefreshClientWithTimeouts(gcpTokenRefreshOverallTimeout, gcpTokenRefreshResponseHeaderTimeout)
+}
+
+// boundedTokenRefreshClientWithTimeouts builds the refresh client with the overall
+// and response-header timeouts made explicit so tests can drive small values
+// against a stalling token endpoint; production callers go through
+// boundedTokenRefreshClient. It builds a fresh transport reproducing
+// [http.DefaultTransport]'s defaults rather than cloning the mutable global, but
+// keeps Proxy = [http.ProxyFromEnvironment], since the [http.DefaultTransport]
+// this replaces honored the egress proxy and a token refresh must still traverse
+// it.
+func boundedTokenRefreshClientWithTimeouts(overall, responseHeader time.Duration) *http.Client {
+	tr := &http.Transport{ //nolint:exhaustruct // only proxy, HTTP/2, and the pool/phase timeouts configured.
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          gcpTokenRefreshMaxIdleConns,
+		IdleConnTimeout:       gcpTokenRefreshIdleConnTimeout,
+		TLSHandshakeTimeout:   gcpTokenRefreshTLSHandshakeTimeout,
+		ExpectContinueTimeout: gcpTokenRefreshExpectContinueTimeout,
+		ResponseHeaderTimeout: responseHeader,
+		DialContext: (&net.Dialer{ //nolint:exhaustruct // only Timeout + KeepAlive configured.
+			Timeout:   gcpTokenRefreshDialTimeout,
+			KeepAlive: gcpTokenRefreshDialKeepAlive,
+		}).DialContext,
+	}
+
+	return &http.Client{Transport: tr, Timeout: overall} //nolint:exhaustruct // only Transport + Timeout set.
+}

--- a/internal/auth/gcp_token_internal_test.go
+++ b/internal/auth/gcp_token_internal_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// TestWithBoundedTokenRefresh_InjectsClientWithoutDeadline asserts the helper
+// carries a bounded [http.Client] under the [oauth2.HTTPClient] key without adding
+// a context deadline. The long-lived session credentials source that findGCP
+// builds retains this context, so it must be bounded (the client) yet not poisoned
+// (no fixed deadline).
+func TestWithBoundedTokenRefresh_InjectsClientWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx := withBoundedTokenRefresh(context.Background())
+
+	hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	if !ok || hc == nil {
+		t.Fatalf("oauth2.HTTPClient value = %v, want a non-nil *http.Client", ctx.Value(oauth2.HTTPClient))
+	}
+	if hc.Timeout != gcpTokenRefreshOverallTimeout {
+		t.Errorf("Client.Timeout = %v, want %v", hc.Timeout, gcpTokenRefreshOverallTimeout)
+	}
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		t.Error("withBoundedTokenRefresh must not add a deadline (a fixed deadline would poison the retained source)")
+	}
+}
+
+// TestBoundedTokenRefreshClient_SetsTimeouts asserts the production refresh client
+// carries the overall backstop and the response-header phase timeout, and honors
+// the proxy (so enterprise egress that [http.DefaultTransport] allowed still works).
+func TestBoundedTokenRefreshClient_SetsTimeouts(t *testing.T) {
+	t.Parallel()
+
+	hc := boundedTokenRefreshClient()
+	if hc.Timeout != gcpTokenRefreshOverallTimeout {
+		t.Errorf("Client.Timeout = %v, want overall backstop %v", hc.Timeout, gcpTokenRefreshOverallTimeout)
+	}
+
+	tr, ok := hc.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", hc.Transport)
+	}
+	if tr.ResponseHeaderTimeout != gcpTokenRefreshResponseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", tr.ResponseHeaderTimeout, gcpTokenRefreshResponseHeaderTimeout)
+	}
+	if tr.TLSHandshakeTimeout != gcpTokenRefreshTLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", tr.TLSHandshakeTimeout, gcpTokenRefreshTLSHandshakeTimeout)
+	}
+	if tr.Proxy == nil {
+		t.Error("Proxy must be honored so a token refresh still traverses a configured egress proxy")
+	}
+}
+
+// TestBoundedTokenRefresh_StalledResponseBodyIsBounded is the end-to-end proof: an
+// oauth2 token source constructed under a context carrying the bounded client
+// returns promptly with an error instead of blocking forever when the token
+// endpoint flushes response headers and then stalls the body. That is exactly the
+// case [http.DefaultTransport] (dial/TLS timeouts only, no response-header or
+// overall timeout) leaves unbounded, so an otherwise contextless
+// [oauth2.TokenSource.Token] would wedge indefinitely.
+func TestBoundedTokenRefresh_StalledResponseBodyIsBounded(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-block
+	}))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	// A small overall backstop keeps the test fast; the response-header timeout is
+	// loose so the OVERALL Client.Timeout is what must end the stalled-body refresh.
+	client := boundedTokenRefreshClientWithTimeouts(200*time.Millisecond, 5*time.Second)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+
+	cfg := &oauth2.Config{ //nolint:exhaustruct // only Endpoint is relevant to a refresh.
+		Endpoint: oauth2.Endpoint{ //nolint:exhaustruct // token URL only.
+			TokenURL:  srv.URL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	src := cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: "refresh"}) //nolint:exhaustruct // forces a refresh.
+
+	start := time.Now()
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("expected an overall-timeout error on the stalled token-refresh body, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("stalled refresh took %v; the bounded client did not bound it", elapsed)
+	}
+}
+
+// TestBoundedTokenRefresh_StalledResponseHeadersAreBounded covers the header-stall
+// case: a token endpoint that completes the TLS handshake and reads the request
+// but never writes a response header is ended by the response-header phase timeout.
+func TestBoundedTokenRefresh_StalledResponseHeadersAreBounded(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { <-block }))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	// A tight response-header timeout with a loose overall backstop so the phase
+	// timeout is what ends the wait.
+	client := boundedTokenRefreshClientWithTimeouts(5*time.Second, 150*time.Millisecond)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+
+	cfg := &oauth2.Config{ //nolint:exhaustruct // only Endpoint is relevant to a refresh.
+		Endpoint: oauth2.Endpoint{ //nolint:exhaustruct // token URL only.
+			TokenURL:  srv.URL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	src := cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: "refresh"}) //nolint:exhaustruct // forces a refresh.
+
+	start := time.Now()
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("expected a response-header timeout on the stalled response, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stalled headers took %v; ResponseHeaderTimeout did not bound the refresh", elapsed)
+	}
+}

--- a/internal/auth/provider_shell.go
+++ b/internal/auth/provider_shell.go
@@ -182,8 +182,11 @@ func buildRegistrationDeps(cfg HardeningConfig) *registrationDeps {
 		awsPolicyARN:      cfg.AWS.PolicyARN,
 		validateAWSPolicy: validateAWSPolicy,
 
+		// withBoundedTokenRefresh gives the retained session token source a
+		// client-side HTTP timeout, so every refresh is bounded even though ctx is
+		// (deliberately) deadline-free and oauth2.TokenSource.Token takes no context.
 		findGCP: func(ctx context.Context) (*google.Credentials, error) {
-			return google.FindDefaultCredentials(ctx, gcpScope)
+			return google.FindDefaultCredentials(withBoundedTokenRefresh(ctx), gcpScope)
 		},
 		probeGCP:    probeGCPToken,
 		gcpIdentity: gcpRegistrationIdentity,

--- a/internal/auth/registration.go
+++ b/internal/auth/registration.go
@@ -207,7 +207,9 @@ func (d *registrationDeps) registerGCP(ctx context.Context, verbose bool) connec
 	// TokenSource retains the supplied context, and the registered provider mints
 	// tokens from it for the whole session. Only the probe is bounded — and it
 	// builds a SEPARATE source (probeGCPToken), so cancelling pctx never poisons
-	// the registered source.
+	// the registered source. The production findGCP still bounds each refresh via a
+	// per-request client timeout (withBoundedTokenRefresh) rather than a ctx
+	// deadline, which would poison the retained source.
 	creds, findErr := d.findGCP(ctx)
 
 	var probeErr error


### PR DESCRIPTION
## What & why

Fixes #131.

The registered GCP credentials come from `google.FindDefaultCredentials` under a deliberately deadline-free context and are shared by both the GCP and GKE providers. `oauth2.TokenSource.Token` takes no context, and over `http.DefaultTransport` a refresh is bounded only at dial and TLS handshake. A token endpoint that accepts the connection, completes the TLS handshake, then stalls the response body makes the refresh block forever. PR #130's Kubernetes preflight cache ceiling (35s) keeps a run from wedging, but the background refresh goroutine leaks until the stall clears (for a body blackhole, effectively never).

The fix injects a bounded `*http.Client` into the ADC context via the `oauth2.HTTPClient` key in the `findGCP` closure. oauth2 routes every non-metadata token refresh through the context-associated client, so this bounds each refresh at a single chokepoint that covers the GKE Container API cluster resolve, GKE `InjectAuth`, the GKE ClusterRole fetch, and the GCP provider's own refreshes.

Details:
- The client's `Timeout` is applied per refresh request, not as a fixed context deadline, so it does not poison the retained-context source (the invariant `registerGCP` documents). `context.WithValue` leaves the context deadline-free.
- The client reproduces `http.DefaultTransport`'s defaults and keeps `Proxy = ProxyFromEnvironment` (a token refresh must still traverse a configured egress proxy), and adds the response-header and overall timeouts the default transport lacks. The 30s overall stays under the 35s preflight cache ceiling.
- The GCE/GKE metadata-server path uses its own client (already bounded by a 5s timeout with finite retries) and is out of scope, matching the issue.

Verified the refresh routing against `oauth2@v0.36.0` and `google.golang.org/api@v0.288.0`: `option.WithHTTPClient` on the Container API service would not help, since the oauth2 adapter calls `ts.Token()` ignoring the request context, so the bound has to be at the source.

## Checklist
- [x] `make check-go` passes locally (100% core coverage, lint, Windows cross-compile); no shell/script files changed, so `check-scripts` is unaffected
- [x] Tests added: an end-to-end proof that an oauth2 token source built under the bounded context returns promptly instead of blocking on a stalled response body / headers, plus unit coverage of the helper and client
- [x] No user-facing behavior change, so no docs update needed