### PR TITLE
test: encode connector e2e live-secret values so multi-line credentials stay one needle

### DIFF
--- a/test/connector-e2e.unit.test.sh
+++ b/test/connector-e2e.unit.test.sh
@@ -141,7 +141,7 @@ if (
 	trap 'rm -rf "$wd" "$ad"' EXIT
 	live_secret="s3cr3t-live-value-abcdef0123"
 	sf=$(mktemp)
-	printf '%s\n' "$live_secret" > "$sf"
+	{ printf '%s' "$live_secret" | base64 | tr -d '\n'; printf '\n'; } > "$sf"  # base64, matching e2e_write_live_secrets
 	# A fake class-2 secret SHAPE (AWS's own documented example access key id; never a
 	# real credential) that has nothing to do with the live-secret file.
 	shape="AKIAIOSFODNN7EXAMPLE"
@@ -188,7 +188,7 @@ if (
 	trap 'rm -rf "$wd" "$ad"' EXIT
 	live_secret="abcdef012345live-xyz"
 	sf=$(mktemp)
-	printf '%s\n' "$live_secret" > "$sf"
+	{ printf '%s' "$live_secret" | base64 | tr -d '\n'; printf '\n'; } > "$sf"  # base64, matching e2e_write_live_secrets
 	# The same secret bytes reversibly hidden behind a non-canonical percent-encoding
 	# (over-encoding the 'c' as %63). quote_plus() leaves this all-safe value unchanged,
 	# so the literal + canonical passes have no form to match; only the decoded backstop
@@ -247,6 +247,43 @@ if (
 	[ -e "$ad/wired/meta.txt" ] || exit 1
 	unset E2E_ARTIFACTS_SUITE E2E_ARTIFACTS_WORKDIR E2E_ARTIFACTS_DIR E2E_ARTIFACTS_SECRET_FILE
 ); then pass "e2e_run_with_retries: collects sanitized artifacts before its fatal exit on a security failure"; else fail "e2e_run_with_retries artifact wiring"; fi
+
+# ---- e2e_write_live_secrets: base64 one line per value, multi-line preserved ----
+# Each value is base64-encoded onto one line, so a multi-line credential (a JSON key
+# blob) stays a single class-1 needle instead of splitting into per-line needles ("{",
+# a project id) that false-positive against any audit legitimately containing them.
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	SINGLE="ghp_singleLineToken1234567890abcdef"
+	MULTI=$(printf '{\n  "project_id": "cynative-cli-ci",\n  "token_url": "https://sts.googleapis.com/v1/token"\n}')
+	export SINGLE MULTI
+	e2e_write_live_secrets "$td/secrets" SINGLE MULTI
+	[ "$(wc -l < "$td/secrets")" -eq 2 ] || exit 1          # one base64 line per value
+	grep -Fq 'cynative-cli-ci' "$td/secrets" && exit 1      # raw fragments never appear
+	grep -Fqx '{' "$td/secrets" && exit 1
+	# each line base64-decodes back to its EXACT value; the multi-line one is preserved whole
+	[ "$(sed -n 1p "$td/secrets" | base64 -d)" = "$SINGLE" ] || exit 1
+	[ "$(sed -n 2p "$td/secrets" | base64 -d)" = "$MULTI" ] || exit 1
+	unset SINGLE MULTI
+); then pass "e2e_write_live_secrets: base64-encodes each value, preserving a multi-line secret as one needle"; else fail "e2e_write_live_secrets base64"; fi
+
+# ---- e2e_write_live_secrets: fail closed when base64 is unavailable -------------
+# POSIX sh has no pipefail, so a missing base64 would let the encode pipeline succeed and
+# write a blank line that drops the secret from the class-1 sweep. The function must
+# refuse (non-zero) instead of silently omitting the secret.
+if (
+	td=$(mktemp -d)
+	trap 'rm -rf "$td"' EXIT
+	X="a-real-secret-value"
+	export X
+	rc=0
+	# Run with base64 off PATH inside its own subshell so the outer cleanup keeps its PATH.
+	# shellcheck disable=SC2123  # intentional: emptying PATH is how we hide base64 here.
+	( PATH=/nonexistent-dir-xyz; e2e_write_live_secrets "$td/out" X >/dev/null 2>&1 ) || rc=$?
+	[ "$rc" -ne 0 ] || exit 1
+	unset X
+); then pass "e2e_write_live_secrets: fails closed when base64 is unavailable"; else fail "e2e_write_live_secrets base64 guard"; fi
 
 if [ "$fails" -ne 0 ]; then
 	printf 'connector-e2e.unit: %d case(s) FAILED\n' "$fails" >&2

--- a/test/connector.aws.e2e.test.sh
+++ b/test/connector.aws.e2e.test.sh
@@ -110,6 +110,7 @@ e2e_require_env connector.aws.e2e "${AWS_E2E_REQUIRE_RUN:-}" \
 e2e_require_cmd go "needed to build cynative" || exit 1
 e2e_require_cmd timeout || exit 1
 e2e_require_cmd python3 "needed to parse the audit log" || exit 1
+e2e_require_cmd base64 "needed to encode the live-secret sweep" || exit 1
 
 workdir=$(mktemp -d)
 # secret_file holds the out-of-band class-1 live secrets for the credential prepass. It

--- a/test/connector.gcp.e2e.test.sh
+++ b/test/connector.gcp.e2e.test.sh
@@ -102,6 +102,7 @@ e2e_require_env connector.gcp.e2e "${GCP_E2E_REQUIRE_RUN:-}" \
 e2e_require_cmd go "needed to build cynative" || exit 1
 e2e_require_cmd timeout || exit 1
 e2e_require_cmd python3 "needed to parse the audit log" || exit 1
+e2e_require_cmd base64 "needed to encode the live-secret sweep" || exit 1
 
 case "${GCP_E2E_CANARY:-1}" in
 	1) run_canary=1 ;;

--- a/test/connector.github.e2e.test.sh
+++ b/test/connector.github.e2e.test.sh
@@ -116,6 +116,7 @@ e2e_require_env connector.github.e2e "${GH_E2E_REQUIRE_RUN:-}" \
 e2e_require_cmd go "needed to build cynative" || exit 1
 e2e_require_cmd timeout || exit 1
 e2e_require_cmd python3 "needed to parse the audit log" || exit 1
+e2e_require_cmd base64 "needed to encode the live-secret sweep" || exit 1
 
 case "${GH_E2E_CANARY:-1}" in
 	1) run_canary=1 ;;

--- a/test/lib/connector-e2e.sh
+++ b/test/lib/connector-e2e.sh
@@ -297,8 +297,13 @@ e2e_collect_artifacts() {
 
 # e2e_write_live_secrets DEST VAR... - build the out-of-band class-1 live-secret file
 # the credential prepass reads via --live-secrets. Writes each SET and NON-EMPTY named
-# env var's value, one per line, to DEST at mode 0600; the values never touch argv or a
-# diagnostic. DEST must be its OWN mktemp path OUTSIDE the retained workdir, and its
+# env var's value, base64-encoded onto ONE line, to DEST at mode 0600; the values never
+# touch argv or a diagnostic. The encoding keeps the WHOLE value as a single exact-value
+# class-1 needle: a multi-line credential (a JSON key blob, a PEM) written raw would be
+# split into per-line needles - "{", "}", URLs, project ids - that false-positive against
+# any audit legitimately containing them, whereas the encoded whole value only matches an
+# actual verbatim leak of the credential. _read_live_secrets base64-decodes each line back
+# to the exact value. DEST must be its OWN mktemp path OUTSIDE the retained workdir, and its
 # removal must be composed into the suite's existing cleanup() (rm -f "$secret_file"),
 # never a competing `trap ... EXIT INT TERM` - which in POSIX sh would REPLACE the
 # suite's signal handlers and break the EXIT-cleanup + INT/TERM-exit-130/143 discipline.
@@ -310,12 +315,20 @@ e2e_collect_artifacts() {
 e2e_write_live_secrets() {
 	_dest=$1
 	shift
+	# Fail closed if base64 is missing. POSIX sh has no pipefail, so a missing base64
+	# would let `printf | base64 | tr` still succeed via tr and write a blank line that
+	# _read_live_secrets drops - silently omitting every class-1 secret. Refuse instead.
+	command -v base64 >/dev/null 2>&1 || {
+		printf 'FAIL: base64 not found - refusing to run without class-1 live-secret detection\n' >&2
+		return 1
+	}
 	: > "$_dest"
 	chmod 600 "$_dest"
 	for _var in "$@"; do
 		eval "_val=\${$_var:-}"
-		if [ -n "$_val" ]; then
-			printf '%s\n' "$_val" >> "$_dest"
-		fi
+		[ -n "$_val" ] || continue
+		# Base64-encode the whole value onto one line (tr collapses base64's own line
+		# wrapping) so a multi-line value stays a single class-1 needle. See the header.
+		{ printf '%s' "$_val" | base64 | tr -d '\n'; printf '\n'; } >> "$_dest"
 	done
 }

--- a/test/lib/connector_audit/engine.py
+++ b/test/lib/connector_audit/engine.py
@@ -18,6 +18,7 @@ three pre-extraction suites) and generalized over the provider spec. Anything th
 cannot express (unknown provider, unknown mode, an incomplete spec, a missing hook, or
 a hook that raises) fails closed to 4 through ``resolve`` and the entrypoint guard.
 """
+import base64
 import glob
 import json
 import os
@@ -563,13 +564,15 @@ _POSITIONAL_RULES = (
 
 
 def _read_live_secrets(path):
-    """The out-of-band live secret values, one per line, blanks dropped. The suites
-    always pass the flag, so a MISSING/UNREADABLE file is a wiring bug and fails closed
-    (4). An EMPTY file is legitimate: ambient-credential runs (AWS profiles/instance
-    roles, GCP ADC, Bedrock/Vertex chains) enumerate no env secret and rely on the
-    class-2/class-3 SHAPE families, so an empty file must not fail. path is None only on
-    the offline replay that passes no flag; class-1 is then skipped, never fatal, so the
-    frozen corpus stays inert."""
+    """The out-of-band live secret values, one BASE64-encoded value per line, blanks
+    dropped. Encoding keeps a multi-line credential (a JSON key blob) as a single exact
+    needle rather than per-line needles that false-positive against an audit. The suites
+    always pass the flag, so a MISSING/UNREADABLE file, or a non-base64 line, is a wiring
+    bug and fails closed (4). An EMPTY file is legitimate: ambient-credential runs (AWS
+    profiles/instance roles, GCP ADC, Bedrock/Vertex chains) enumerate no env secret and
+    rely on the class-2/class-3 SHAPE families, so an empty file must not fail. path is
+    None only on the offline replay that passes no flag; class-1 is then skipped, never
+    fatal, so the frozen corpus stays inert."""
     if path is None:
         return []
     text = None
@@ -579,7 +582,16 @@ def _read_live_secrets(path):
         insecure("credential prepass: cannot read live-secrets file %s: %s - failing closed" % (path, e))
     except UnicodeDecodeError:
         insecure("credential prepass: live-secrets file is not valid UTF-8 - failing closed")
-    return [s for s in (line.strip() for line in text.splitlines()) if s]
+    out = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(base64.b64decode(line, validate=True).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            insecure("credential prepass: live-secrets file has a non-base64 line - failing closed")
+    return out
 
 
 def _cred_expand(value, blobs):
@@ -981,7 +993,17 @@ def _shared_selftest():
         # bytes that pin the percent-encoding path.
         live_secret = "s3cr3t-ambient-value-xyz0"
         enc_secret = "aa/bb+cc=dd-EE"
-        p_secrets = _write(tmp, live_secret + "\n" + enc_secret + "\n")
+
+        def _b64line(s):
+            return base64.b64encode(s.encode("utf-8")).decode("ascii") + "\n"
+
+        # The live-secrets file is base64-encoded, one value per line (see
+        # _read_live_secrets), so a multi-line credential stays a single exact needle.
+        p_secrets = _write(tmp, _b64line(live_secret) + _b64line(enc_secret))
+        # A multi-line credential blob whose non-secret lines ("{", a project id) must
+        # NOT false-positive on their own, while a verbatim leak of the whole blob does.
+        multi_secret = '{\n  "project_id": "cynative-cli-ci",\n  "token_url": "x"\n}'
+        p_secrets_multi = _write(tmp, _b64line(multi_secret))
 
         def cp(lines, secrets=None):
             recs = []
@@ -1052,6 +1074,14 @@ def _shared_selftest():
         # is a wiring bug that fails closed.
         p_empty_secrets = _write(tmp, "")
         p_missing_secrets = os.path.join(tmp, "no-such-secrets.txt")
+        # class-1 multi-line: a verbatim leak of the WHOLE credential blob is caught, but a
+        # benign audit carrying only its non-secret fragments ("{", the project id) must
+        # NOT false-positive - the regression the base64 exact-value encoding closes.
+        multi_leak_line = _jline("c1", "result", read_args,
+                                 result="HTTP/1.1 200 OK\r\n\r\n" + multi_secret, outcome="ok")
+        multi_benign_line = _jline("c1", "result", read_args,
+                                   result='HTTP/1.1 200 OK\r\n\r\n{"projectId":"cynative-cli-ci"}',
+                                   outcome="ok")
 
         cases = [
             ("dupkey", 4, lambda: _guard(lambda: load_records(p_dupkey))),
@@ -1085,6 +1115,8 @@ def _shared_selftest():
             ("cred_redacted_placeholder_ok", 0, lambda: _guard(lambda: cp([redacted_line]))),
             ("cred_witness_fact_ok", 0, lambda: _guard(lambda: cp([witness_line]))),
             ("cred_percent_encoded_secret", 4, lambda: _guard(lambda: cp([enc_line], p_secrets))),
+            ("cred_multiline_blob_leaked", 4, lambda: _guard(lambda: cp([multi_leak_line], p_secrets_multi))),
+            ("cred_multiline_no_false_positive", 0, lambda: _guard(lambda: cp([multi_benign_line], p_secrets_multi))),
             # class-3 new rules: a credential-named YAML/env line leaks its value.
             ("cred_yaml_credential_field", 4, lambda: _guard(lambda: cp([yaml_cred_line]))),
             ("cred_env_credential_field", 4, lambda: _guard(lambda: cp([env_cred_line]))),


### PR DESCRIPTION
## What & why

Fixes a regression in the `#56` credential prepass that failed the live GCP connector e2e (surfaced on the release-please gate for #151):

```
SECURITY: credential prepass: a live secret value appears in the audit - failing closed
```

The gcp suite sweeps `CYNATIVE_LLM_VERTEX_AUTH_CREDENTIALS` as a class-1 live secret. That value is a multi-line service-account/WIF JSON, and `e2e_write_live_secrets` wrote it one line per line, so `_read_live_secrets` treated each line as a separate needle - including trivial ones like `{`, `}`, and lines carrying `cynative-cli-ci`/`googleapis.com` that legitimately appear in a GCP audit. False positive on every live run; invisible offline because `--selftest` runs with an empty live-secret file.

Fix: `e2e_write_live_secrets` **base64-encodes each value onto one line**, and `_read_live_secrets` decodes it back. The whole value stays a single exact-value class-1 needle, so a verbatim leak of the credential still fails closed, but its non-secret lines never match on their own. This keeps the Vertex value's class-1 coverage (rather than dropping it) while removing the false positive.

Verified offline: benign audit fragments (`{`, the project id) -> 0; a verbatim whole-blob leak -> 4. New shared-machinery selftest cases (`cred_multiline_blob_leaked`=4, `cred_multiline_no_false_positive`=0) and a `connector-e2e.unit.test.sh` base64 round-trip case pin it, so this class of bug is now caught without a live run.

Follow-up to #152 (merged as #156).

## Checklist
- [x] `make check` / `make sh-test` + `make shellcheck` pass locally
- [x] Tests added (2 engine cases + a unit case)
- [x] Regression reproduced offline and the fix verified