### PR TITLE
ci: add live LLM smoke for direct OpenAI and Anthropic

### DIFF
--- a/.github/live-llm-manifest.json
+++ b/.github/live-llm-manifest.json
@@ -32,5 +32,49 @@
     "required": true,
     "require_no_connectors": true,
     "note": "aws-ci binds the stable OIDC subject; role_var preflight fails loud (cynative#48)."
+  },
+  {
+    "id": "openai-notool",
+    "enabled": true,
+    "provider": "openai",
+    "auth": "api-key",
+    "suite": "llm-smoke",
+    "model_var": "CYNATIVE_CLI_CI_OPENAI_MODEL",
+    "required": true,
+    "require_no_connectors": true,
+    "note": "Direct OpenAI no-tool nonce echo over the api-key family (cynative#119)."
+  },
+  {
+    "id": "openai-tools",
+    "enabled": true,
+    "provider": "openai",
+    "auth": "api-key",
+    "suite": "llm-tools-smoke",
+    "model_var": "CYNATIVE_CLI_CI_OPENAI_MODEL",
+    "required": true,
+    "require_no_connectors": false,
+    "note": "Direct OpenAI code_execution tool-use proof (cynative#119)."
+  },
+  {
+    "id": "anthropic-notool",
+    "enabled": true,
+    "provider": "anthropic",
+    "auth": "api-key",
+    "suite": "llm-smoke",
+    "model_var": "CYNATIVE_CLI_CI_ANTHROPIC_MODEL",
+    "required": true,
+    "require_no_connectors": true,
+    "note": "Direct Anthropic no-tool nonce echo over the api-key family (cynative#119)."
+  },
+  {
+    "id": "anthropic-tools",
+    "enabled": true,
+    "provider": "anthropic",
+    "auth": "api-key",
+    "suite": "llm-tools-smoke",
+    "model_var": "CYNATIVE_CLI_CI_ANTHROPIC_MODEL",
+    "required": true,
+    "require_no_connectors": false,
+    "note": "Direct Anthropic code_execution tool-use proof (cynative#119)."
   }
 ]

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -321,3 +321,94 @@ jobs:
             llm-tools-smoke) make llm-tools-smoke ;;
             *) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;
           esac
+
+  api-smoke:
+    name: Live LLM / ${{ matrix.id }}
+    needs: [detect, plan]
+    # Same gating and trust boundary as gcp-smoke/aws-smoke. GitHub never hands
+    # secrets to fork-PR runs, but the same-repo head check is still what keeps a
+    # fork's code from ever reaching the job at all.
+    if: >-
+      needs.detect.outputs.relevant == 'true' &&
+      needs.plan.outputs.api_has == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    # Bind to the llm-api-keys GitHub Environment: unlike the keyless families it
+    # holds real long-lived secrets (OPENAI_API_KEY, ANTHROPIC_API_KEY), so a
+    # required-reviewer gate stands between any run and the keys. One approval
+    # releases every leg of this matrix that is waiting on the environment. A
+    # static literal, never a matrix expression.
+    environment: llm-api-keys
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # no id-token: nothing is minted, the stored keys are the credentials
+    strategy:
+      fail-fast: false # one provider's failure must not cancel the others
+      max-parallel: 4 # bound simultaneous live token spend as the matrix grows
+      matrix: ${{ fromJSON(needs.plan.outputs.api_matrix) }}
+    steps:
+      # Resolve the model before anything else (see gcp-smoke). A required row
+      # with an unset model fails here; an optional row with an unset model skips
+      # the remaining steps.
+      - name: Resolve model
+        id: model
+        env:
+          MODEL: ${{ vars[matrix.model_var] }}
+          MODEL_VAR: ${{ matrix.model_var }}
+          REQUIRED: ${{ matrix.required }}
+        run: |
+          if [ -n "$MODEL" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$REQUIRED" = "true" ]; then
+            echo "::error::required row has unset model variable $MODEL_VAR" >&2
+            exit 1
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "optional row with no model configured ($MODEL_VAR unset); skipping"
+          fi
+      - name: Report tested head SHA
+        run: echo "Testing PR head SHA ${{ github.event.pull_request.head.sha || github.sha }}"
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - if: steps.model.outputs.run == 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Both keys are exposed to exactly this one step. The shell selects the
+      # matching key by provider (fail-closed default branch), preflights it
+      # non-empty (a rotated or deleted secret fails loud instead of skipping
+      # green; an unset ${{ secrets.X }} resolves to ""), drops the raw names so
+      # only CYNATIVE_LLM_API_KEY reaches the binary, and execs into make so not
+      # even this shell's process image retains the unselected key. Matrix values
+      # go through env, never into the run script text; the suite dispatch stays
+      # a literal case (fail-closed), as in the other jobs.
+      - name: Run the smoke
+        if: steps.model.outputs.run == 'true'
+        env:
+          CYNATIVE_LLM_PROVIDER: ${{ matrix.provider }}
+          CYNATIVE_LLM_MODEL: ${{ vars[matrix.model_var] }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # required -> hard-fail on an unset/renamed model var (never a silent skip);
+          # require_no_connectors -> hard-fail unless the runner stays connector-dark.
+          SMOKE_REQUIRE_RUN: ${{ matrix.required && '1' || '' }}
+          SMOKE_REQUIRE_NO_CONNECTORS: ${{ matrix.require_no_connectors && '1' || '' }}
+          SUITE: ${{ matrix.suite }}
+        run: |
+          case "$CYNATIVE_LLM_PROVIDER" in
+            openai) CYNATIVE_LLM_API_KEY="$OPENAI_API_KEY" ;;
+            anthropic) CYNATIVE_LLM_API_KEY="$ANTHROPIC_API_KEY" ;;
+            *) echo "::error::no API-key wiring for provider: $CYNATIVE_LLM_PROVIDER" >&2; exit 1 ;;
+          esac
+          if [ -z "$CYNATIVE_LLM_API_KEY" ]; then
+            echo "::error::the $CYNATIVE_LLM_PROVIDER API-key secret is empty or unset; provision it in the llm-api-keys environment." >&2
+            exit 1
+          fi
+          export CYNATIVE_LLM_API_KEY
+          unset OPENAI_API_KEY ANTHROPIC_API_KEY
+          case "$SUITE" in
+            llm-smoke) exec make llm-smoke ;;
+            llm-tools-smoke) exec make llm-tools-smoke ;;
+            *) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;
+          esac

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -20,7 +20,10 @@ name: Live LLM smoke
 # llm-api-keys`. A new auth family is the one deliberate case that adds a job.
 # Mirrors install-e2e.yaml's detect gating, so the heavy live runs only fire for
 # release-please PRs or a manual dispatch, and every credential step is gated to
-# same-repo events so untrusted forks never reach it. Not a required status check.
+# same-repo events so untrusted forks never reach it. The `Live LLM gate` summary
+# job is a required status check: on a release-please PR a red, cancelled, or
+# skipped live leg blocks the merge, while a non-release PR passes trivially
+# (everything skips).
 on:
   # Include `labeled` (on top of the opened/synchronize/reopened defaults) so the
   # `autorelease: pending` fallback in the detect job actually fires when that
@@ -412,3 +415,42 @@ jobs:
             llm-tools-smoke) exec make llm-tools-smoke ;;
             *) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;
           esac
+
+  gate:
+    name: Live LLM gate
+    needs: [detect, plan, gcp-smoke, aws-smoke, api-smoke]
+    # The one stable check name the ruleset pins as a required status check (matrix
+    # leg names change with the manifest, so the legs themselves cannot be pinned).
+    # Runs on every PR: on a non-release PR the live jobs skip and this passes
+    # trivially; on a release-please PR or a dispatch it fails unless every live job
+    # actually SUCCEEDED. GitHub satisfies a required check with a conditionally
+    # skipped job, which would fail open, so this job runs on always() and asserts
+    # results explicitly (result == 'success', never != 'failure': a cancelled or
+    # skipped live leg must block the merge, not slip past it).
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert live legs ran and passed
+        env:
+          DETECT: ${{ needs.detect.result }}
+          RELEVANT: ${{ needs.detect.outputs.relevant }}
+          PLAN: ${{ needs.plan.result }}
+          GCP: ${{ needs.gcp-smoke.result }}
+          AWS: ${{ needs.aws-smoke.result }}
+          API: ${{ needs.api-smoke.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result: $DETECT)" >&2
+            exit 1
+          fi
+          if [ "$RELEVANT" != "true" ]; then
+            echo "not a release-please PR or dispatch; nothing to gate"
+            exit 0
+          fi
+          rc=0
+          [ "$PLAN" = "success" ] || { echo "::error::plan result: $PLAN" >&2; rc=1; }
+          [ "$GCP" = "success" ] || { echo "::error::gcp-smoke result: $GCP" >&2; rc=1; }
+          [ "$AWS" = "success" ] || { echo "::error::aws-smoke result: $AWS" >&2; rc=1; }
+          [ "$API" = "success" ] || { echo "::error::api-smoke result: $API" >&2; rc=1; }
+          exit $rc

--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -4,20 +4,23 @@ name: Live LLM smoke
 # manifest .github/live-llm-manifest.json (cynative#50). Each enabled manifest row
 # is one matrix job: a provider x suite pair. The manifest carries the provider
 # details (id, model variable, suite, required-or-optional, auth family) so adding
-# or disabling a same-family provider is a one-row manifest edit, not a workflow
-# rewrite; internal/llm/livellm_manifest_test.go validates it fail-closed under the
+# or disabling a row for an already-wired provider is a one-row manifest edit, not
+# a workflow rewrite (a new provider needs its family's credential wiring too);
+# internal/llm/livellm_manifest_test.go validates it fail-closed under the
 # required `Lint & Test` check, so a malformed row blocks merge.
 #
-# The `plan` job turns the manifest into two per-family matrices; the smoke jobs
+# The `plan` job turns the manifest into three per-family matrices; the smoke jobs
 # consume them. Credential mechanics genuinely differ per family and cannot be
 # expressed as data, so each auth family has its own job: `gcp-smoke` authenticates
-# to GCP project cynative-cli-ci via keyless Workload Identity Federation, and
+# to GCP project cynative-cli-ci via keyless Workload Identity Federation,
 # `aws-smoke` authenticates to AWS via keyless GitHub OIDC role assumption under a
-# static `environment: aws-ci` (the stable OIDC subject the AWS role trusts). A new
-# auth family is the one deliberate case that adds a job. Mirrors install-e2e.yaml's
-# detect gating, so the heavy live runs only fire for release-please PRs or a manual
-# dispatch, and every credential step is gated to same-repo events so untrusted
-# forks never reach it. Not a required status check.
+# static `environment: aws-ci` (the stable OIDC subject the AWS role trusts), and
+# `api-smoke` runs the direct API-key providers (OpenAI, Anthropic) with real
+# long-lived secrets held behind the reviewer-protected `environment:
+# llm-api-keys`. A new auth family is the one deliberate case that adds a job.
+# Mirrors install-e2e.yaml's detect gating, so the heavy live runs only fire for
+# release-please PRs or a manual dispatch, and every credential step is gated to
+# same-repo events so untrusted forks never reach it. Not a required status check.
 on:
   # Include `labeled` (on top of the opened/synchronize/reopened defaults) so the
   # `autorelease: pending` fallback in the detect job actually fires when that
@@ -28,6 +31,15 @@ on:
 
 permissions:
   contents: read
+
+# One live run per PR: an environment-gated job can wait on reviewer approval for
+# up to 30 days, so without this every push to a release PR would stack another
+# pending run. PR runs share a PR-scoped group and cancel their predecessor; a
+# manual dispatch gets a per-run group so it never cancels (or is cancelled by)
+# anything else.
+concurrency:
+  group: llm-smoke-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   detect:
@@ -70,6 +82,8 @@ jobs:
       gcp_has: ${{ steps.build.outputs.gcp_has }}
       aws_matrix: ${{ steps.build.outputs.aws_matrix }}
       aws_has: ${{ steps.build.outputs.aws_has }}
+      api_matrix: ${{ steps.build.outputs.api_matrix }}
+      api_has: ${{ steps.build.outputs.api_has }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build per-family matrices from the manifest
@@ -84,24 +98,28 @@ jobs:
           # strategy evaluation instead of skipping).
           gcp="$(jq -c '{include: [.[] | select(.enabled and .auth == "gcp-wif") | {id, provider, suite, model_var, required, require_no_connectors}]}' "$MANIFEST")"
           aws="$(jq -c '{include: [.[] | select(.enabled and .auth == "aws-oidc") | {id, provider, suite, model_var, role_var, required, require_no_connectors}]}' "$MANIFEST")"
+          api="$(jq -c '{include: [.[] | select(.enabled and .auth == "api-key") | {id, provider, suite, model_var, required, require_no_connectors}]}' "$MANIFEST")"
           enabled_n="$(jq '[.[] | select(.enabled)] | length' "$MANIFEST")"
           gcp_n="$(jq '[.[] | select(.enabled and .auth == "gcp-wif")] | length' "$MANIFEST")"
           aws_n="$(jq '[.[] | select(.enabled and .auth == "aws-oidc")] | length' "$MANIFEST")"
+          api_n="$(jq '[.[] | select(.enabled and .auth == "api-key")] | length' "$MANIFEST")"
           # Fail closed: every enabled row must belong to a known auth family, so an
           # enabled row with an unknown/typo'd auth turns this job red instead of
           # silently vanishing from every matrix (the Go validator is the merge-time
           # guard; this is the run-time backstop for a dispatch on unmerged code).
-          if [ "$enabled_n" -ne "$((gcp_n + aws_n))" ]; then
-            echo "::error::$enabled_n enabled rows but only $gcp_n gcp-wif + $aws_n aws-oidc; an enabled row has an unknown auth." >&2
+          if [ "$enabled_n" -ne "$((gcp_n + aws_n + api_n))" ]; then
+            echo "::error::$enabled_n enabled rows but only $gcp_n gcp-wif + $aws_n aws-oidc + $api_n api-key; an enabled row has an unknown auth." >&2
             exit 1
           fi
           {
             printf 'gcp_matrix=%s\n' "$gcp"
             printf 'aws_matrix=%s\n' "$aws"
+            printf 'api_matrix=%s\n' "$api"
             printf 'gcp_has=%s\n' "$([ "$gcp_n" -gt 0 ] && echo true || echo false)"
             printf 'aws_has=%s\n' "$([ "$aws_n" -gt 0 ] && echo true || echo false)"
+            printf 'api_has=%s\n' "$([ "$api_n" -gt 0 ] && echo true || echo false)"
           } >> "$GITHUB_OUTPUT"
-          printf 'enabled: %s | gcp rows: %s | aws rows: %s\n' "$enabled_n" "$gcp_n" "$aws_n"
+          printf 'enabled: %s | gcp rows: %s | aws rows: %s | api rows: %s\n' "$enabled_n" "$gcp_n" "$aws_n" "$api_n"
 
   gcp-smoke:
     name: Live LLM / ${{ matrix.id }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,16 +651,16 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
 ### CI and release
 
 - `.github/workflows/ci.yaml` runs `make check` as the single **`Lint & Test`** job on every PR
-  against `main`; a bootstrap step installs the pinned shellcheck (download + SHA-256 verify)
-  and the pinned Pester/PSScriptAnalyzer modules, versions read from the `Makefile` via
-  `make -s print-*`. The job is gated to pull requests (the workflow also fires on push to
-  `main`, where it skips). Direct pushes to `main` are **blocked** by an active GitHub
-  **ruleset** (squash-only merges, linear history, required review-thread resolution, no human
-  bypass) whose required status checks, under a strict up-to-date policy, are **`Lint & Test`**,
-  **`Validate PR title`** (`semantic-pr.yaml`), and **`Build & smoke-test macOS packaging
-  toolchain`** (`pkg-tools.yaml`); the ruleset also runs Copilot code review on each push. The
-  pre-commit hook runs the fast hermetic `make check-go`, a local mirror of the Go half of the
-  gate, not the enforcement boundary.
+  against `main`; a bootstrap step installs the pinned shellcheck (download + SHA-256 verify) and
+  the pinned Pester/PSScriptAnalyzer modules, versions read from the `Makefile` via `make -s
+  print-*`. The job is gated to pull requests (the workflow also fires on push to `main`, where
+  it skips). Direct pushes to `main` are **blocked** by an active GitHub **ruleset** (squash-only
+  merges, linear history, required review-thread resolution, no human bypass) whose required
+  status checks, under a strict up-to-date policy, are **`Lint & Test`**, **`Validate PR title`**
+  (`semantic-pr.yaml`), **`Build & smoke-test macOS packaging toolchain`** (`pkg-tools.yaml`),
+  and **`Live LLM gate`** (`llm-smoke.yaml`); the ruleset also runs Copilot code review on each
+  push. The pre-commit hook runs the fast hermetic `make check-go`, a local mirror of the Go half
+  of the gate, not the enforcement boundary.
 - `.github/workflows/install-e2e.yaml` exercises the real installer against the goreleaser
   release archives for release confidence. It does not run on normal PRs: a `detect` job flags
   release-please PRs and manual `workflow_dispatch`, one `snapshot` job builds the archives
@@ -680,8 +680,12 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   reviewer-protected `environment: llm-api-keys`; contents-read only, no id-token, in-shell secret
   selection) consume them. Same `detect` gating and fork-trust boundary as `install-e2e.yaml`, and
   `internal/llm/livellm_manifest_test.go` validates the manifest fail-closed under `Lint & Test`,
-  so a malformed row blocks merge. A new auth family is the one case that adds a job. Not a
-  required status check.
+  so a malformed row blocks merge. A new auth family is the one case that adds a job. The `Live LLM
+  gate` summary job is a required status check (added to the ruleset post-merge): it asserts every
+  live leg's result is exactly `success` when the detect gate fired, so a release-please PR cannot
+  merge with a red, cancelled, or unapproved-and-expired live run, while non-release PRs pass
+  trivially because everything skips. The matrix legs themselves stay unpinned (their names change
+  with the manifest).
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
   version bump, enforced by `semantic-pr.yaml`. Dependency bumps use the `deps:` type

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -670,15 +670,18 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   required status check, so they gate release-please PRs and on-demand runs, never normal
   merges.
 - `.github/workflows/llm-smoke.yaml` runs the live LLM smoke against real providers for release
-  confidence, driven by the checked-in manifest `.github/live-llm-manifest.json`: each enabled
-  row (a provider x suite pair, carrying the model variable, required-or-optional, and auth
-  family) becomes one matrix job, so adding or disabling a same-auth-family provider is a manifest
-  edit, not a workflow change. A `plan` job splits the manifest into per-family matrices; a
-  `gcp-smoke` job (Vertex via Workload Identity Federation) and an `aws-smoke` job (Bedrock via
-  GitHub OIDC under a static `environment: aws-ci`) consume them. Same `detect` gating and
-  fork-trust boundary as `install-e2e.yaml`, and `internal/llm/livellm_manifest_test.go` validates
-  the manifest fail-closed under `Lint & Test`, so a malformed row blocks merge. A new auth family
-  is the one case that adds a job. Not a required status check.
+  confidence, driven by the checked-in manifest `.github/live-llm-manifest.json`: each enabled row
+  (a provider x suite pair, carrying the model variable, required-or-optional, and auth family)
+  becomes one matrix job, so adding or disabling a row for an already-wired provider is a manifest
+  edit, not a workflow change (a new provider also needs its family's credential wiring). A `plan`
+  job splits the manifest into per-family matrices; a `gcp-smoke` job (Vertex via Workload Identity
+  Federation), an `aws-smoke` job (Bedrock via GitHub OIDC under a static `environment: aws-ci`),
+  and an `api-smoke` job (direct OpenAI/Anthropic via API-key secrets held behind the
+  reviewer-protected `environment: llm-api-keys`; contents-read only, no id-token, in-shell secret
+  selection) consume them. Same `detect` gating and fork-trust boundary as `install-e2e.yaml`, and
+  `internal/llm/livellm_manifest_test.go` validates the manifest fail-closed under `Lint & Test`,
+  so a malformed row blocks merge. A new auth family is the one case that adds a job. Not a
+  required status check.
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
   version bump, enforced by `semantic-pr.yaml`. Dependency bumps use the `deps:` type

--- a/internal/llm/livellm_manifest_test.go
+++ b/internal/llm/livellm_manifest_test.go
@@ -245,23 +245,47 @@ func TestLiveLLMManifest_CheckedInFileValidates(t *testing.T) {
 		t.Fatalf("unmarshal manifest: %v", uerr)
 	}
 
-	// Golden: the Vertex + Bedrock starters are still present (guards against an
-	// accidental deletion that would silently drop release coverage), and both
-	// auth families are exercised (so the two-family workflow keeps both jobs live).
-	ids := make(map[string]bool, len(rows))
-	auths := make(map[string]bool, len(rows))
-	for _, r := range rows {
-		ids[r.ID] = true
-		auths[r.Auth] = true
+	// Golden: every starter row is present, enabled, and wired as the workflow
+	// expects (guards against an accidental deletion, a silent disable, or a
+	// miswired row quietly dropping release coverage), and every auth family is
+	// exercised by an enabled row (so the three-family workflow keeps all jobs
+	// live). model_var and the flags stay unpinned on purpose: the id and the
+	// adapter map cross-check the rest, and pinning every field would turn each
+	// legitimate manifest tweak into a test edit.
+	starters := map[string]struct{ provider, auth, suite string }{
+		"vertex-notool":    {provider: "vertex", auth: authGCPWIF, suite: suiteNoTool},
+		"vertex-tools":     {provider: "vertex", auth: authGCPWIF, suite: suiteTools},
+		"bedrock-notool":   {provider: "bedrock", auth: authAWSOIDC, suite: suiteNoTool},
+		"openai-notool":    {provider: "openai", auth: authAPIKey, suite: suiteNoTool},
+		"openai-tools":     {provider: "openai", auth: authAPIKey, suite: suiteTools},
+		"anthropic-notool": {provider: "anthropic", auth: authAPIKey, suite: suiteNoTool},
+		"anthropic-tools":  {provider: "anthropic", auth: authAPIKey, suite: suiteTools},
 	}
-	for _, want := range []string{"vertex-notool", "vertex-tools", "bedrock-notool"} {
-		if !ids[want] {
-			t.Errorf("manifest is missing starter row %q", want)
+	rowsByID := make(map[string]liveLLMRow, len(rows))
+	enabledAuths := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		rowsByID[r.ID] = r
+		if r.Enabled != nil && *r.Enabled {
+			enabledAuths[r.Auth] = true
 		}
 	}
-	for _, want := range []string{authGCPWIF, authAWSOIDC} {
-		if !auths[want] {
-			t.Errorf("manifest has no %q row; both auth families must stay covered", want)
+	for id, want := range starters {
+		r, ok := rowsByID[id]
+		if !ok {
+			t.Errorf("manifest is missing starter row %q", id)
+			continue
+		}
+		if r.Enabled == nil || !*r.Enabled {
+			t.Errorf("starter row %q must stay enabled", id)
+		}
+		if r.Provider != want.provider || r.Auth != want.auth || r.Suite != want.suite {
+			t.Errorf("starter row %q is miswired: got (%s, %s, %s), want (%s, %s, %s)",
+				id, r.Provider, r.Auth, r.Suite, want.provider, want.auth, want.suite)
+		}
+	}
+	for _, want := range []string{authGCPWIF, authAWSOIDC, authAPIKey} {
+		if !enabledAuths[want] {
+			t.Errorf("manifest has no enabled %q row; every auth family must stay covered", want)
 		}
 	}
 }

--- a/internal/llm/livellm_manifest_test.go
+++ b/internal/llm/livellm_manifest_test.go
@@ -49,6 +49,7 @@ type liveLLMRow struct {
 const (
 	authGCPWIF  = "gcp-wif"
 	authAWSOIDC = "aws-oidc"
+	authAPIKey  = "api-key"
 	suiteNoTool = "llm-smoke"
 	suiteTools  = "llm-tools-smoke"
 	// maxRows is a deliberately small cap on live legs (each is a real,
@@ -60,14 +61,17 @@ const (
 
 // providerAuthAdapter pins each provider to the one credential+env-wiring adapter
 // the workflow implements for it: gcp-wif exports only CYNATIVE_LLM_VERTEX_*,
-// aws-oidc only CYNATIVE_LLM_BEDROCK_*. Membership in llm.ChatProviders() means
-// "chat-capable", not "wired for CI", so a row's (provider, auth) pair must be one
-// of these adapters. A genuinely new provider needs a new adapter (a workflow
-// job), which is the deliberate non-data case; a same-adapter model (another
-// Vertex or Bedrock model id) is a pure manifest edit.
+// aws-oidc only CYNATIVE_LLM_BEDROCK_*, api-key only CYNATIVE_LLM_API_KEY.
+// Membership in llm.ChatProviders() means "chat-capable", not "wired for CI", so
+// a row's (provider, auth) pair must be one of these adapters. A genuinely new
+// provider needs new adapter wiring (a job for a new auth family; a secret and a
+// selection branch for another api-key provider), the deliberate non-data cases;
+// a same-adapter model id is a pure manifest edit.
 var providerAuthAdapter = map[string]string{ //nolint:gochecknoglobals // stateless test data table.
-	"vertex":  authGCPWIF,
-	"bedrock": authAWSOIDC,
+	"vertex":    authGCPWIF,
+	"bedrock":   authAWSOIDC,
+	"openai":    authAPIKey,
+	"anthropic": authAPIKey,
 }
 
 // idPattern and varNamePattern pin the manifest's identifier and variable-name
@@ -156,8 +160,9 @@ func validateRowEnums(r liveLLMRow, validProviders map[string]bool) error {
 	if !validProviders[r.Provider] {
 		return fmt.Errorf("row %q: provider %q is not a known chat provider", r.ID, r.Provider)
 	}
-	if r.Auth != authGCPWIF && r.Auth != authAWSOIDC {
-		return fmt.Errorf("row %q: auth %q must be %q or %q", r.ID, r.Auth, authGCPWIF, authAWSOIDC)
+	if r.Auth != authGCPWIF && r.Auth != authAWSOIDC && r.Auth != authAPIKey {
+		return fmt.Errorf("row %q: auth %q must be one of %q, %q, %q",
+			r.ID, r.Auth, authGCPWIF, authAWSOIDC, authAPIKey)
 	}
 	if providerAuthAdapter[r.Provider] != r.Auth {
 		return fmt.Errorf("row %q: provider %q is wired for auth %q, not %q",
@@ -173,14 +178,15 @@ func validateRowEnums(r liveLLMRow, validProviders map[string]bool) error {
 }
 
 // validateRoleVar enforces that role_var is present and valid exactly for the
-// aws-oidc family (which needs a role ARN to assume); gcp-wif must not carry one.
+// aws-oidc family (which needs a role ARN to assume); gcp-wif and api-key must
+// not carry one.
 func validateRoleVar(r liveLLMRow) error {
 	switch r.Auth {
 	case authAWSOIDC:
 		return validateVarName("role_var", r.ID, r.RoleVar)
-	case authGCPWIF:
+	case authGCPWIF, authAPIKey:
 		if r.RoleVar != "" {
-			return fmt.Errorf("row %q: gcp-wif must not set role_var (got %q)", r.ID, r.RoleVar)
+			return fmt.Errorf("row %q: auth %q must not set role_var (got %q)", r.ID, r.Auth, r.RoleVar)
 		}
 	}
 	return nil
@@ -263,10 +269,11 @@ func TestLiveLLMManifest_CheckedInFileValidates(t *testing.T) {
 func TestLiveLLMManifest_AcceptsValid(t *testing.T) {
 	t.Parallel()
 
-	providers := map[string]bool{"vertex": true, "bedrock": true}
+	providers := map[string]bool{"vertex": true, "bedrock": true, "openai": true, "anthropic": true}
 	valid := `[
 	  {"id":"vertex-notool","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_VERTEX_MODEL","required":true,"require_no_connectors":true,"note":"ok"},
-	  {"id":"bedrock-notool","enabled":true,"provider":"bedrock","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_BEDROCK_MODEL","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":false,"require_no_connectors":true}
+	  {"id":"bedrock-notool","enabled":true,"provider":"bedrock","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_BEDROCK_MODEL","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":false,"require_no_connectors":true},
+	  {"id":"openai-notool","enabled":true,"provider":"openai","auth":"api-key","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_OPENAI_MODEL","required":true,"require_no_connectors":true,"note":"ok"}
 	]`
 	if err := validateLiveLLMManifest([]byte(valid), providers); err != nil {
 		t.Fatalf("expected valid manifest to pass, got: %v", err)
@@ -276,7 +283,7 @@ func TestLiveLLMManifest_AcceptsValid(t *testing.T) {
 func TestLiveLLMManifest_RejectsInvalid(t *testing.T) {
 	t.Parallel()
 
-	providers := map[string]bool{"vertex": true, "bedrock": true}
+	providers := map[string]bool{"vertex": true, "bedrock": true, "openai": true, "anthropic": true}
 	// Each case is a full manifest that must be rejected for exactly one reason.
 	cases := map[string]string{
 		"unknown field": `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true,"bogus":1}]`,
@@ -305,6 +312,12 @@ func TestLiveLLMManifest_RejectsInvalid(t *testing.T) {
 		// provider is chat-capable but its (provider, auth) pair is not a wired adapter.
 		"vertex with aws auth":  `[{"id":"a","enabled":true,"provider":"vertex","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":true,"require_no_connectors":true}]`,
 		"bedrock with gcp auth": `[{"id":"a","enabled":true,"provider":"bedrock","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		// api-key carries no role to assume: role_var stays aws-oidc-only.
+		"api-key with role_var": `[{"id":"a","enabled":true,"provider":"openai","auth":"api-key","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":true,"require_no_connectors":true}]`,
+		// openai/anthropic are wired for api-key only; a federated auth is a miswire.
+		"openai with gcp auth":    `[{"id":"a","enabled":true,"provider":"openai","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
+		"openai with aws auth":    `[{"id":"a","enabled":true,"provider":"openai","auth":"aws-oidc","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","role_var":"CYNATIVE_CLI_CI_AWS_ROLE","required":true,"require_no_connectors":true}]`,
+		"anthropic with gcp auth": `[{"id":"a","enabled":true,"provider":"anthropic","auth":"gcp-wif","suite":"llm-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
 		// require_no_connectors is a silent no-op on the tools suite, so true is rejected.
 		"tools with require_no_connectors": `[{"id":"a","enabled":true,"provider":"vertex","auth":"gcp-wif","suite":"llm-tools-smoke","model_var":"CYNATIVE_CLI_CI_X","required":true,"require_no_connectors":true}]`,
 	}


### PR DESCRIPTION
Closes #119.

Adds a third auth family, api-key, to the live LLM smoke: direct OpenAI and direct
Anthropic, four manifest rows (no-tool + tools each), all required.

- One new api-smoke job: contents-read only, no id-token, bound to the new
  reviewer-protected llm-api-keys environment holding OPENAI_API_KEY and
  ANTHROPIC_API_KEY. Both secrets are exposed to exactly one step; the shell
  selects the right key by provider with a fail-closed default, preflights it
  non-empty (a rotated key fails loud instead of skipping green), unsets the raw
  names, and execs into the literal suite dispatch, so only CYNATIVE_LLM_API_KEY
  reaches the binary. Same detect gating and same-repo fork boundary as the
  federated jobs.
- The plan job now builds three per-family matrices and its fail-closed row
  arithmetic covers the new family.
- A stable `Live LLM gate` summary job asserts every live leg succeeded on release
  PRs (fail-closed on skipped or cancelled legs) and is intended as a required
  status check, added to the ruleset after this merges; non-release PRs pass it
  trivially.
- A PR-scoped concurrency group cancels stale runs, since environment-gated jobs
  can hold a pending approval for up to 30 days.
- The manifest validator gains the api-key family (openai/anthropic adapter pins,
  role_var forbidden) and a strengthened golden check: starter rows must be
  present, enabled, and wired as expected, and every family must keep an enabled
  row.
- The smoke scripts needed no changes: they were already provider-agnostic via
  CYNATIVE_LLM_PROVIDER/MODEL/API_KEY.

Verified: make check green; all four provider/suite combos run green locally
against the real APIs; workflow_dispatch dry run on this branch with the
environment gate exercised (one approval releases all four legs).