### PR TITLE
ci: merge Dependabot PRs with an App token so releases re-trigger

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,18 +1,66 @@
 name: Dependabot auto-merge
 
-on: pull_request
+# Runs in the trusted default-branch context after CI completes on a PR, so the App key
+# (an Actions secret) is never exposed to a Dependabot PR's head-modified workflow code,
+# and the merge is attributed to the App so its push to main triggers the Release Pipeline
+# (GITHUB_TOKEN merges never trigger further workflows, which left the release PR stale).
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
+# The dedicated App token performs the merge; GITHUB_TOKEN only reads the PR to identify it.
 permissions:
-  contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
-  dependabot:
+  automerge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+      # Identify the PR from the completed run's head SHA using the read-only GITHUB_TOKEN.
+      # Only an open, base-main, Dependabot-authored PR whose current head is still exactly
+      # that SHA proceeds; everything else no-ops (human PRs, push-triggered CI runs, or a
+      # stale run after a Dependabot rebase, which the new head's CI run re-arms), so the
+      # App token is never even minted for them.
+      - name: Resolve Dependabot PR
+        id: pr
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          num="$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+            --jq '[.[] | select(.state=="open" and .base.ref=="main" and .user.login=="dependabot[bot]" and .head.sha==env.HEAD_SHA)][0].number // empty')"
+          if [ -n "${num}" ]; then
+            echo "number=${num}" >> "${GITHUB_OUTPUT}"
+            echo "Matched Dependabot PR #${num}"
+          else
+            echo "No matching open Dependabot PR for ${HEAD_SHA}; nothing to do."
+          fi
+      # Mint a dedicated-App installation token, scoped to this repo and downscoped to the
+      # three permissions arming auto-merge on a workflow-touching PR needs. Only reached
+      # for a real Dependabot PR. This is the trusted default-branch workflow, so the key
+      # is never handed to unreviewed PR code.
+      - name: Generate App Token
+        id: app-token
+        if: steps.pr.outputs.number != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cynative
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+      # Arm auto-merge with the App token so the completed merge is attributed to the App
+      # and its push to main triggers the Release Pipeline.
+      - name: Enable auto-merge
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "${PR_NUMBER}"


### PR DESCRIPTION
## What & why

Dependabot auto-merge ran under `secrets.GITHUB_TOKEN` on `pull_request`. GitHub's recursion guard means a push made by `GITHUB_TOKEN` (including a completed auto-merge) triggers no further `on: push` workflows, so the Release Pipeline (`release.yaml`) never re-ran after a deps merge. Its `publish` job's release-please phase 2 (`skip-github-release`) is the only place the release-please PR is refreshed and rebased onto current `main`, so the PR went stale (changelog missing merged `fix(deps)` commits) and fell `BEHIND` `main`, which the strict up-to-date ruleset then blocked from merging (observed on PR #112).

This moves the merge into a **`workflow_run`** that fires when `CI` completes on a Dependabot PR. The job runs in the trusted default-branch context, resolves the PR from the run's head SHA (open, base `main`, `dependabot[bot]`-authored, current head still that SHA), and arms auto-merge with a **dedicated App** token. The completed merge is attributed to the App, so its push to `main` re-triggers `release.yaml`; release-please then refreshes and rebases its release PR.

Why this shape, rather than a simpler `pull_request` + reused-App token:

- **`workflow_run`, not `pull_request`.** A `pull_request` run executes the PR's head version of the workflow, so a Dependabot bump of `create-github-app-token` in this file would run the unreviewed new action with the App key available. `workflow_run` runs the default-branch version with Actions secrets, so the key is never in a PR-modified context. The job also does no checkout and runs no PR code; the head SHA and PR number flow through `env`, not raw interpolation.
- **A dedicated App, not the release App.** Dependabot groups `github-actions`, so action-bump PRs regularly modify `.github/workflows/*` (e.g. #135). Arming auto-merge on such a PR with an App token requires the App to have `Workflows: write`. The dedicated App has exactly `contents` + `pull-requests` + `workflows` write and is installed on `cynative` only, keeping that capability off the release/tap/bucket tokens. The minted token is scoped to `cynative` and downscoped to those three permissions.

Prerequisite (done): the dedicated App's credentials are in Actions secrets `AUTOMERGE_APP_ID` / `AUTOMERGE_APP_PRIVATE_KEY`. Verified live that the token mints `cynative`-scoped with `contents` + `pull-requests` + `workflows` write.

Acceptance (observational, on the next real Dependabot merge, since `workflow_run` cannot run until this is on `main`): a Release Pipeline run appears on the resulting `main` SHA (unlike the pre-fix Dependabot merge SHAs, which had none), the release-please PR reflects the merged commit and is not left `BEHIND`, and an action-bump PR that touches a workflow file auto-merges (the `Workflows: write` case).

Closes #134

## Checklist
- [ ] `make check` passes locally: N/A for a workflow-only change (`make check`/`check-go` cover Go and shell, not workflow YAML). Validated instead with `actionlint` (clean), a YAML parse, and live credential/permission checks; CI's `Lint & Test` still runs `make check` on this PR.
- [ ] Tests added/updated: N/A - the repo has no test harness for GitHub workflow YAML; the workflow_run path is exercised on the next real Dependabot merge.
- [ ] Docs updated: N/A - internal CI behavior; the rationale is captured in the workflow's inline comments.
