### PR TITLE
ci: retry auto-merge arming past the body-edit recheck race

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -102,9 +102,28 @@ jobs:
           echo "Wrote per-package override to PR #${PR_NUMBER}."
       # Arm auto-merge with the App token so the completed merge is attributed to the App
       # and its push to main triggers the Release Pipeline.
+      # Retried because the body edit above races the merge: the PATCH fires a
+      # pull_request_target "edited" event that re-runs the required "Validate PR title"
+      # check, while gh handles GitHub's refusal to arm auto-merge on an already-clean PR
+      # by falling back to a direct merge. When the re-run check registers between those
+      # two calls, the ruleset rejects the direct merge ("Validate PR title is expected")
+      # and nothing re-triggers this workflow. A later attempt converges either way:
+      # check still pending arms auto-merge, check finished direct-merges clean.
       - name: Enable auto-merge
         if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "${PR_NUMBER}"
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "${PR_NUMBER}"; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "Merge attempt ${attempt} rejected; retrying in 20s."
+              sleep 20
+            fi
+          done
+          echo "Auto-merge still rejected after 3 attempts." >&2
+          exit 1


### PR DESCRIPTION
## Problem

Dependabot PR #145 sat fully green and unmerged: the auto-merge workflow run failed with

```
GraphQL: Repository rule violations found
Required status check "Validate PR title" is expected.
 (mergePullRequest)
```

The workflow races itself. The changelog-override step PATCHes the PR body, which fires a `pull_request_target: edited` event and re-runs the required "Validate PR title" check, flipping it back to "expected" on the same head SHA. One second later, `gh pr merge --auto` asks GitHub to arm auto-merge; GitHub refuses because the PR still looks clean, so gh falls back to a direct merge. When the re-run check registers between those two calls (a window of a few seconds), the ruleset rejects the direct merge. Nothing re-triggers the workflow, so the PR stays open with auto-merge never armed. Failed run: https://github.com/cynative/cynative/actions/runs/29526980507

The race only bites when the body is actually edited, which is the first auto-merge pass of every new Dependabot PR; re-runs take the "already current" path and cannot race.

## Fix

Retry `gh pr merge --auto --squash` up to three times, 20 seconds apart. A later attempt converges either way:

- check still pending: the PR is no longer clean, so arming auto-merge succeeds and the merge happens when the check passes
- check finished: the PR is clean and the direct-merge fallback lands

The PATCH-before-merge order is intentional and unchanged: the body must be final before the squash so release-please sees the override block.

A deterministic alternative (poll the re-triggered check run to completion before merging) needs the PATCH step to signal whether it edited, plus logic to distinguish the new check run from the superseded one; the bounded retry is simpler and also rides out unrelated transient rejections.

## Notes

- `workflow_run` workflows execute the default-branch copy, so this cannot be exercised from the PR; the next Dependabot cycle after merge is the live verification.
- PR #145 itself unblocks by re-running its green CI run after this merges: the override is already current, so no PATCH, no edited event, and the App-token merge proceeds.