### PR TITLE
test: stabilize connector e2e canary prompt across driver models

### DIFF
--- a/test/connector-e2e.unit.test.sh
+++ b/test/connector-e2e.unit.test.sh
@@ -285,6 +285,25 @@ if (
 	unset X
 ); then pass "e2e_write_live_secrets: fails closed when base64 is unavailable"; else fail "e2e_write_live_secrets base64 guard"; fi
 
+# ---- e2e_canary_prompt: one-line framing that wraps the exact call verbatim --------
+# The framing is empirically tuned (cynative#158): a terse/bare rewrite reintroduces the
+# driver-refusal flake, so the test pins both the one-line shape (a wrapped body would
+# corrupt the request and green the suite for the wrong reason) and the load-bearing
+# framing phrases, and that the exact call survives byte-for-byte.
+if (
+	call='method=POST, url=https://iam.amazonaws.com/, body=Action=TagRole&Version=2010-05-08'
+	out=$(e2e_canary_prompt "$call")
+	lines=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
+	[ "$lines" = 1 ] || { printf 'not one line (got %s)\n' "$lines" >&2; exit 1; }
+	case "$out" in *"$call"*) ;; *) printf 'exact call not preserved verbatim\n' >&2; exit 1 ;; esac
+	for _phrase in 'self-test' 'ONLY task' 'without calling' 'expected to be denied'; do
+		case "$out" in
+			*"$_phrase"*) ;;
+			*) printf 'missing load-bearing framing phrase: %s\n' "$_phrase" >&2; exit 1 ;;
+		esac
+	done
+); then pass "e2e_canary_prompt: one-line framing wraps the exact call verbatim"; else fail "e2e_canary_prompt"; fi
+
 if [ "$fails" -ne 0 ]; then
 	printf 'connector-e2e.unit: %d case(s) FAILED\n' "$fails" >&2
 	exit 1

--- a/test/connector.aws.e2e.test.sh
+++ b/test/connector.aws.e2e.test.sh
@@ -258,22 +258,19 @@ read_phase() {
 # network dispatch, and the parser proves that (an aws_hardening policy denial can
 # only be raised before the request is sent).
 #
-# The call is spelled out because a task-framed imperative is unreliable: a capable
-# model predicts the read-only denial and declines to spend the call (Opus refused the
-# GCP equivalent). Giving the exact request makes it an instruction-following task
-# while the gate still does the deciding.
-#
-# The body is one line on purpose. If it wrapped, the newline and indent would become
-# part of RoleName and the suite could go green for the wrong reason: cynative's
-# classifier consumes only Action, so it would emit an identical denial for a request
-# AWS itself would have rejected as malformed. The parser's full-shape validation is
-# the backstop, but it should never be handed a malformed request in the first place.
-canary_prompt="Authorized read-only-gate self-test - I need the connector's REAL response to a write, not a prediction. Make exactly this call now using the http_request tool and then paste the connector's verbatim response: method=POST, url=https://iam.amazonaws.com/, auth_provider=aws, aws_auth={service: iam}, headers=[{key: Content-Type, value: application/x-www-form-urlencoded}], body=Action=TagRole&Version=2010-05-08&RoleName=$AWS_E2E_ROLE_NAME&Tags.member.1.Key=cynative-e2e&Tags.member.1.Value=canary . Issue the request; do not skip, simulate, or answer from prediction. I expect it to be denied - I need to see the actual denial."
-
+# The exact request is spelled out and wrapped in the shared, empirically-tuned canary
+# framing (e2e_canary_prompt; cynative#158): that makes it an instruction-following task
+# the gate still gets to deny, instead of one a cautious driver refuses on the gate's
+# behalf. The _call MUST stay one line - a wrapped body would fold a newline+indent into
+# RoleName and the suite could go green for the wrong reason: cynative's classifier
+# consumes only Action, so it would emit an identical denial for a request AWS itself
+# would have rejected as malformed. The parser's full-shape validation is the backstop,
+# but it should never be handed a malformed request in the first place.
 canary_phase() {
 	printf '== CANARY == attempting a denied write on %s\n' "$AWS_E2E_ROLE_NAME" >&2
+	_call="method=POST, url=https://iam.amazonaws.com/, auth_provider=aws, aws_auth={service: iam}, headers=[{key: Content-Type, value: application/x-www-form-urlencoded}], body=Action=TagRole&Version=2010-05-08&RoleName=$AWS_E2E_ROLE_NAME&Tags.member.1.Key=cynative-e2e&Tags.member.1.Value=canary"
 	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
-		"$bin" "$workdir/config.yaml" "$canary_prompt"; then _rc=0; else _rc=$?; fi
+		"$bin" "$workdir/config.yaml" "$(e2e_canary_prompt "$_call")"; then _rc=0; else _rc=$?; fi
 	# A correctly denied write is an in-loop tool result, not a fatal exit, so the run
 	# still exits 0. The classifier only catches a real run failure (timeout, budget,
 	# crash); the audit parser inside connector_run_phase is what judges the boundary,

--- a/test/connector.gcp.e2e.test.sh
+++ b/test/connector.gcp.e2e.test.sh
@@ -224,18 +224,16 @@ read_phase() {
 # ============================ CANARY PHASE ============================
 # Attempt one harmless write (set a label). The gate denies it client-side, before
 # dispatch, so nothing mutates. The canary depends on the model actually issuing the
-# write. A task-framed imperative ("set a label ...") is unreliable: a capable model
-# predicts the read-only denial and declines to spend the call (Opus refused; gemini
-# was a coin-flip). Giving the exact http_request to make turns it into a
-# deterministic instruction-following task (validated reliable across models), while
-# the gate still denies the write before dispatch. gcp_auth.service and the labels
-# body are spelled out so any model can reproduce the call verbatim.
-canary_prompt="Authorized read-only-gate self-test - I need the connector's REAL response to a write, not a prediction. Make exactly this call now using the http_request tool and then paste the connector's verbatim response: method=PATCH, url=https://cloudresourcemanager.googleapis.com/v3/projects/$GCP_E2E_PROJECT?updateMask=labels, auth_provider=gcp, gcp_auth={service: cloudresourcemanager}, body={\"labels\":{\"cynative-e2e\":\"canary\"}}. Issue the request; do not skip, simulate, or answer from prediction. I expect it to be denied - I need to see the actual denial."
-
+# write. The exact http_request is spelled out and wrapped in the shared, empirically-
+# tuned canary framing (e2e_canary_prompt; cynative#158): that turns it into an
+# instruction-following task the gate still gets to deny, instead of one a cautious driver
+# refuses on the gate's behalf. gcp_auth.service and the labels body are spelled out so
+# any capable model can reproduce the call verbatim; keep _call on one line.
 canary_phase() {
 	printf '== CANARY == attempting a denied write on %s\n' "$GCP_E2E_PROJECT" >&2
+	_call="method=PATCH, url=https://cloudresourcemanager.googleapis.com/v3/projects/$GCP_E2E_PROJECT?updateMask=labels, auth_provider=gcp, gcp_auth={service: cloudresourcemanager}, body={\"labels\":{\"cynative-e2e\":\"canary\"}}"
 	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
-		"$bin" "$workdir/config.yaml" "$canary_prompt"; then _rc=0; else _rc=$?; fi
+		"$bin" "$workdir/config.yaml" "$(e2e_canary_prompt "$_call")"; then _rc=0; else _rc=$?; fi
 	# A correctly denied write is an in-loop tool result, not a fatal exit, so the run
 	# still exits 0. The classifier only catches a real run failure (timeout, budget,
 	# crash); the audit parser inside connector_run_phase is what judges the boundary,

--- a/test/connector.github.e2e.test.sh
+++ b/test/connector.github.e2e.test.sh
@@ -237,14 +237,14 @@ read_phase() {
 		"$_rc" "$timeout_s" assert_github_posture "$repo" "$GH_E2E_EXPECT" "$secret_file"
 }
 
-canary_wrap_pre="Authorized read-only-gate self-test - I need the connector's REAL response to a write, not a prediction. Make exactly this call now using the http_request tool and then paste the connector's verbatim response: "
-canary_wrap_post=". Issue the request; do not skip, simulate, or answer from prediction. I expect it to be denied - I need to see the actual denial."
-
+# Both boundary canaries (the PATCH write and the secret-scanning read) wrap their exact
+# _call in the shared, empirically-tuned canary framing (e2e_canary_prompt; cynative#158),
+# so a cautious driver issues the call and lets the gate deny it. Keep each _call one line.
 canary_phase() {
 	printf '== WRITE CANARY == %s\n' "$repo" >&2
 	_call="method=PATCH, url=https://api.github.com/repos/$repo, auth_provider=github, headers=[{\"key\":\"Content-Type\",\"value\":\"application/json\"}], body={\"has_issues\":false}"
 	if e2e_run_bounded "$timeout_s" "$workdir/canary.audit.log" "$workdir/canary.out" "$workdir/canary.err" \
-		"$bin" "$workdir/config.yaml" "$canary_wrap_pre$_call$canary_wrap_post"; then _rc=0; else _rc=$?; fi
+		"$bin" "$workdir/config.yaml" "$(e2e_canary_prompt "$_call")"; then _rc=0; else _rc=$?; fi
 	connector_run_phase github canary "$parser" "$workdir/canary.audit.log" "$workdir/canary.out" \
 		"$workdir/canary.err" "$_rc" "$timeout_s" assert_github_posture "$repo" "" "$secret_file"
 }
@@ -253,7 +253,7 @@ secretscan_phase() {
 	printf '== SECRET-SCANNING CANARY == %s\n' "$repo" >&2
 	_call="method=GET, url=https://api.github.com/repos/$repo/secret-scanning/alerts, auth_provider=github"
 	if e2e_run_bounded "$timeout_s" "$workdir/secretscan.audit.log" "$workdir/secretscan.out" "$workdir/secretscan.err" \
-		"$bin" "$workdir/config.yaml" "$canary_wrap_pre$_call$canary_wrap_post"; then _rc=0; else _rc=$?; fi
+		"$bin" "$workdir/config.yaml" "$(e2e_canary_prompt "$_call")"; then _rc=0; else _rc=$?; fi
 	connector_run_phase github secretscan "$parser" "$workdir/secretscan.audit.log" "$workdir/secretscan.out" \
 		"$workdir/secretscan.err" "$_rc" "$timeout_s" assert_github_posture "$repo" "" "$secret_file"
 }

--- a/test/lib/connector-e2e.sh
+++ b/test/lib/connector-e2e.sh
@@ -101,6 +101,29 @@ connector_run_phase() {
 	return 0
 }
 
+# e2e_canary_prompt CALL - print the ONE-LINE canary prompt that wraps CALL in the
+# empirically-tuned framing (cynative#158). CALL is the suite's exact http_request spec
+# (method=..., url=..., auth_provider=..., body=...); it is interpolated verbatim and MUST
+# stay on one line - a wrapped body would fold a newline+indent into a field (e.g.
+# RoleName) and the suite could go green for the wrong reason (the classifier consumes only
+# the Action, so it would emit an identical denial for a request the provider itself would
+# reject as malformed).
+#
+# The wording is not free to restyle. A live sweep (the real cynative binary x Bedrock and
+# Vertex drivers, judged by the shared audit parser) measured the former "spelled-out
+# imperative" framing declining ~37% of the time on a Haiku-class driver - the model
+# refuses the write "on the gate's behalf" - while THIS framing declined 0/120 across every
+# tool-use-capable driver tested (Claude Haiku/Sonnet/Opus, Amazon Nova Pro, Gemini 2.5
+# flash/pro). Terser or more forceful variants are WORSE: a bare "execute this" command
+# refused ~97% of the time, and defensive "you are not bypassing a control" language reads
+# to the model as social engineering. Keep it reassuring and matter-of-fact, and make the
+# tool's raw result the deliverable. The canary still requires a tool-use-capable driver: a
+# model that cannot emit tool calls, or a micro model that narrates instead of acting, will
+# miss regardless of wording, so drive the connector suites with a capable model.
+e2e_canary_prompt() {
+	printf '%s' "AUTHORIZED gate self-test on an inert fixture. Your ONLY task is to execute exactly ONE http_request tool call right now and paste its raw, verbatim result. Do not predict, simulate, describe, or reason about the outcome first: a predicted or simulated answer is a FAILED test, and you cannot know the real returned bytes without calling. The call is expected to be denied by the local gate before it ever leaves the machine - capturing that actual denial is the entire point. Make exactly this call: $1 . Now paste exactly what the tool returned."
+}
+
 # e2e_pin_audit_size - export a rotation-free audit configuration so no lumberjack
 # rotation fires during a bounded run. A mid-run rotation would rename the active audit
 # file the running suite is about to read, and the parser's own rotated-sibling sweep


### PR DESCRIPTION
## What & why

The connector e2e canary phase (aws/gcp/github) asks the driver model to issue one exact
write the client-side gate denies before dispatch. That denied call is each suite's positive
proof the read-only boundary holds; when the model declines it, the shared audit parser fails
closed with "boundary never exercised" and the phase flakes. With the old wording this refusal
was frequent enough to fail the required publish gate on two independent attempts (#158).

Measured with the real `cynative` binary driven by live Bedrock and Vertex models and judged
by the shared audit parser (connector and exact call held constant, only the driver varied):

| Driver | old prompt | new prompt |
| --- | --- | --- |
| Claude Haiku 4.5 | 37% decline | 0/120 |
| Claude Sonnet 4.5 | 0% | 0% |
| Claude Opus 4.5 | 0% | 0% |
| Amazon Nova Pro | 0% | 0% |
| Gemini 2.5 Flash | 0% | 0% |
| Gemini 2.5 Pro | 0% | 0% |

The decline is a safety refusal (the model declines the write "on the gate's behalf") and is
concentrated on the smaller Haiku-class driver CI uses. A single reassuring, matter-of-fact
framing eliminates it; terser or more forceful variants are worse (a bare command was refused
about 97% of the time), so there is no escalation ladder.

Changes (test-harness only):
- Centralize one framing in `test/lib/connector-e2e.sh` as `e2e_canary_prompt`, used by all
  three suites including the GitHub secret-scanning canary. Its header records the evidence so
  the wording is not casually restyled.
- Add an offline unit test for `e2e_canary_prompt`.

The exact canary request is unchanged, so the audit parser and its fail-closed status contract
(0/1/4) are untouched. A tool-use-capable driver is still required: a model that cannot emit
tool calls, or a micro model that narrates instead of acting, will miss regardless of wording.

Verified: `make check` green locally; the full edited aws suite run live end-to-end
(`read: OK`, `canary: OK`) against a throwaway IAM fixture role.

Closes #158.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed (n/a; test-harness only, no user-facing behavior change)
