### PR TITLE
fix: decode byte[] checksum body in the Windows installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -131,7 +131,12 @@ function Resolve-CynAttestationAction {
 
 function Get-CynString {
     param([Parameter(Mandatory)][string]$Url)
-    (Invoke-WebRequest -UseBasicParsing -Uri $Url -Headers @{ 'User-Agent' = 'cynative-install' }).Content
+    $content = (Invoke-WebRequest -UseBasicParsing -Uri $Url -Headers @{ 'User-Agent' = 'cynative-install' }).Content
+    # Windows PowerShell 5.1 returns .Content as a byte[] when the response Content-Type is not
+    # text. GitHub serves every release asset - checksums.txt included - as
+    # application/octet-stream, so decode a byte[] body here to hand callers a string always.
+    if ($content -is [byte[]]) { return [System.Text.Encoding]::UTF8.GetString($content) }
+    [string]$content
 }
 
 function Save-CynFile {

--- a/test/install.unit.Tests.ps1
+++ b/test/install.unit.Tests.ps1
@@ -48,6 +48,23 @@ Describe 'Resolve-CynBaseUrl' {
     }
 }
 
+Describe 'Get-CynString' {
+    # Windows PowerShell 5.1's Invoke-WebRequest hands back .Content as a byte[] for a
+    # non-text Content-Type. GitHub serves release assets (checksums.txt) as
+    # application/octet-stream, so without decoding the byte[] flows into a [string] param
+    # and fails to bind ("Cannot convert value to type System.String"). This mocks that path.
+    It 'decodes a byte[] body (WinPS 5.1 octet-stream path) to a string' {
+        Mock Invoke-WebRequest {
+            [pscustomobject]@{ Content = [System.Text.Encoding]::UTF8.GetBytes("aaaa1111  a.zip`n") }
+        }
+        Get-CynString -Url 'https://example.com/checksums.txt' | Should -Be "aaaa1111  a.zip`n"
+    }
+    It 'passes a string body through unchanged (PS7 / text Content-Type path)' {
+        Mock Invoke-WebRequest { [pscustomobject]@{ Content = "plain text body" } }
+        Get-CynString -Url 'https://example.com/x' | Should -Be 'plain text body'
+    }
+}
+
 Describe 'Get-CynExpectedHash' {
     # Pester 5 separates discovery from run: fixtures must be set in BeforeAll, not the
     # Describe body, or they are undefined inside It during the run phase.

--- a/test/serve-fixture.py
+++ b/test/serve-fixture.py
@@ -12,6 +12,15 @@ class Quiet(http.server.SimpleHTTPRequestHandler):
     def log_message(self, *args):
         pass
 
+    def guess_type(self, path):
+        # GitHub serves every release asset, checksums.txt included, as
+        # application/octet-stream. Mirror that so the Windows installer e2e exercises
+        # Invoke-WebRequest's WinPS 5.1 byte[] .Content path (the one Get-CynString decodes),
+        # instead of the text/plain SimpleHTTPRequestHandler would infer from the extension.
+        if path.endswith("checksums.txt"):
+            return "application/octet-stream"
+        return super().guess_type(path)
+
 
 handler = functools.partial(Quiet, directory=srv_dir)
 httpd = http.server.HTTPServer(("127.0.0.1", 0), handler)


### PR DESCRIPTION
## What & why

The post-publish Windows install-script smoke (`irm install.ps1 | iex`, Windows PowerShell 5.1) fails with:

```
FAIL: Cannot process argument transformation on parameter 'ChecksumsText'. Cannot convert value to type System.String.
```

**Root cause.** `Get-CynString` returned `Invoke-WebRequest`'s `.Content` unchanged. On Windows PowerShell 5.1 (the floor `install.ps1` targets, and what a stock `irm | iex` uses) that `.Content` is a **`byte[]`** whenever the response `Content-Type` is not text - and GitHub serves every release asset, `checksums.txt` included, as `application/octet-stream` (verified against the live asset). The `byte[]` then flowed into `Get-CynExpectedHash`'s `[string] $ChecksumsText` parameter and failed to bind, aborting the install.

This is a real, long-standing install bug (present since `install.ps1` was introduced), not a regression. It stayed latent because the two conditions only meet against real GitHub assets under WinPS 5.1 - a path no test exercised until the against-real-assets smoke was added. It has failed identically on every release that ran that smoke (v1.5.2, v1.5.3); the smoke is a non-required post-publish check, so the red never blocked a release.

**Fix.** Decode a `byte[]` body to a UTF-8 string in `Get-CynString`, so callers always get a string. A string body passes through unchanged (PowerShell 7 and text-`Content-Type` paths). `Get-CynString` is the single place `.Content` is read, so this is the one choke point.

**Test gap closed.** The unit tests passed literal strings and the loopback e2e fixture served `checksums.txt` as `text/plain`, so neither hit the byte[] path. This adds:
- `Get-CynString` unit tests (byte[]-decode and string-passthrough) that mock `Invoke-WebRequest` - the always-on guard in the required `Lint & Test` gate. RED against the old code, GREEN after.
- `serve-fixture.py` now serves `checksums.txt` as `application/octet-stream`, so the Windows e2e reproduces GitHub's behavior under WinPS 5.1 (harmless to the curl-based POSIX tests).

Note: the documented Windows install pulls the script from `main`, so merging unblocks the default install path immediately; a release is only needed to fix the tag-pinned path.

## Checklist
- [x] `make check-scripts` passes locally (PSScriptAnalyzer clean; new Pester tests run in-gate); pre-commit `make check-go` passed
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed (n/a - no behavior/docs change)