### PR TITLE
fix: bound the ADC token refresh against a blackholed GCP token endpoint

### DIFF
--- a/internal/auth/adc.go
+++ b/internal/auth/adc.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// adcTokenRefreshTimeout bounds each OAuth2 token refresh minted from the
+// registered Application Default Credentials source (shared by the gcp and gke
+// providers for the whole session) for the token-endpoint credential forms:
+// gcloud user credentials, service-account JSON keys, workload-identity /
+// external-account, and impersonation. Those refresh through
+// oauth2's internal.ContextClient, which dials the token endpoint with the
+// [http.Client] stored at the credential-creation context's oauth2.HTTPClient
+// key, defaulting to [http.DefaultClient] (no timeout). Since
+// oauth2.TokenSource.Token takes no context, a token endpoint that accepts the
+// connection and then stalls the response would otherwise block the refresh
+// forever, uncancellable by the request or preflight context. This bound sits
+// below the 35s k8sBootstrapFetchTimeout so a stalled refresh surfaces its own
+// error before the GKE ClusterRole-preflight ceiling fires.
+//
+// The in-cluster GCE/GKE metadata-server credential form is the one exception: it
+// mints through the cloud.google.com/go/compute/metadata client, not the oauth2
+// refresh path, so this value is inert there. That path is bounded independently
+// by the metadata client's own ~5s per-attempt timeout.
+const adcTokenRefreshTimeout = 30 * time.Second
+
+// boundedADCContext returns ctx carrying a token-refresh HTTP client (via the
+// oauth2.HTTPClient context key) whose [http.Client] Timeout bounds every
+// token-endpoint refresh minted from the resulting credentials source. It is
+// threaded onto the credential-creation context so the bound reaches the
+// contextless oauth2.TokenSource.Token refreshes the gcp and gke providers make
+// for the whole session: the GKE Container API cluster resolve, GKE InjectAuth,
+// and the GCP provider paths. The GCE/GKE metadata-server form is the exception
+// (see adcTokenRefreshTimeout): it mints through a different client and is
+// bounded independently.
+//
+// The bound is a per-request Client.Timeout, not a context deadline: the ctx
+// itself never gains a deadline, so the long-lived registered source is never
+// poisoned (every refresh gets a fresh timeout). A nil-Transport client uses
+// [http.DefaultTransport], preserving its dial/TLS timeouts and proxy resolution
+// (HTTP_PROXY) for the token endpoint.
+func boundedADCContext(ctx context.Context, timeout time.Duration) context.Context {
+	client := &http.Client{Timeout: timeout} //nolint:exhaustruct // Timeout is the only field this bound sets.
+
+	return context.WithValue(ctx, oauth2.HTTPClient, client)
+}

--- a/internal/auth/adc_internal_test.go
+++ b/internal/auth/adc_internal_test.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// TestBoundedADCContext_ThreadsBoundedClient pins the wiring: boundedADCContext
+// threads an [http.Client] via the oauth2.HTTPClient context key with the given
+// Client.Timeout. Using a per-request Client.Timeout (not a context deadline) is
+// what keeps the long-lived registered credentials source from being poisoned:
+// each refresh gets a fresh timeout, the context never expires.
+func TestBoundedADCContext_ThreadsBoundedClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := boundedADCContext(context.Background(), 42*time.Second)
+
+	hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	if !ok {
+		t.Fatal("boundedADCContext did not thread an *http.Client via the oauth2.HTTPClient context key")
+	}
+	if hc.Timeout != 42*time.Second {
+		t.Fatalf("client timeout = %v, want 42s", hc.Timeout)
+	}
+	if _, deadlineSet := ctx.Deadline(); deadlineSet {
+		t.Fatal("boundedADCContext set a context deadline; it must bound via Client.Timeout only (no poisoning)")
+	}
+}
+
+// TestBoundedADCContext_BoundsStalledTokenRefresh pins the fix: an oauth2 token
+// refresh minted from a boundedADCContext honors the client timeout even against
+// a token endpoint that accepts the connection and then never responds. Without
+// the bound the refresh uses [http.DefaultClient] (no timeout) and ts.Token()
+// blocks forever, since TokenSource.Token takes no context to cancel it.
+func TestBoundedADCContext_BoundsStalledTokenRefresh(t *testing.T) {
+	t.Parallel()
+
+	// A token endpoint that stalls: the request arrives, TLS/handshake complete,
+	// and the response never comes (blackholed token endpoint).
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done(): // client gave up (its bounded timeout fired).
+		case <-block: // teardown fallback.
+		}
+	}))
+	// LIFO cleanup: close(block) runs first so any stuck handler unblocks before
+	// srv.Close (which waits for outstanding requests) runs.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(block) })
+
+	cfg := &oauth2.Config{ //nolint:exhaustruct // token endpoint only.
+		Endpoint: oauth2.Endpoint{TokenURL: srv.URL, AuthStyle: oauth2.AuthStyleInParams},
+	}
+	// An already-expired token forces a refresh against the stalled endpoint.
+	ts := cfg.TokenSource(
+		boundedADCContext(context.Background(), 150*time.Millisecond),
+		&oauth2.Token{RefreshToken: "refresh", Expiry: time.Unix(1, 0)}, //nolint:exhaustruct // refresh path only.
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ts.Token()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the stalled token refresh to be bounded, got a token")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("token refresh was not bounded by the ADC client timeout (still hung after 5s)")
+	}
+}

--- a/internal/auth/gke.go
+++ b/internal/auth/gke.go
@@ -72,7 +72,10 @@ func newGKEProvider(tokenSource oauth2.TokenSource) *gkeProvider {
 // TokenSource.Token takes no context, so a stalled refresh would otherwise be
 // uncancellable and could wedge the preflight; the goroutine + select makes the
 // wait honor ctx (the abandoned refresh drains into the buffered channel and the
-// goroutine exits when it finally returns).
+// goroutine exits when it returns). That return is now time-bounded: ADC token
+// refreshes are capped (boundedADCContext for token-endpoint creds, the metadata
+// client's own timeout in-cluster), so an abandoned goroutine cannot leak
+// indefinitely. A tighter ctx cancellation still returns first.
 func tokenWithContext(ctx context.Context, ts oauth2.TokenSource) (*oauth2.Token, error) {
 	type result struct {
 		tok *oauth2.Token

--- a/internal/auth/provider_shell.go
+++ b/internal/auth/provider_shell.go
@@ -183,7 +183,12 @@ func buildRegistrationDeps(cfg HardeningConfig) *registrationDeps {
 		validateAWSPolicy: validateAWSPolicy,
 
 		findGCP: func(ctx context.Context) (*google.Credentials, error) {
-			return google.FindDefaultCredentials(ctx, gcpScope)
+			// Bound every token refresh minted from the registered source: the
+			// context carries only an oauth2.HTTPClient value (per-request
+			// Client.Timeout, no deadline), so it stays deadline-free (see the
+			// note in registerGCP) while a stalled token endpoint can no longer
+			// hang ts.Token().
+			return google.FindDefaultCredentials(boundedADCContext(ctx, adcTokenRefreshTimeout), gcpScope)
 		},
 		probeGCP:    probeGCPToken,
 		gcpIdentity: gcpRegistrationIdentity,

--- a/internal/auth/registration.go
+++ b/internal/auth/registration.go
@@ -203,11 +203,14 @@ func awsScopeDegraded(decision awshardening.CredScopeDecision, result awshardeni
 // regardless of explicit/verbose: the credential is confirmed present. On
 // success it captures a bounded, display-only identity.
 func (d *registrationDeps) registerGCP(ctx context.Context, verbose bool) connectorOutcome {
-	// findGCP MUST use the unbounded ctx: google.FindDefaultCredentials' returned
-	// TokenSource retains the supplied context, and the registered provider mints
-	// tokens from it for the whole session. Only the probe is bounded — and it
-	// builds a SEPARATE source (probeGCPToken), so cancelling pctx never poisons
-	// the registered source.
+	// findGCP MUST use a DEADLINE-FREE ctx: google.FindDefaultCredentials'
+	// returned TokenSource retains the supplied context, and the registered
+	// provider mints tokens from it for the whole session, so a deadline would
+	// eventually poison it. findGCP still wraps ctx with boundedADCContext, which
+	// adds only an oauth2.HTTPClient value (a per-request Client.Timeout, not a
+	// deadline), so each refresh is bounded without poisoning the source. Only the
+	// probe is deadline-bounded, and it builds a SEPARATE source (probeGCPToken),
+	// so cancelling pctx never poisons the registered source.
 	creds, findErr := d.findGCP(ctx)
 
 	var probeErr error


### PR DESCRIPTION
## What & why

The `gcp` and `gke` connectors share the Application Default Credentials (ADC) token source captured once at registration, under the long-lived session context. That source refreshes through oauth2's `TokenSource.Token`, which takes no context and dials the token endpoint with the `http.Client` on the credential-creation context (the `oauth2.HTTPClient` key), defaulting to `http.DefaultClient`, which has no timeout. A token endpoint that accepts the connection, completes the TLS handshake, and then stalls the response made `ts.Token()` block indefinitely, uncancellable by the request or preflight context.

PR #130 (issue #120) bounded the caller of the GKE ClusterRole preflight (a 35s `syncCache` ceiling plus a cancellable token mint), so a stalled endpoint no longer wedges the run. But the underlying refresh goroutine still leaked until the refresh unblocked, which for a blackholed endpoint against `http.DefaultTransport` is effectively never (issue #131).

This threads a per-request-timeout `http.Client` onto the credential-creation context via the `oauth2.HTTPClient` key (`boundedADCContext`), so every token-endpoint refresh minted from the registered source is bounded at the source: the GKE Container API cluster resolve, GKE `InjectAuth`, and the GCP provider paths. The bound is a `Client.Timeout` (a fresh per-request bound), not a context deadline, so the long-lived source is never poisoned. At 30s it sits below the 35s preflight ceiling, so a stalled refresh surfaces its own error first.

Note on the two options in the issue: this takes option 2 (bound at ADC creation). Option 1 (a timeout on the Container API service's HTTP client) would not bound the refresh, which happens in oauth2's separate internal client before the API round-trip and is uncancellable by the request context.

The in-cluster GCE/GKE metadata-server credential form is the one exception: it mints through the `cloud.google.com/go/compute/metadata` client, not the oauth2 refresh path, so it is bounded independently by that client's own ~5s per-attempt timeout (noted in the code).

## Checklist
- [x] `make check-go` passes locally (lint 0 issues, 100% core coverage, Windows amd64/arm64 cross-compile); Go-only change, no scripts touched
- [x] Tests added (`internal/auth/adc_internal_test.go`: bounded-refresh behavior + wiring)
- [x] Docs updated if behavior changed (code comments only; no user-facing behavior change)

Fixes #131.
