### PR TITLE
ci: publish the Scoop manifest only after the release is published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -742,8 +742,9 @@ jobs:
       tag: ${{ needs.release.outputs.tag_name }}
 
   # Renders and pushes the Scoop bucket manifest after publish (cynative#103),
-  # replacing goreleaser's pre-publish bucket push. secrets: inherit passes the
-  # App credentials the reusable workflow mints its scoop-bucket token from.
+  # replacing goreleaser's pre-publish bucket push. Only the App credentials are
+  # passed (not `secrets: inherit`); the reusable workflow mints its
+  # scoop-bucket-scoped, contents:write token from them.
   scoop-publish:
     name: Publish Scoop manifest
     needs: [release, publish]
@@ -753,7 +754,9 @@ jobs:
     uses: ./.github/workflows/scoop-publish.yaml
     with:
       tag: ${{ needs.release.outputs.tag_name }}
-    secrets: inherit
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   scoop-smoke:
     name: Scoop install smoke

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,6 @@ jobs:
           repositories: |
             cynative
             homebrew-tap
-            scoop-bucket
 
       # release-please PHASE 1 — releases only (skip-github-pull-request):
       # creates the GitHub release as a DRAFT ("draft": true in
@@ -255,7 +254,6 @@ jobs:
           repositories: |
             cynative
             homebrew-tap
-            scoop-bucket
 
       - name: Upload pkgs to draft release
         if: ${{ steps.release-please.outputs.release_created == 'true' }}
@@ -583,7 +581,6 @@ jobs:
           repositories: |
             cynative
             homebrew-tap
-            scoop-bucket
 
       # The publish scripts live in the repo; check out the exact SHA the
       # release was cut from.
@@ -720,8 +717,10 @@ jobs:
   # homebrew-smoke (cynative#45) runs after the tap push and validates the
   # brew channel; install-script-smoke (cynative#47) validates the documented
   # curl|sh and irm|iex install paths against the public release assets;
-  # scoop-smoke (cynative#46) validates the documented scoop bucket add +
-  # install path against the public bucket and release assets.
+  # scoop-publish (cynative#103) renders and pushes the Scoop bucket manifest
+  # after publish (goreleaser no longer pushes it), and scoop-smoke (cynative#46)
+  # then validates the documented scoop bucket add + install path against the
+  # public bucket and release assets.
   homebrew-smoke:
     name: Homebrew install smoke
     needs: [release, publish]
@@ -742,9 +741,23 @@ jobs:
     with:
       tag: ${{ needs.release.outputs.tag_name }}
 
+  # Renders and pushes the Scoop bucket manifest after publish (cynative#103),
+  # replacing goreleaser's pre-publish bucket push. secrets: inherit passes the
+  # App credentials the reusable workflow mints its scoop-bucket token from.
+  scoop-publish:
+    name: Publish Scoop manifest
+    needs: [release, publish]
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/scoop-publish.yaml
+    with:
+      tag: ${{ needs.release.outputs.tag_name }}
+    secrets: inherit
+
   scoop-smoke:
     name: Scoop install smoke
-    needs: [release, publish]
+    needs: [release, publish, scoop-publish]
     if: ${{ needs.release.outputs.release_created == 'true' }}
     permissions:
       contents: read

--- a/.github/workflows/scoop-publish.yaml
+++ b/.github/workflows/scoop-publish.yaml
@@ -1,0 +1,116 @@
+name: Publish Scoop manifest
+
+# Render + push cynative/scoop-bucket's bucket/cynative.json AFTER the release is
+# published and verified (cynative#103). goreleaser no longer pushes the bucket
+# (scoops[0].skip_upload: true); this workflow owns the live manifest. Two entry
+# points, no PR trigger: the Release Pipeline calls it post-publish
+# (workflow_call, tag input), and maintainers can dispatch it manually to
+# recover from a channel-push failure without re-running the publish gate against
+# an already-published release. Self-contained: it derives the two Windows-zip
+# hashes from the immutable published release's checksums.txt, so both entry
+# points share one code path and neither needs the release-artifacts hand-off.
+# The Scoop smoke runs after this publisher.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to publish (e.g. v0.4.0)
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish (blank = latest published release)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-scoop:
+    name: Render & push Scoop manifest
+    # Public reusable workflow hygiene: the App secrets never flow to a fork
+    # calling this via a local path, but the guard makes "a fork never reaches
+    # the push" explicit rather than merely survivable.
+    if: ${{ github.repository == 'cynative/cynative' }}
+    runs-on: ubuntu-latest
+    # Bounded: a wedged call would otherwise hold the release-pipeline
+    # concurrency group for the default 360 minutes.
+    timeout-minutes: 10
+    steps:
+      # scoop-bucket write is the point of this job; cynative read authorizes the
+      # release read/download below. This is the ONLY place scoop-bucket write
+      # authority lives now.
+      - name: Generate App Token
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            cynative
+            scoop-bucket
+
+      # The tag input wins when present (the call path always passes it); a
+      # manual dispatch with no input resolves the latest published release.
+      # Keying on input presence rather than the event name matters: a called
+      # workflow inherits the caller's event. Fail closed on an empty tag or an
+      # empty resolved version.
+      - name: Resolve tag & version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          if [ -n "${TAG_INPUT}" ]; then
+            tag="${TAG_INPUT}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" \
+              || { echo "::error::no published release to publish"; exit 1; }
+          else
+            echo "::error::empty tag input on the workflow_call path"; exit 1
+          fi
+          # Guard the tag shape as a whole string BEFORE it reaches GITHUB_OUTPUT
+          # and the checkout ref: our release tags are always v<version>. The
+          # bash =~ anchors ^...$ over the entire value, so a newline- or
+          # metacharacter-bearing dispatch input (output/ref injection) is
+          # rejected rather than split into extra outputs.
+          if [[ ! "${tag}" =~ ^v[0-9][0-9A-Za-z.+-]*$ ]]; then
+            echo "::error::unexpected tag format '${tag}' (want v<version>)"; exit 1
+          fi
+          version="${tag#v}"
+          if [ -z "${version}" ]; then
+            echo "::error::resolved an empty version from tag '${tag}'"; exit 1
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "publishing scoop manifest for ${tag}"
+
+      # Render from the exact source the release was cut from (provenance).
+      # persist-credentials off: publish-scoop.sh does its own authenticated
+      # clone of scoop-bucket with the App token.
+      - name: Checkout scripts at the release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+          persist-credentials: false
+
+      # The published release's checksums.txt is immutable and authoritative; it
+      # was asserted byte-equal to the built assets pre-publish and re-verified
+      # post-publish, and archive-smoke cross-checks its rows.
+      - name: Download published checksums
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --pattern checksums.txt --dir "${RUNNER_TEMP}" --clobber
+          test -s "${RUNNER_TEMP}/checksums.txt"
+
+      - name: Render & push manifest
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: scripts/release/publish-scoop.sh "${VERSION}" "${RUNNER_TEMP}/checksums.txt"

--- a/.github/workflows/scoop-publish.yaml
+++ b/.github/workflows/scoop-publish.yaml
@@ -65,28 +65,44 @@ jobs:
       # manual dispatch with no input resolves the latest published release
       # (releases/latest excludes drafts). Keying on input presence rather than
       # the event name matters: a called workflow inherits the caller's event.
-      # Fail closed on an empty tag or an empty resolved version.
+      # The resolved tag must equal the latest published release (the bucket
+      # tracks latest, never a downgrade). Fail closed on an empty tag, a
+      # non-latest tag, or an empty resolved version.
       - name: Resolve tag & version
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_INPUT: ${{ inputs.tag }}
         run: |
+          # releases/latest excludes drafts; empty when there is no published
+          # release yet.
+          latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null)" \
+            || latest_tag=""
           if [ -n "${TAG_INPUT}" ]; then
             tag="${TAG_INPUT}"
           elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" \
-              || { echo "::error::no published release to publish"; exit 1; }
+            [ -n "${latest_tag}" ] || { echo "::error::no published release to publish"; exit 1; }
+            tag="${latest_tag}"
           else
             echo "::error::empty tag input on the workflow_call path"; exit 1
           fi
-          # Guard the tag shape as a whole string BEFORE it reaches GITHUB_OUTPUT
-          # and the checkout ref: our release tags are always v<version>. The
-          # bash =~ anchors ^...$ over the entire value, so a newline- or
-          # metacharacter-bearing dispatch input (output/ref injection) is
-          # rejected rather than split into extra outputs.
+          # Guard the tag shape as a whole string BEFORE it reaches GITHUB_OUTPUT:
+          # our release tags are always v<version>. The bash =~ anchors ^...$ over
+          # the entire value, so a newline- or metacharacter-bearing dispatch
+          # input (output injection) is rejected rather than split into extra
+          # outputs.
           if [[ ! "${tag}" =~ ^v[0-9][0-9A-Za-z.+-]*$ ]]; then
             echo "::error::unexpected tag format '${tag}' (want v<version>)"; exit 1
+          fi
+          # The Scoop bucket serves only the latest release. Refuse a non-latest
+          # tag: publish-scoop.sh clones the current bucket tip, and a plain
+          # fast-forward push would otherwise commit a DOWNGRADE on top of a newer
+          # manifest. On the call path the just-published tag is already latest
+          # (verify-published.sh asserted make_latest before this job); this also
+          # fences a manual dispatch that names a stale tag.
+          if [ -z "${latest_tag}" ] || [ "${tag}" != "${latest_tag}" ]; then
+            echo "::error::refusing to publish ${tag}: latest published release is ${latest_tag:-<none>}; the Scoop bucket tracks latest (dispatch with no tag, or the latest tag)"
+            exit 1
           fi
           version="${tag#v}"
           if [ -z "${version}" ]; then
@@ -122,15 +138,19 @@ jobs:
           fi
           echo "release ${TAG} is published (${published})"
 
-      # Render from the exact source the release was cut from (provenance).
-      # refs/tags/ is explicit: an unqualified ref lets actions/checkout prefer a
-      # like-named branch, which would supply the privileged publish script while
-      # checksums still came from the real release. persist-credentials off:
-      # publish-scoop.sh does its own authenticated clone of scoop-bucket.
-      - name: Checkout scripts at the release tag
+      # Check out the commit that triggered THIS run (default checkout ref = the
+      # release commit on the call path, the dispatched branch's HEAD on
+      # recovery), NOT the release tag. The manifest content is fully determined
+      # by the tag's version and the published checksums.txt, not by the revision
+      # of these scripts, so a bug fixed in render-scoop.sh / publish-scoop.sh can
+      # be dispatched for an already-published tag instead of re-running the tag's
+      # frozen (possibly broken) copy. The default ref is a concrete commit SHA
+      # from our own repo, so there is no branch/tag ambiguity or fork exposure.
+      # persist-credentials off: publish-scoop.sh does its own authenticated clone
+      # of scoop-bucket.
+      - name: Checkout scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: refs/tags/${{ steps.resolve.outputs.tag }}
           persist-credentials: false
 
       # The published release's checksums.txt is immutable and authoritative; it

--- a/.github/workflows/scoop-publish.yaml
+++ b/.github/workflows/scoop-publish.yaml
@@ -17,6 +17,13 @@ on:
         description: Release tag to publish (e.g. v0.4.0)
         required: true
         type: string
+    # Only the App credentials are needed; declaring them keeps the caller from
+    # handing this workflow every secret (no `secrets: inherit`).
+    secrets:
+      APP_ID:
+        required: true
+      APP_PRIVATE_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -39,9 +46,11 @@ jobs:
     # concurrency group for the default 360 minutes.
     timeout-minutes: 10
     steps:
-      # scoop-bucket write is the point of this job; cynative read authorizes the
-      # release read/download below. This is the ONLY place scoop-bucket write
-      # authority lives now.
+      # Least privilege: the App token is scoped to scoop-bucket with only
+      # contents:write (the push), the single authority this job needs. Release
+      # reads/downloads below use the job's read-only GITHUB_TOKEN, so the
+      # privileged publish script never gets write access to the cynative repo.
+      # This is the ONLY place scoop-bucket write authority lives now.
       - name: Generate App Token
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -49,19 +58,18 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: |
-            cynative
-            scoop-bucket
+          repositories: scoop-bucket
+          permission-contents: write
 
       # The tag input wins when present (the call path always passes it); a
-      # manual dispatch with no input resolves the latest published release.
-      # Keying on input presence rather than the event name matters: a called
-      # workflow inherits the caller's event. Fail closed on an empty tag or an
-      # empty resolved version.
+      # manual dispatch with no input resolves the latest published release
+      # (releases/latest excludes drafts). Keying on input presence rather than
+      # the event name matters: a called workflow inherits the caller's event.
+      # Fail closed on an empty tag or an empty resolved version.
       - name: Resolve tag & version
         id: resolve
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG_INPUT: ${{ inputs.tag }}
         run: |
           if [ -n "${TAG_INPUT}" ]; then
@@ -88,13 +96,41 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "publishing scoop manifest for ${tag}"
 
+      # Refuse to advance Scoop for anything but a PUBLISHED release. gh's
+      # explicit-tag resolution (and gh release download) will resolve a DRAFT by
+      # its pending tag, so a manual dispatch naming the in-flight draft would
+      # otherwise push the bucket before publication - the exact failure #103
+      # fixes. releases/latest already excludes drafts, so this guards the
+      # explicit-tag dispatch path (and is a cheap belt-and-braces check on the
+      # call path, which only runs after the publish job). Fails closed if the
+      # release is a draft, unpublished, tag-mismatched, or not visible.
+      - name: Assert the release is published
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          info="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --json isDraft,tagName,publishedAt 2>/dev/null)" \
+            || { echo "::error::no visible release for tag ${TAG}; refusing to advance Scoop"; exit 1; }
+          draft="$(printf '%s' "${info}" | jq -r '.isDraft')"
+          published="$(printf '%s' "${info}" | jq -r '.publishedAt')"
+          rtag="$(printf '%s' "${info}" | jq -r '.tagName')"
+          if [ "${rtag}" != "${TAG}" ] || [ "${draft}" != "false" ] \
+              || [ -z "${published}" ] || [ "${published}" = "null" ]; then
+            echo "::error::release ${TAG} is not published (isDraft=${draft}, publishedAt=${published}, tagName=${rtag}); refusing to advance Scoop"
+            exit 1
+          fi
+          echo "release ${TAG} is published (${published})"
+
       # Render from the exact source the release was cut from (provenance).
-      # persist-credentials off: publish-scoop.sh does its own authenticated
-      # clone of scoop-bucket with the App token.
+      # refs/tags/ is explicit: an unqualified ref lets actions/checkout prefer a
+      # like-named branch, which would supply the privileged publish script while
+      # checksums still came from the real release. persist-credentials off:
+      # publish-scoop.sh does its own authenticated clone of scoop-bucket.
       - name: Checkout scripts at the release tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.resolve.outputs.tag }}
+          ref: refs/tags/${{ steps.resolve.outputs.tag }}
           persist-credentials: false
 
       # The published release's checksums.txt is immutable and authoritative; it
@@ -102,7 +138,7 @@ jobs:
       # post-publish, and archive-smoke cross-checks its rows.
       - name: Download published checksums
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/scoop-smoke.yaml
+++ b/.github/workflows/scoop-smoke.yaml
@@ -9,13 +9,13 @@ name: Scoop install smoke
 # published release. Failure semantics: a red run with a green Release
 # Pipeline `publish` job means the public Scoop channel is broken -
 # investigate and re-run via workflow_dispatch, nothing to roll back.
-# goreleaser currently pushes the bucket manifest during the pre-publish
-# GoReleaser step (cynative#103 tracks moving it post-publish), so on
-# the call path the first bucket probe normally succeeds. A manual dispatch
-# racing a live release run can wedge in exactly one ordering (bucket
-# already advanced, release not yet published): the wait below then times
-# out with instructions; a dispatch before the bucket advances simply
-# validates the previous release. Residual: the manifest's arm64 entry is
+# The scoop-publish workflow (cynative#103) renders and pushes the bucket
+# manifest after publish, and on the release-pipeline call path it runs before
+# this smoke, so the first bucket probe normally succeeds. A manual dispatch
+# racing a live release run can wedge in exactly one ordering (release
+# published but scoop-publish not yet pushed): the wait below then times out
+# with instructions; a dispatch before the bucket advances simply validates the
+# previous release. Residual: the manifest's arm64 entry is
 # not exercised (this smoke is x64-only); a windows-11-arm leg needs its own
 # proving run before joining the release-adjacent path. Both jobs carry
 # explicit timeout-minutes: a caller job that `uses:` a reusable workflow
@@ -74,8 +74,8 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "expecting cynative ${version}"
 
-      # goreleaser pushes the bucket BEFORE the release publishes, so on the
-      # call path the first probe normally succeeds; the loop is bounded
+      # scoop-publish pushes the bucket after publish, before this smoke on the
+      # call path, so the first probe normally succeeds; the loop is bounded
       # defense for a manual dispatch racing a live release run (which
       # freezes the previous release as expected and cannot converge - the
       # final error says to re-run after publication). Each probe is an
@@ -86,9 +86,10 @@ jobs:
       # failed), ABSENT (manifest missing), INVALID (version not a nonempty
       # JSON string), MISMATCH (wrong version). Probe-loop worst case: 12 x
       # 25s clone caps + 11 x 30s sleeps, about 10.5 minutes, inside this
-      # job's 12-minute timeout (tighter than the homebrew tap poll: the
-      # bucket push happens even earlier than the tap push, so a longer
-      # budget buys nothing). No sleep after the final attempt: the step's
+      # job's 12-minute timeout (the bucket now advances post-publish in
+      # scoop-publish, which this smoke gates on, so on the call path the
+      # manifest is already served and this budget is race defense for a manual
+      # dispatch). No sleep after the final attempt: the step's
       # own budget-exhaustion error must fire inside the job timeout (and the
       # default shell is bash -e, so this must be an if, not a bare [ ] &&
       # chain).

--- a/.github/workflows/scoop-smoke.yaml
+++ b/.github/workflows/scoop-smoke.yaml
@@ -11,11 +11,11 @@ name: Scoop install smoke
 # investigate and re-run via workflow_dispatch, nothing to roll back.
 # The scoop-publish workflow (cynative#103) renders and pushes the bucket
 # manifest after publish, and on the release-pipeline call path it runs before
-# this smoke, so the first bucket probe normally succeeds. A manual dispatch
-# racing a live release run can wedge in exactly one ordering (release
-# published but scoop-publish not yet pushed): the wait below then times out
-# with instructions; a dispatch before the bucket advances simply validates the
-# previous release. Residual: the manifest's arm64 entry is
+# this smoke, so the first bucket probe normally succeeds. A manual dispatch can
+# race a live release run: if it resolves the just-published version before
+# scoop-publish has pushed, the wait below converges once the publisher pushes,
+# or times out with instructions if that push is delayed or failed; a dispatch
+# that resolves an already-served version validates it immediately. Residual: the manifest's arm64 entry is
 # not exercised (this smoke is x64-only); a windows-11-arm leg needs its own
 # proving run before joining the release-adjacent path. Both jobs carry
 # explicit timeout-minutes: a caller job that `uses:` a reusable workflow
@@ -76,9 +76,9 @@ jobs:
 
       # scoop-publish pushes the bucket after publish, before this smoke on the
       # call path, so the first probe normally succeeds; the loop is bounded
-      # defense for a manual dispatch racing a live release run (which
-      # freezes the previous release as expected and cannot converge - the
-      # final error says to re-run after publication). Each probe is an
+      # defense for a manual dispatch that resolves a just-published version
+      # before scoop-publish has pushed it - it converges when the publisher
+      # pushes, or the final error says to re-run after the publisher completes. Each probe is an
       # anonymous shallow git clone of the public bucket - the same mechanism
       # scoop itself uses, with none of the REST rate-limit or cross-repo
       # token-scope questions. Deliberately not raw.githubusercontent.com: no

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,9 +51,9 @@ scoops:
       owner: cynative
       name: scoop-bucket
       branch: main
-    # skip_upload: goreleaser still generates dist/bucket/cynative.json but no
-    # longer pushes it during the pre-publish build (cynative#103). The live
-    # manifest is rendered and pushed after publish by
+    # skip_upload: goreleaser still generates its Scoop manifest locally under
+    # dist/ but no longer pushes it during the pre-publish build (cynative#103).
+    # The live manifest is rendered and pushed after publish by
     # scripts/release/render-scoop.sh + publish-scoop.sh, which is the
     # authoritative renderer; the fields below only shape goreleaser's inert
     # local copy.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,11 +51,18 @@ scoops:
       owner: cynative
       name: scoop-bucket
       branch: main
+    # skip_upload: goreleaser still generates dist/bucket/cynative.json but no
+    # longer pushes it during the pre-publish build (cynative#103). The live
+    # manifest is rendered and pushed after publish by
+    # scripts/release/render-scoop.sh + publish-scoop.sh, which is the
+    # authoritative renderer; the fields below only shape goreleaser's inert
+    # local copy.
+    skip_upload: true
     # Scoop's recommended layout keeps manifests in a `bucket/` subdirectory
     # (mirrors the official ScoopInstaller bucket template).
     directory: bucket
     homepage: "https://github.com/cynative/cynative"
-    description: "Agentic security research across your code, cloud and runtime — read-only by construction"
+    description: "Agentic security research across your code, cloud, and runtime (read-only)"
     license: "Apache-2.0"
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,11 @@ sh-test:
 	@sh test/install.unit.test.sh
 	@sh test/install.smoke.test.sh
 	@sh test/e2e-guardrails.unit.test.sh
+	@sh test/render-scoop.unit.test.sh
 	@sh test/connector.gcp.e2e.test.sh --selftest
 	@sh test/connector.aws.e2e.test.sh --selftest
 	@sh test/connector.github.e2e.test.sh --selftest
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector audit parsers)"
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + render-scoop unit + connector audit parsers)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/scripts/release/assets-lib.sh
+++ b/scripts/release/assets-lib.sh
@@ -14,3 +14,24 @@ sha_for() {
   }
   printf '%s' "${sha}"
 }
+
+# sha_for_checksums <checksums-file> <asset-name>: pull an asset's sha256 out of
+# a goreleaser checksums.txt ("<sha256>  <name>" rows), failing closed unless
+# EXACTLY one row names the asset and its digest is 64-hex. Stricter than
+# sha_for, which takes the first match: the Scoop path must reject a duplicate
+# row, because Scoop verifies the manifest SHA-256 and a wrong hash bricks every
+# install.
+sha_for_checksums() {
+  local file="$1" name="$2" sha count
+  count="$(awk -v n="${name}" '$2==n{c++} END{print c+0}' "${file}")"
+  if [ "${count}" -ne 1 ]; then
+    echo "::error::expected exactly 1 checksum row for ${name}, found ${count}" >&2
+    return 1
+  fi
+  sha="$(awk -v n="${name}" '$2==n{print $1; exit}' "${file}")"
+  [[ "${sha}" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "::error::missing or invalid sha256 for ${name}" >&2
+    return 1
+  }
+  printf '%s' "${sha}"
+}

--- a/scripts/release/publish-scoop.sh
+++ b/scripts/release/publish-scoop.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Render + push the Scoop manifest to cynative/scoop-bucket, AFTER the release is
+# published and verified. The Scoop analog of publish-tap.sh. Requires GH_TOKEN
+# with push access to scoop-bucket.
+# Usage: publish-scoop.sh <version-without-v> <checksums-file>
+#   checksums-file: the published release's checksums.txt ("<sha256>  <name>" rows).
+set -euo pipefail
+version="$1"; checksums="$2"
+: "${GH_TOKEN:?}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/release/assets-lib.sh
+# shellcheck disable=SC1091 # gated standalone; the shellcheck gate runs without -x.
+. "${here}/assets-lib.sh"
+
+# Strict, duplicate-detecting lookups: the manifest hash is Scoop's install-time
+# integrity check, so a wrong or ambiguous digest must fail the push, not ship.
+sha_windows_intel="$(sha_for_checksums "${checksums}" cynative_Windows_x86_64.zip)"
+sha_windows_arm="$(sha_for_checksums "${checksums}" cynative_Windows_arm64.zip)"
+
+work="$(mktemp -d)"; trap 'rm -rf "${work}"' EXIT
+git clone --depth 1 \
+  "https://x-access-token:${GH_TOKEN}@github.com/cynative/scoop-bucket.git" "${work}/bucket"
+
+mkdir -p "${work}/bucket/bucket"
+"${here}/render-scoop.sh" "${version}" "${sha_windows_intel}" "${sha_windows_arm}" \
+  > "${work}/bucket/bucket/cynative.json"
+git -C "${work}/bucket" add bucket/cynative.json
+
+# Idempotent: the bucket already serves identical content.
+if git -C "${work}/bucket" diff --cached --quiet; then echo "bucket unchanged"; exit 0; fi
+git -C "${work}/bucket" -c user.name="cynative-release[bot]" -c user.email="release@cynative.com" \
+  commit -m "cynative ${version}"
+# Fast-forward only: a plain push rejects a non-ff update, never --force.
+git -C "${work}/bucket" push origin HEAD
+echo "pushed scoop manifest ${version}"

--- a/scripts/release/render-scoop.sh
+++ b/scripts/release/render-scoop.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Render the Scoop manifest (bucket/cynative.json) to stdout. The Scoop analog of
+# render-formula.sh: pure and arg-driven, so it is unit-testable offline.
+# Usage: render-scoop.sh <version-without-v> <sha_windows_x86_64> <sha_windows_arm64>
+set -euo pipefail
+version="$1"; sha_intel="$2"; sha_arm="$3"
+
+[ -n "${version}" ] || { echo "::error::empty version" >&2; exit 1; }
+for sha in "${sha_intel}" "${sha_arm}"; do
+  [[ "${sha}" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::malformed sha256: ${sha}" >&2; exit 1; }
+done
+
+base="https://github.com/cynative/cynative/releases/download/v${version}"
+jq -n --indent 4 \
+  --arg version "${version}" \
+  --arg url64 "${base}/cynative_Windows_x86_64.zip" \
+  --arg hash64 "${sha_intel}" \
+  --arg urlarm "${base}/cynative_Windows_arm64.zip" \
+  --arg hasharm "${sha_arm}" \
+  --arg homepage "https://github.com/cynative/cynative" \
+  --arg license "Apache-2.0" \
+  --arg description "Agentic security research across your code, cloud, and runtime (read-only)" \
+  '{
+     version: $version,
+     architecture: {
+       "64bit": { url: $url64, bin: ["cynative.exe"], hash: $hash64 },
+       "arm64": { url: $urlarm, bin: ["cynative.exe"], hash: $hasharm }
+     },
+     homepage: $homepage,
+     license: $license,
+     description: $description
+   }'

--- a/test/render-scoop.unit.test.sh
+++ b/test/render-scoop.unit.test.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# render-scoop.unit.test.sh - offline unit tests for the Scoop manifest renderer
+# (scripts/release/render-scoop.sh) and the strict checksums lookup
+# (scripts/release/assets-lib.sh: sha_for_checksums), cynative#103.
+#
+# Hermetic: no network, no credentials, no bucket clone. Exercises the pure
+# renderer's output shape and its fail-closed hash validation, plus the
+# duplicate/missing/malformed handling of the checksums parser the post-publish
+# push derives its two Windows-zip hashes from. Run by `make sh-test`.
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+root=$(CDPATH='' cd -- "$here/.." && pwd)
+render="$root/scripts/release/render-scoop.sh"
+lib="$root/scripts/release/assets-lib.sh"
+
+command -v jq >/dev/null 2>&1 || { printf 'FAIL: jq not found (required by render-scoop.sh)\n' >&2; exit 1; }
+
+fails=0
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+sha_a=5c712baad9179d576da1f8cff632b840b4b03495fd565a79fea8fe1a2b8b6be1
+sha_b=1321513cd9c9a8bd117c0ec1986845daf9face1ccdc35441b2b1910e50ce7be8
+desc='Agentic security research across your code, cloud, and runtime (read-only)'
+
+# ---- render-scoop.sh: happy path renders every required field ----------------
+if (
+	out=$("$render" 1.5.1 "$sha_a" "$sha_b") || exit 1
+	printf '%s' "$out" | jq -e . >/dev/null || exit 1                                   # valid JSON
+	[ "$(printf '%s' "$out" | jq -r '.version')" = "1.5.1" ] || exit 1                  # nonempty exact version
+	[ "$(printf '%s' "$out" | jq -r '.architecture | keys | sort | join(",")')" = "64bit,arm64" ] || exit 1  # exactly the two arches
+	[ "$(printf '%s' "$out" | jq -r '.architecture."64bit".url')" = "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Windows_x86_64.zip" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.architecture."arm64".url')" = "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Windows_arm64.zip" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.architecture."64bit".hash')" = "$sha_a" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.architecture."arm64".hash')" = "$sha_b" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.architecture."64bit".bin | join(",")')" = "cynative.exe" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.architecture."arm64".bin | join(",")')" = "cynative.exe" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.homepage')" = "https://github.com/cynative/cynative" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.license')" = "Apache-2.0" ] || exit 1
+	[ "$(printf '%s' "$out" | jq -r '.description')" = "$desc" ] || exit 1
+	# No checkver/autoupdate blocks.
+	[ "$(printf '%s' "$out" | jq -r 'has("checkver"), has("autoupdate") | select(. == true)')" = "" ] || exit 1
+	# No em dash anywhere in the rendered manifest.
+	printf '%s' "$out" | grep -q '—' && exit 1
+	exit 0
+); then pass "render-scoop renders version/arches/urls/bin/hash/meta, no checkver/autoupdate, no em dash"; else fail "render-scoop happy path"; fi
+
+# ---- render-scoop.sh: fail-closed on a malformed hash ------------------------
+if "$render" 1.5.1 not-a-hash "$sha_b" >/dev/null 2>&1; then fail "render-scoop malformed hash should fail"; else pass "render-scoop fails on a malformed hash"; fi
+
+# ---- render-scoop.sh: fail-closed on an empty version ------------------------
+if "$render" "" "$sha_a" "$sha_b" >/dev/null 2>&1; then fail "render-scoop empty version should fail"; else pass "render-scoop fails on an empty version"; fi
+
+# ---- sha_for_checksums: exactly-one, malformed, missing, duplicate ----------
+# Bash function (uses [[ =~ ]]); exercise it through a bash subprocess so this
+# POSIX-sh harness stays dialect-clean.
+checkfn() { bash -c '. "$1"; sha_for_checksums "$2" "$3"' _ "$lib" "$1" "$2"; }
+
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	{
+		printf '%s  cynative_Darwin_arm64.tar.gz\n' aaaa
+		printf '%s  cynative_Windows_x86_64.zip\n' "$sha_a"
+		printf '%s  cynative_Windows_arm64.zip\n' "$sha_b"
+	} > "$td/checksums.txt"
+	[ "$(checkfn "$td/checksums.txt" cynative_Windows_x86_64.zip)" = "$sha_a" ] || exit 1  # exactly one -> value
+	[ "$(checkfn "$td/checksums.txt" cynative_Windows_arm64.zip)" = "$sha_b" ] || exit 1
+	if checkfn "$td/checksums.txt" cynative_Windows_386.zip >/dev/null 2>&1; then exit 1; fi   # missing -> fail
+	if checkfn "$td/checksums.txt" cynative_Darwin_arm64.tar.gz >/dev/null 2>&1; then exit 1; fi # malformed (aaaa) -> fail
+	# Append a duplicate arm64 row -> fail.
+	printf '%s  cynative_Windows_arm64.zip\n' "$sha_b" >> "$td/checksums.txt"
+	if checkfn "$td/checksums.txt" cynative_Windows_arm64.zip >/dev/null 2>&1; then exit 1; fi   # duplicate -> fail
+	exit 0
+); then pass "sha_for_checksums returns the unique digest, fails on missing/malformed/duplicate"; else fail "sha_for_checksums"; fi
+
+if [ "$fails" -ne 0 ]; then
+	printf 'render-scoop.unit: %d case(s) FAILED\n' "$fails" >&2
+	exit 1
+fi
+printf 'render-scoop.unit: OK\n' >&2

--- a/test/render-scoop.unit.test.sh
+++ b/test/render-scoop.unit.test.sh
@@ -46,6 +46,18 @@ if (
 	exit 0
 ); then pass "render-scoop renders version/arches/urls/bin/hash/meta, no checkver/autoupdate, no em dash"; else fail "render-scoop happy path"; fi
 
+# ---- render-scoop.sh: byte-for-byte parity against a frozen golden -----------
+# Pins field order, four-space indent, and the single trailing LF - Scoop and
+# the previous goreleaser output are byte-shaped, and the semantic jq asserts
+# above cannot catch a formatting regression. Update the golden deliberately
+# (regenerate with the same args) if the manifest shape is intentionally changed.
+golden="$here/testdata/scoop-cynative.golden.json"
+if "$render" 1.5.1 "$sha_a" "$sha_b" | diff -u "$golden" - >/dev/null 2>&1; then
+	pass "render-scoop output matches the frozen golden byte-for-byte"
+else
+	fail "render-scoop golden byte parity (regenerate test/testdata/scoop-cynative.golden.json if intentional)"
+fi
+
 # ---- render-scoop.sh: fail-closed on a malformed hash ------------------------
 if "$render" 1.5.1 not-a-hash "$sha_b" >/dev/null 2>&1; then fail "render-scoop malformed hash should fail"; else pass "render-scoop fails on a malformed hash"; fi
 

--- a/test/testdata/scoop-cynative.golden.json
+++ b/test/testdata/scoop-cynative.golden.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.5.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Windows_x86_64.zip",
+            "bin": [
+                "cynative.exe"
+            ],
+            "hash": "5c712baad9179d576da1f8cff632b840b4b03495fd565a79fea8fe1a2b8b6be1"
+        },
+        "arm64": {
+            "url": "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Windows_arm64.zip",
+            "bin": [
+                "cynative.exe"
+            ],
+            "hash": "1321513cd9c9a8bd117c0ec1986845daf9face1ccdc35441b2b1910e50ce7be8"
+        }
+    },
+    "homepage": "https://github.com/cynative/cynative",
+    "license": "Apache-2.0",
+    "description": "Agentic security research across your code, cloud, and runtime (read-only)"
+}


### PR DESCRIPTION
## What & why

Closes #103.

**Problem.** goreleaser pushed `bucket/cynative.json` to `cynative/scoop-bucket` during the pre-publish "Run GoReleaser" step, while the release was still a draft. When a later step failed (v1.5.1 notarization on 2026-07-10), the public bucket advertised a version whose assets were not yet downloadable, breaking `scoop install cynative` until the retry published ~23 minutes later. Recovering a failed run by deleting the draft could strand the bucket on URLs that never materialize.

**Change.** Move the Scoop push to after publish, mirroring the Homebrew `render-formula.sh` + `publish-tap.sh` split:

- `.goreleaser.yaml`: `scoops[0].skip_upload: true` - goreleaser still generates its local manifest but no longer pushes.
- `scripts/release/render-scoop.sh`: pure `jq` renderer, byte-compatible with the previous goreleaser output (pinned by a golden fixture).
- `scripts/release/publish-scoop.sh` + `sha_for_checksums`: fast-forward-only, idempotent push that derives the two Windows-zip hashes from the published `checksums.txt`, failing closed on a missing, duplicate, or malformed row.
- `.github/workflows/scoop-publish.yaml`: reusable workflow - `workflow_call` from the pipeline post-publish, plus `workflow_dispatch` to recover a failed channel push without re-running the publish gate. It refuses to advance the bucket unless the resolved release is actually published, and uses a least-privilege token (`GITHUB_TOKEN` for release reads; App token scoped to `scoop-bucket` + `contents: write`).
- `release.yaml`: new `scoop-publish` job gated on `publish`; `scoop-smoke` now gates on it; `scoop-bucket` dropped from all three App-token grants, so that authority lives only where the post-publish push runs.
- `test/render-scoop.unit.test.sh` (+ golden) wired into `make sh-test`.

The Scoop `description` loses its em dash to match the Homebrew formula; that is the only content change versus the current live manifest.

**Acceptance criteria (#103):**

- [x] Manifest renders with an exact version, one x64 and one arm64 URL/hash pair, `bin: ["cynative.exe"]`; fails on a missing, duplicate, or malformed hash; no checkver/autoupdate.
- [x] Push is fast-forward only (never force) and idempotent when the bucket already serves identical content.
- [x] A channel-push failure is recoverable via `workflow_dispatch` without re-running the publish gate.
- [x] goreleaser no longer needs bucket write; `scoop-bucket` dropped from the pre-publish grants.
- [x] The Scoop smoke workflow's pre-publish-push comment is updated to post-publish semantics.

**Follow-up (manual, maintainer):** after merge and the next release, dispatch `scoop-publish.yaml` once to confirm idempotency (a second run reports `bucket unchanged`), then the Scoop smoke runs after it.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed (release-pipeline comments updated; no user docs affected)
