### PR TITLE
ci: give dependency updates their own changelog section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ multi-ecosystem-groups:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "fix(deps)"
+      prefix: "deps"
 
 updates:
   - package-ecosystem: "gomod"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -9,8 +9,10 @@ on:
     workflows: [CI]
     types: [completed]
 
-# The dedicated App token performs the merge; GITHUB_TOKEN only reads the PR to identify it.
+# The dedicated App token performs the body edit and the merge; GITHUB_TOKEN only
+# reads the PR to identify it and checks out the trusted default-branch scripts.
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -56,6 +58,42 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-workflows: write
+      # Check out the trusted default-branch copy of the override renderer. A
+      # workflow_run job resolves to the default branch's commit, so a Dependabot
+      # PR that modifies the script can never influence this run.
+      - name: Checkout override renderer
+        if: steps.pr.outputs.number != ''
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts/ci/dependabot-commit-override.sh
+          sparse-checkout-cone-mode: false
+      # Rewrite the PR body with a release-please commit-override block so the
+      # changelog lists each updated package instead of the opaque group title.
+      # Fail-safe: an unparseable message or an already-current body skips the
+      # edit and the squash title renders as before; continue-on-error keeps a
+      # failure here from ever blocking the merge.
+      - name: Write per-package changelog override
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          gh api "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message' > /tmp/commit-msg
+          gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > /tmp/pr-body
+          new_body="$(sh scripts/ci/dependabot-commit-override.sh render /tmp/pr-body < /tmp/commit-msg)"
+          if [ -z "${new_body}" ]; then
+            echo "No dependency metadata parsed; leaving the body unchanged."
+            exit 0
+          fi
+          if [ "${new_body}" = "$(cat /tmp/pr-body)" ]; then
+            echo "Override already current."
+            exit 0
+          fi
+          gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f body="${new_body}"
+          echo "Wrote per-package override to PR #${PR_NUMBER}."
       # Arm auto-merge with the App token so the completed merge is attributed to the App
       # and its push to main triggers the Release Pipeline.
       - name: Enable auto-merge

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -75,16 +75,19 @@ jobs:
       # Fail-safe: an unparseable message or an already-current body skips the
       # edit and the squash title renders as before; continue-on-error keeps a
       # failure here from ever blocking the merge.
+      # The metadata commit is selected by content, not position: a branch updated by a merge
+      # from main has a metadata-free head commit, and the bump commit is what carries
+      # updated-dependencies.
       - name: Write per-package changelog override
         if: steps.pr.outputs.number != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          gh api "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message' > /tmp/commit-msg
+          gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" \
+            --jq '[.[].commit.message | select(contains("updated-dependencies:"))] | last // ""' > /tmp/commit-msg
           gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > /tmp/pr-body
           new_body="$(sh scripts/ci/dependabot-commit-override.sh render /tmp/pr-body < /tmp/commit-msg)"
           if [ -z "${new_body}" ]; then

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -61,8 +61,11 @@ jobs:
       # Check out the trusted default-branch copy of the override renderer. A
       # workflow_run job resolves to the default branch's commit, so a Dependabot
       # PR that modifies the script can never influence this run.
+      # continue-on-error here too: a checkout failure must degrade to the group title, never
+      # block the merge.
       - name: Checkout override renderer
         if: steps.pr.outputs.number != ''
+        continue-on-error: true
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: scripts/ci/dependabot-commit-override.sh

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -18,3 +18,17 @@ jobs:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            deps
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -681,11 +681,17 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   is the one case that adds a job. Not a required status check.
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
-  version bump, enforced by `semantic-pr.yaml`. `.goreleaser.yaml` handles binary builds for
-  release tags. The Release Pipeline splits at the publish boundary: the `release` job builds,
-  signs, and statically asserts everything, then hands the draft's exact asset set (pkgs,
-  archives, manifests) to downstream jobs as the `release-artifacts` workflow artifact; the
-  `macos-pkg-smoke` job (pinned `macos-26` + `macos-26-intel`, no secrets) runs
+  version bump, enforced by `semantic-pr.yaml`. Dependency bumps use the `deps:` type
+  (Dependabot's commit prefix) and render under a dedicated Dependencies changelog section, one
+  entry per updated package: the auto-merge workflow writes a release-please commit-override
+  block into the PR body via `scripts/ci/dependabot-commit-override.sh` (unit-tested by `make
+  sh-test`), falling back to the group title when the metadata cannot be parsed. `deps` commits
+  still cut patch releases; `release-please-config.json` pins the visible section list
+  explicitly, so re-check it when release-please is bumped. `.goreleaser.yaml` handles binary
+  builds for release tags. The Release Pipeline splits at the publish boundary: the `release`
+  job builds, signs, and statically asserts everything, then hands the draft's exact asset set
+  (pkgs, archives, manifests) to downstream jobs as the `release-artifacts` workflow artifact;
+  the `macos-pkg-smoke` job (pinned `macos-26` + `macos-26-intel`, no secrets) runs
   `test/pkg.smoke.test.sh` against each pkg on its native arch (sha256 vs manifest, pkgutil
   signature, stapler validate, gating spctl Gatekeeper assess, real `installer` install, receipt
   version, exact `--version`); the `archive-smoke` job (ubuntu-latest, ubuntu-24.04-arm,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,11 @@ Add tests alongside any new code, or the coverage gate fails. Useful targets:
 
 - **Branch** from `main`; direct pushes to `main` are blocked.
 - **Conventional-Commit PR titles** are required (CI enforces this): `feat:`,
-  `fix:`, `docs:`, `refactor:`, `chore:`, etc. Use `!` and a `BREAKING CHANGE:`
-  footer for breaking changes. Releases and the changelog are automated by
-  release-please from these titles — **do not hand-edit `CHANGELOG.md`**.
+  `fix:`, `docs:`, `refactor:`, `chore:`, etc. Dependency-only updates use
+  `deps:` (rendered in the changelog's Dependencies section); reserve `fix:`
+  for product defects. Use `!` and a `BREAKING CHANGE:` footer for breaking
+  changes. Releases and the changelog are automated by release-please from
+  these titles — **do not hand-edit `CHANGELOG.md`**.
 - PRs are **squash-merged** with linear history; keep them focused.
 - Required checks (`Lint & Test`, `Validate PR title`, `Build & smoke-test macOS
   packaging toolchain`) must pass and review threads must be resolved before merge.

--- a/Makefile
+++ b/Makefile
@@ -102,22 +102,24 @@ pwsh-test:
 	pwsh -NoProfile -Command 'if (-not (Get-Module -ListAvailable -Name Pester | Where-Object Version -eq "$(PESTER_VERSION)")) { Write-Host "FAIL: Pester $(PESTER_VERSION) not installed — run: Install-Module Pester -RequiredVersion $(PESTER_VERSION) -Scope CurrentUser -SkipPublisherCheck"; exit 1 }; Import-Module -Name Pester -RequiredVersion $(PESTER_VERSION) -Force -ErrorAction Stop; $$r = Invoke-Pester -Path test/install.unit.Tests.ps1 -Output Detailed -PassThru; if ($$r.FailedCount -gt 0) { exit 1 }'
 
 # sh-test: POSIX install.sh unit + loopback smoke tests, the live-e2e guardrails
-# library unit tests (test/lib/e2e-guardrails.sh), and all three connector suites'
-# offline audit-parser selftests (--selftest). All hermetic: no network, no
-# credentials. The parsers are the security boundary of the live connector e2es,
-# so they are gated here rather than only exercised on a live run. Presence-
-# check python3 (the smoke test's loopback fixture server) with an install hint,
-# mirroring the shellcheck/pwsh install-free pattern.
+# library unit tests (test/lib/e2e-guardrails.sh), the per-package changelog
+# override renderer unit tests (test/dependabot-override.unit.test.sh), and all
+# three connector suites' offline audit-parser selftests (--selftest). All
+# hermetic: no network, no credentials. The parsers are the security boundary of
+# the live connector e2es, so they are gated here rather than only exercised on a
+# live run. Presence-check python3 (the smoke test's loopback fixture server)
+# with an install hint, mirroring the shellcheck/pwsh install-free pattern.
 sh-test:
 	@command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 not found — needed by the install.sh loopback smoke test (test/install.smoke.test.sh)."; exit 1; }
 	@sh test/install.unit.test.sh
 	@sh test/install.smoke.test.sh
 	@sh test/e2e-guardrails.unit.test.sh
 	@sh test/render-scoop.unit.test.sh
+	@sh test/dependabot-override.unit.test.sh
 	@sh test/connector.gcp.e2e.test.sh --selftest
 	@sh test/connector.aws.e2e.test.sh --selftest
 	@sh test/connector.github.e2e.test.sh --selftest
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + render-scoop unit + connector audit parsers)"
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + render-scoop unit + dependabot-override unit + connector audit parsers)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,13 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "draft": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "revert", "section": "Reverts" }
+  ],
   "packages": {
     ".": {}
   }

--- a/scripts/ci/dependabot-commit-override.sh
+++ b/scripts/ci/dependabot-commit-override.sh
@@ -131,7 +131,13 @@ block=$(printf '%s' "$parsed" | awk -F '\t' -v bodylen="$bodylen" -v max="$max_b
 		if (NR == 0) exit 0
 		reserve = 80
 		tail = "\nEND_COMMIT_OVERRIDE"
-		block = "BEGIN_COMMIT_OVERRIDE\n" lines[1]
+		# The first entry is admitted only if it fits the budget too; when even
+		# that does not fit, emit nothing so the caller skips the edit and the
+		# group title renders unchanged.
+		first = "BEGIN_COMMIT_OVERRIDE\n" lines[1]
+		r = (NR > 1) ? reserve : 0
+		if (bodylen + 2 + length(first) + length(tail) + r > max) exit 0
+		block = first
 		used = 1
 		for (i = 2; i <= NR; i++) {
 			add = "\nBEGIN_NESTED_COMMIT\n" lines[i] "\nEND_NESTED_COMMIT"

--- a/scripts/ci/dependabot-commit-override.sh
+++ b/scripts/ci/dependabot-commit-override.sh
@@ -101,6 +101,11 @@ parsed=$(awk '
 			if (name !~ /^[A-Za-z0-9@._\/+-]+$/) exit 0
 			if (nv != "" && nv !~ /^[A-Za-z0-9._+-]+$/) exit 0
 			if (old != "" && old !~ /^[A-Za-z0-9._+-]+$/) old = ""
+			# A marker substring in any field would corrupt the override
+			# framing (release-please and our own strip scan both match
+			# markers unanchored), so the render abandons, the same
+			# fail-safe as the charset checks above.
+			if ((name old nv) ~ /(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)/) exit 0
 			out = out name "\t" old "\t" nv "\n"
 		}
 		printf "%s", out
@@ -142,7 +147,12 @@ block=$(printf '%s' "$parsed" | awk -F '\t' -v bodylen="$bodylen" -v max="$max_b
 		for (i = 2; i <= NR; i++) {
 			add = "\nBEGIN_NESTED_COMMIT\n" lines[i] "\nEND_NESTED_COMMIT"
 			cand = block add
-			if (bodylen + 2 + length(cand) + length(tail) + reserve > max) break
+			# Only a later entry could still force a summary, so the
+			# reserve is charged for every candidate except the last:
+			# a final entry that fits must not be collapsed into a
+			# "1 more dependencies" summary it does not need.
+			r2 = (i < NR) ? reserve : 0
+			if (bodylen + 2 + length(cand) + length(tail) + r2 > max) break
 			block = cand
 			used++
 		}

--- a/scripts/ci/dependabot-commit-override.sh
+++ b/scripts/ci/dependabot-commit-override.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# dependabot-commit-override.sh - render a release-please commit-override block
+# from a Dependabot commit message, so the changelog lists one Dependencies
+# entry per updated package instead of the opaque group title.
+#
+# Usage: dependabot-commit-override.sh render <body-file> < commit-message
+#
+# stdin  - the Dependabot head commit's full message. The authoritative package
+#          list is the machine-generated `updated-dependencies:` YAML fragment;
+#          old versions are enriched from the "Updates `x` from A to B" prose,
+#          the "| Package | From | To |" table, or the ungrouped "Bumps x from
+#          A to B." line, whichever the message carries.
+# arg    - file holding the current PR body. Any existing override block in it
+#          is replaced, never appended to, so reruns after a rebase are
+#          idempotent.
+# stdout - the new full PR body, or NOTHING when no dependencies were parsed or
+#          any entry failed sanitization (the caller must then skip the edit;
+#          the squash title renders as before). Fail-safe: a complete accurate
+#          list or nothing, never a partial one.
+#
+# MAX_BODY (default 60000) caps the assembled body under GitHub's 65536-char
+# limit; overflow collapses the tail into one "deps: bump N more dependencies"
+# entry so the count stays honest.
+set -eu
+
+[ "${1:-}" = "render" ] && [ -n "${2:-}" ] || {
+	echo "usage: $0 render <body-file> < commit-message" >&2
+	exit 2
+}
+body_file=$2
+max_body=${MAX_BODY:-60000}
+
+# Pass 1: parse the commit message into "NAME<TAB>OLD<TAB>NEW" lines (OLD may
+# be empty). Emits nothing when the fragment is absent or any entry is unsafe.
+parsed=$(awk '
+	# Prose enrichment: Updates `NAME` from OLD to NEW (versions may be
+	# backticked for submodule bumps).
+	/^Updates `[^`]+` from .* to .*$/ {
+		line = $0
+		sub(/^Updates `/, "", line)
+		name = line; sub(/`.*/, "", name)
+		sub(/^[^`]*` from /, "", line)
+		gsub(/`/, "", line)
+		old = line; sub(/ to .*/, "", old)
+		nv = line; sub(/^.* to /, "", nv); sub(/\.$/, "", nv)
+		from[name] = old; tonew[name] = nv
+	}
+	# Ungrouped enrichment: Bumps [NAME](url) from OLD to NEW.
+	/^Bumps \[[^]]+\]\([^)]*\) from .* to .*\.$/ {
+		line = $0
+		sub(/^Bumps \[/, "", line)
+		name = line; sub(/\].*/, "", name)
+		sub(/^[^)]*\) from /, "", line)
+		gsub(/`/, "", line)
+		old = line; sub(/ to .*/, "", old)
+		nv = line; sub(/^.* to /, "", nv); sub(/\.$/, "", nv)
+		from[name] = old; tonew[name] = nv
+	}
+	# Ungrouped enrichment without a link: Bumps NAME from OLD to NEW.
+	/^Bumps [^ []+ from [^ ]+ to [^ ]+\.$/ {
+		name = $2; old = $4; nv = $6
+		gsub(/`/, "", name); gsub(/`/, "", old); gsub(/`/, "", nv)
+		sub(/\.$/, "", nv)
+		from[name] = old; tonew[name] = nv
+	}
+	# Table enrichment: | [NAME](url) | `OLD` | `NEW` |.
+	/^\| \[/ {
+		nf = split($0, f, /\|/)
+		if (nf >= 5) {
+			name = f[2]
+			sub(/^[ ]*\[/, "", name); sub(/\].*/, "", name)
+			old = f[3]; gsub(/[ `]/, "", old)
+			nv = f[4]; gsub(/[ `]/, "", nv)
+			if (name != "") { from[name] = old; tonew[name] = nv }
+		}
+	}
+	# Authoritative package list: the updated-dependencies YAML fragment.
+	/^updated-dependencies:$/ { inyaml = 1; next }
+	inyaml && /^\.\.\.$/ { inyaml = 0 }
+	inyaml && /^- dependency-name: / {
+		n++
+		dep = $0; sub(/^- dependency-name: /, "", dep)
+		names[n] = dep; vers[n] = ""
+	}
+	inyaml && /^  dependency-version: / && n > 0 {
+		v = $0; sub(/^  dependency-version: /, "", v)
+		vers[n] = v
+	}
+	END {
+		if (n == 0) exit 0
+		out = ""
+		for (i = 1; i <= n; i++) {
+			name = names[i]; nv = vers[i]; old = ""
+			if (name in from) old = from[name]
+			if (nv == "" && (name in tonew)) nv = tonew[name]
+			key = name "\t" nv
+			if (key in seen) continue
+			seen[key] = 1
+			# Fail-safe sanitization: any entry outside the safe
+			# charset abandons the whole render.
+			if (name !~ /^[A-Za-z0-9@._\/+-]+$/) exit 0
+			if (nv != "" && nv !~ /^[A-Za-z0-9._+-]+$/) exit 0
+			if (old != "" && old !~ /^[A-Za-z0-9._+-]+$/) old = ""
+			out = out name "\t" old "\t" nv "\n"
+		}
+		printf "%s", out
+	}
+')
+[ -n "$parsed" ] || exit 0
+
+# Pass 2: drop any previous override block from the body (replace, not append).
+stripped=$(awk '
+	index($0, "BEGIN_COMMIT_OVERRIDE") { skip = 1 }
+	skip == 0 { print }
+	index($0, "END_COMMIT_OVERRIDE") { skip = 0 }
+' "$body_file")
+bodylen=$(printf '%s' "$stripped" | wc -c)
+
+# Pass 3: assemble the override block within the body budget. The first entry
+# sits directly after the marker; every further entry is a nested commit, which
+# is what release-please splits on (blank-line splitting does not recognize the
+# deps type).
+block=$(printf '%s' "$parsed" | awk -F '\t' -v bodylen="$bodylen" -v max="$max_body" '
+	{
+		if ($2 != "" && $3 != "") l = "deps: bump " $1 " from " $2 " to " $3
+		else if ($3 != "") l = "deps: bump " $1 " to " $3
+		else l = "deps: bump " $1
+		lines[NR] = l
+	}
+	END {
+		if (NR == 0) exit 0
+		reserve = 80
+		tail = "\nEND_COMMIT_OVERRIDE"
+		block = "BEGIN_COMMIT_OVERRIDE\n" lines[1]
+		used = 1
+		for (i = 2; i <= NR; i++) {
+			add = "\nBEGIN_NESTED_COMMIT\n" lines[i] "\nEND_NESTED_COMMIT"
+			cand = block add
+			if (bodylen + 2 + length(cand) + length(tail) + reserve > max) break
+			block = cand
+			used++
+		}
+		if (used < NR) {
+			left = NR - used
+			block = block "\nBEGIN_NESTED_COMMIT\ndeps: bump " left " more dependencies\nEND_NESTED_COMMIT"
+		}
+		printf "%s%s", block, tail
+	}
+')
+[ -n "$block" ] || exit 0
+
+if [ -n "$stripped" ]; then
+	printf '%s\n\n%s\n' "$stripped" "$block"
+else
+	printf '%s\n' "$block"
+fi

--- a/scripts/ci/dependabot-commit-override.sh
+++ b/scripts/ci/dependabot-commit-override.sh
@@ -33,6 +33,15 @@ max_body=${MAX_BODY:-60000}
 # Pass 1: parse the commit message into "NAME<TAB>OLD<TAB>NEW" lines (OLD may
 # be empty). Emits nothing when the fragment is absent or any entry is unsafe.
 parsed=$(awk '
+	# Dependabot YAML-quotes numeric-looking scalars ('\''5'\'', "25.0"); strip a
+	# matched surrounding quote pair so the sanitize charset sees the value.
+	function dequote(s,    q) {
+		q = substr(s, 1, 1)
+		if ((q == "\"" || q == "'\''") && length(s) >= 2 && substr(s, length(s), 1) == q) {
+			return substr(s, 2, length(s) - 2)
+		}
+		return s
+	}
 	# Prose enrichment: Updates `NAME` from OLD to NEW (versions may be
 	# backticked for submodule bumps).
 	/^Updates `[^`]+` from .* to .*$/ {
@@ -80,11 +89,11 @@ parsed=$(awk '
 	inyaml && /^- dependency-name: / {
 		n++
 		dep = $0; sub(/^- dependency-name: /, "", dep)
-		names[n] = dep; vers[n] = ""
+		names[n] = dequote(dep); vers[n] = ""
 	}
 	inyaml && /^  dependency-version: / && n > 0 {
 		v = $0; sub(/^  dependency-version: /, "", v)
-		vers[n] = v
+		vers[n] = dequote(v)
 	}
 	END {
 		if (n == 0) exit 0

--- a/test/dependabot-override.unit.test.sh
+++ b/test/dependabot-override.unit.test.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+# dependabot-override.unit.test.sh - offline unit tests for the per-package
+# changelog override renderer (scripts/ci/dependabot-commit-override.sh).
+#
+# Hermetic: no network, no credentials. Exercises the parser against the three
+# real Dependabot message shapes (prose, table, ungrouped), the fail-safe empty
+# outputs, idempotent body replacement, sanitization, and the MAX_BODY overflow
+# summary. Run by `make sh-test`.
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+root=$(CDPATH='' cd -- "$here/.." && pwd)
+render="$root/scripts/ci/dependabot-commit-override.sh"
+
+fails=0
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Prose-shaped grouped message (modeled on PR #142).
+cat > "$tmp/prose.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+Bumps the all-dependencies group with 2 updates: [github.com/maximhq/bifrost/core](https://github.com/maximhq/bifrost) and [github.com/go-openapi/strfmt](https://github.com/go-openapi/strfmt).
+
+Updates `github.com/maximhq/bifrost/core` from 1.7.1 to 1.7.2
+- [Release notes](https://github.com/maximhq/bifrost/releases)
+
+Updates `github.com/go-openapi/strfmt` from 0.26.4 to 0.27.0
+- [Release notes](https://github.com/go-openapi/strfmt/releases)
+
+---
+updated-dependencies:
+- dependency-name: github.com/maximhq/bifrost/core
+  dependency-version: 1.7.2
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+  dependency-group: all-dependencies
+- dependency-name: github.com/go-openapi/strfmt
+  dependency-version: 0.27.0
+  dependency-type: indirect
+  update-type: version-update:semver-minor
+  dependency-group: all-dependencies
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+EOF
+
+printf 'Original PR body.\n' > "$tmp/body.txt"
+
+# ---- prose shape: one entry per package, first plain, rest nested ------------
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/prose.msg") || exit 1
+	[ -n "$out" ] || exit 1
+	printf '%s\n' "$out" | grep -q '^Original PR body\.$' || exit 1
+	[ "$(printf '%s\n' "$out" | grep -c '^BEGIN_COMMIT_OVERRIDE$')" = "1" ] || exit 1
+	[ "$(printf '%s\n' "$out" | grep -c '^END_COMMIT_OVERRIDE$')" = "1" ] || exit 1
+	# First entry directly after the marker, unnested.
+	printf '%s\n' "$out" | grep -A1 '^BEGIN_COMMIT_OVERRIDE$' \
+		| grep -q '^deps: bump github.com/maximhq/bifrost/core from 1.7.1 to 1.7.2$' || exit 1
+	# Second entry nested.
+	[ "$(printf '%s\n' "$out" | grep -c '^BEGIN_NESTED_COMMIT$')" = "1" ] || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump github.com/go-openapi/strfmt from 0.26.4 to 0.27.0$' || exit 1
+	exit 0
+); then pass "prose shape renders per-package override"; else fail "prose shape"; fi
+
+# ---- idempotence: re-running on its own output replaces, not appends ---------
+if (
+	out1=$("$render" render "$tmp/body.txt" < "$tmp/prose.msg") || exit 1
+	printf '%s\n' "$out1" > "$tmp/body2.txt"
+	out2=$("$render" render "$tmp/body2.txt" < "$tmp/prose.msg") || exit 1
+	[ "$out1" = "$out2" ] || exit 1
+	exit 0
+); then pass "idempotent replacement of an existing override block"; else fail "idempotence"; fi
+
+# ---- table shape (modeled on PR #124) -----------------------------------------
+cat > "$tmp/table.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+Bumps the all-dependencies group with 2 updates:
+
+| Package | From | To |
+| --- | --- | --- |
+| [cel.dev/expr](https://github.com/google/cel-spec) | `0.25.1` | `0.25.2` |
+| [cloud.google.com/go/auth](https://github.com/googleapis/google-cloud-go) | `0.20.0` | `0.22.0` |
+
+---
+updated-dependencies:
+- dependency-name: cel.dev/expr
+  dependency-version: 0.25.2
+  dependency-type: indirect
+- dependency-name: cloud.google.com/go/auth
+  dependency-version: 0.22.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/table.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump cel.dev/expr from 0.25.1 to 0.25.2$' || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump cloud.google.com/go/auth from 0.20.0 to 0.22.0$' || exit 1
+	exit 0
+); then pass "table shape enriches old versions"; else fail "table shape"; fi
+
+# ---- ungrouped security shape -------------------------------------------------
+cat > "$tmp/single.msg" <<'EOF'
+deps: Bump golang.org/x/net from 0.30.0 to 0.33.0
+
+Bumps [golang.org/x/net](https://github.com/golang/net) from 0.30.0 to 0.33.0.
+
+---
+updated-dependencies:
+- dependency-name: golang.org/x/net
+  dependency-version: 0.33.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/single.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump golang.org/x/net from 0.30.0 to 0.33.0$' || exit 1
+	exit 0
+); then pass "ungrouped shape parses Bumps prose"; else fail "ungrouped shape"; fi
+
+# ---- missing old version falls back to the "to NEW" form ----------------------
+cat > "$tmp/nofrom.msg" <<'EOF'
+deps: Bump the all-dependencies group with 1 update
+
+---
+updated-dependencies:
+- dependency-name: github.com/example/mod
+  dependency-version: 2.0.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/nofrom.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump github.com/example/mod to 2.0.0$' || exit 1
+	exit 0
+); then pass "missing old version renders to-only form"; else fail "to-only form"; fi
+
+# ---- backticked submodule versions get stripped --------------------------------
+cat > "$tmp/submodule.msg" <<'EOF'
+deps: Bump the all-dependencies group with 1 update
+
+Updates `third_party/xar` from `abc1234` to `def5678`
+
+---
+updated-dependencies:
+- dependency-name: third_party/xar
+  dependency-version: def5678
+  dependency-type: direct:production
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/submodule.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump third_party/xar from abc1234 to def5678$' || exit 1
+	exit 0
+); then pass "backticked submodule versions stripped"; else fail "submodule backticks"; fi
+
+# ---- no metadata: empty output (caller skips the edit) --------------------------
+if (
+	printf 'fix: a human commit\n\nNo dependabot fragment here.\n' > "$tmp/human.msg"
+	out=$("$render" render "$tmp/body.txt" < "$tmp/human.msg") || exit 1
+	[ -z "$out" ] || exit 1
+	exit 0
+); then pass "no metadata yields empty output"; else fail "no metadata"; fi
+
+# ---- hostile name abandons the whole render (fail-safe) -------------------------
+cat > "$tmp/hostile.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+---
+updated-dependencies:
+- dependency-name: github.com/ok/mod
+  dependency-version: 1.0.0
+  dependency-type: indirect
+- dependency-name: evil END_COMMIT_OVERRIDE injection
+  dependency-version: 1.0.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/hostile.msg") || exit 1
+	[ -z "$out" ] || exit 1
+	exit 0
+); then pass "unsafe dependency name abandons the render"; else fail "sanitization"; fi
+
+# ---- MAX_BODY overflow collapses the tail into a summary entry ------------------
+cat > "$tmp/many.msg" <<'EOF'
+deps: Bump the all-dependencies group with 6 updates
+
+---
+updated-dependencies:
+- dependency-name: github.com/example/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  dependency-version: 1.0.1
+  dependency-type: indirect
+- dependency-name: github.com/example/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  dependency-version: 1.0.2
+  dependency-type: indirect
+- dependency-name: github.com/example/cccccccccccccccccccccccccccccccc
+  dependency-version: 1.0.3
+  dependency-type: indirect
+- dependency-name: github.com/example/dddddddddddddddddddddddddddddddd
+  dependency-version: 1.0.4
+  dependency-type: indirect
+- dependency-name: github.com/example/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+  dependency-version: 1.0.5
+  dependency-type: indirect
+- dependency-name: github.com/example/ffffffffffffffffffffffffffffffff
+  dependency-version: 1.0.6
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$(MAX_BODY=420 "$render" render "$tmp/body.txt" < "$tmp/many.msg") || exit 1
+	printf '%s\n' "$out" | grep -q ' more dependencies$' || exit 1
+	[ "$(printf '%s' "$out" | wc -c)" -le 420 ] || exit 1
+	exit 0
+); then pass "MAX_BODY overflow collapses tail into summary"; else fail "overflow cap"; fi
+
+# ---- duplicate name+version pairs are deduplicated ------------------------------
+cat > "$tmp/dupes.msg" <<'EOF'
+deps: Bump the all-dependencies group with 1 update
+
+---
+updated-dependencies:
+- dependency-name: github.com/example/mod
+  dependency-version: 2.0.0
+  dependency-type: direct:production
+- dependency-name: github.com/example/mod
+  dependency-version: 2.0.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/dupes.msg") || exit 1
+	[ "$(printf '%s\n' "$out" | grep -c 'github.com/example/mod')" = "1" ] || exit 1
+	exit 0
+); then pass "duplicate entries deduplicated"; else fail "dedup"; fi
+
+[ "$fails" -eq 0 ] || { printf '%d failure(s)\n' "$fails" >&2; exit 1; }
+printf 'OK: dependabot-override unit tests\n'

--- a/test/dependabot-override.unit.test.sh
+++ b/test/dependabot-override.unit.test.sh
@@ -191,6 +191,27 @@ if (
 	exit 0
 ); then pass "unsafe dependency name abandons the render"; else fail "sanitization"; fi
 
+# ---- a marker-substring name (valid charset) abandons the whole render ---------
+cat > "$tmp/marker.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+---
+updated-dependencies:
+- dependency-name: github.com/ok/mod
+  dependency-version: 1.0.0
+  dependency-type: indirect
+- dependency-name: owner/END_COMMIT_OVERRIDE
+  dependency-version: 1.0.0
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/marker.msg") || exit 1
+	[ -z "$out" ] || exit 1
+	exit 0
+); then pass "marker-substring dependency name abandons the render"; else fail "marker substring"; fi
+
 # ---- MAX_BODY overflow collapses the tail into a summary entry ------------------
 cat > "$tmp/many.msg" <<'EOF'
 deps: Bump the all-dependencies group with 6 updates
@@ -233,6 +254,30 @@ if (
 	[ -z "$out" ] || exit 1
 	exit 0
 ); then pass "oversized existing body yields empty output"; else fail "oversized body"; fi
+
+# ---- a final entry that fits is not collapsed into a summary -------------------
+cat > "$tmp/final.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+---
+updated-dependencies:
+- dependency-name: a
+  dependency-version: 1
+  dependency-type: indirect
+- dependency-name: b
+  dependency-version: 1
+  dependency-type: indirect
+...
+EOF
+
+if (
+	printf '' > "$tmp/empty.txt"
+	out=$(MAX_BODY=160 "$render" render "$tmp/empty.txt" < "$tmp/final.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump a to 1$' || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump b to 1$' || exit 1
+	[ "$(printf '%s\n' "$out" | grep -c ' more dependencies$')" = "0" ] || exit 1
+	exit 0
+); then pass "a final entry that fits is not collapsed into a summary"; else fail "final-entry budget"; fi
 
 # ---- duplicate name+version pairs are deduplicated ------------------------------
 cat > "$tmp/dupes.msg" <<'EOF'

--- a/test/dependabot-override.unit.test.sh
+++ b/test/dependabot-override.unit.test.sh
@@ -225,6 +225,15 @@ if (
 	exit 0
 ); then pass "MAX_BODY overflow collapses tail into summary"; else fail "overflow cap"; fi
 
+# ---- an oversized existing body leaves no room for even the first entry --------
+if (
+	awk 'BEGIN { for (i = 0; i < 20; i++) print "This existing PR body line pads out the body content." }' \
+		> "$tmp/bigbody.txt"
+	out=$(MAX_BODY=100 "$render" render "$tmp/bigbody.txt" < "$tmp/prose.msg") || exit 1
+	[ -z "$out" ] || exit 1
+	exit 0
+); then pass "oversized existing body yields empty output"; else fail "oversized body"; fi
+
 # ---- duplicate name+version pairs are deduplicated ------------------------------
 cat > "$tmp/dupes.msg" <<'EOF'
 deps: Bump the all-dependencies group with 1 update

--- a/test/dependabot-override.unit.test.sh
+++ b/test/dependabot-override.unit.test.sh
@@ -162,6 +162,29 @@ if (
 	exit 0
 ); then pass "backticked submodule versions stripped"; else fail "submodule backticks"; fi
 
+# ---- YAML-quoted version scalars are dequoted -----------------------------------
+cat > "$tmp/quoted.msg" <<'EOF'
+deps: Bump the all-dependencies group with 2 updates
+
+---
+updated-dependencies:
+- dependency-name: github.com/example/five
+  dependency-version: '5'
+  dependency-type: indirect
+- dependency-name: github.com/example/twofive
+  dependency-version: "25.0"
+  dependency-type: indirect
+...
+EOF
+
+if (
+	out=$("$render" render "$tmp/body.txt" < "$tmp/quoted.msg") || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump github.com/example/five to 5$' || exit 1
+	printf '%s\n' "$out" | grep -q '^deps: bump github.com/example/twofive to 25.0$' || exit 1
+	[ "$(printf '%s\n' "$out" | grep '^deps: bump' | grep -Ec "['\"]")" = "0" ] || exit 1
+	exit 0
+); then pass "YAML-quoted version scalars are dequoted"; else fail "quoted versions"; fi
+
 # ---- no metadata: empty output (caller skips the edit) --------------------------
 if (
 	printf 'fix: a human commit\n\nNo dependabot fragment here.\n' > "$tmp/human.msg"


### PR DESCRIPTION
## What & why

Dependabot bumps land in the changelog under Bug Fixes as "**deps:** Bump the all-dependencies group with N updates", drowning out real fixes and never naming a package. This gives dependency updates their own **Dependencies** section and makes each release list exactly which packages shipped, while keeping bumps cutting patch releases (release-please skips a release only when the rendered notes are empty, so the new visible section keeps `deps` releasable).

- `.github/dependabot.yml`: the group's commit prefix becomes `deps`.
- `release-please-config.json`: explicit `changelog-sections` with a Dependencies section (feat/fix/perf/deps/revert visible; unlisted types stay hidden and non-releasing, matching the preset defaults being replaced).
- `.github/workflows/semantic-pr.yaml`: explicit `types` list, the 11 defaults plus `deps` (supplying the list replaces the defaults wholesale; `chore` stays because release-please's own PR titles use it).
- `.github/workflows/dependabot-auto-merge.yaml` + `scripts/ci/dependabot-commit-override.sh`: before arming auto-merge, the workflow rewrites the PR body with a release-please commit-override block built from Dependabot's own `updated-dependencies` metadata, so the changelog renders one entry per package (`deps: bump X from A to B`) instead of the opaque group title. Fail-safe throughout: unparseable metadata, a failed checkout, an oversized body, or a suspicious field falls back to the group title, and nothing on this path can block the merge. The metadata commit is selected by content rather than head position, since a branch updated by a merge from main has a metadata-free head commit (#124 is a real instance).
- `CONTRIBUTING.md` / `AGENTS.md`: document the `deps:` convention (dependency-only PRs use `deps:`; `fix:` stays reserved for product defects).

Verified against real merged PRs: #142 (prose metadata, 4 packages), #124 (table metadata, 70 packages, merge-from-main head), #100 (single update).

Notes:
- This PR's own title uses `ci:` because the title check validates against the base branch's workflow; `deps:` becomes valid once this merges.
- Watch item: a Dependabot security PR may not inherit the group prefix. If one arrives as `fix(deps)` it still self-releases, just under Bug Fixes; extend the config then.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change (`test/dependabot-override.unit.test.sh`, 13 cases, wired into `make sh-test`)
- [x] Docs updated if behavior changed (`CONTRIBUTING.md`, `AGENTS.md`)