### PR TITLE
feat: add shell completions for bash, zsh, fish, and powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,41 @@ Cynative calls your stack using the credentials already in your shell - it keeps
 Cynative prints a short operational footer (timing, token usage) to **stderr** - redirecting stdout (`cynative -p "..." > out.txt`) keeps the captured answer clean. `--version` prints version, commit, build date, Go version, and platform.
 
 <details>
+<summary><strong>Shell completions</strong></summary>
+
+Generate a completion script (no config or credentials required):
+
+```bash
+# current session
+source <(cynative completion bash)   # bash
+source <(cynative completion zsh)    # zsh
+cynative completion fish | source    # fish
+```
+
+Install for every new session (examples):
+
+```bash
+# bash (Linux)
+cynative completion bash > /etc/bash_completion.d/cynative
+# bash (macOS Homebrew)
+cynative completion bash > "$(brew --prefix)/etc/bash_completion.d/cynative"
+
+# zsh (Linux)
+cynative completion zsh > "${fpath[1]}/_cynative"
+# zsh (macOS Homebrew)
+cynative completion zsh > "$(brew --prefix)/share/zsh/site-functions/_cynative"
+
+# fish
+cynative completion fish > ~/.config/fish/completions/cynative.fish
+
+# powershell
+cynative completion powershell | Out-String | Invoke-Expression
+```
+
+See `cynative completion <shell> --help` for the full install notes for each shell.
+</details>
+
+<details>
 <summary><strong>Resource &amp; cost controls for unattended runs</strong></summary>
 
 **Resource & cost controls:** for unattended, scheduled or long-horizon runs - wired into cron, CI or any trigger - bound the work explicitly. The key knobs (config keys / env vars):

--- a/README.md
+++ b/README.md
@@ -187,8 +187,15 @@ Generate a completion script (no config or credentials required):
 ```bash
 # current session
 source <(cynative completion bash)   # bash
-source <(cynative completion zsh)    # zsh
+# zsh needs compinit before the script's compdef calls (skip if already enabled)
+autoload -U compinit && compinit
+source <(cynative completion zsh)
 cynative completion fish | source    # fish
+```
+
+```powershell
+# current session (PowerShell)
+cynative completion powershell | Out-String | Invoke-Expression
 ```
 
 Install for every new session (examples):
@@ -199,16 +206,20 @@ cynative completion bash > /etc/bash_completion.d/cynative
 # bash (macOS Homebrew)
 cynative completion bash > "$(brew --prefix)/etc/bash_completion.d/cynative"
 
-# zsh (Linux)
+# zsh (Linux) — also ensure compinit is enabled in ~/.zshrc if needed:
+#   echo "autoload -U compinit; compinit" >> ~/.zshrc
 cynative completion zsh > "${fpath[1]}/_cynative"
 # zsh (macOS Homebrew)
 cynative completion zsh > "$(brew --prefix)/share/zsh/site-functions/_cynative"
 
 # fish
 cynative completion fish > ~/.config/fish/completions/cynative.fish
+```
 
-# powershell
-cynative completion powershell | Out-String | Invoke-Expression
+```powershell
+# PowerShell — append to your profile so every new session loads completions:
+#   if (!(Test-Path $PROFILE)) { New-Item -Path $PROFILE -Type File -Force }
+Add-Content -Path $PROFILE -Value 'cynative completion powershell | Out-String | Invoke-Expression'
 ```
 
 See `cynative completion <shell> --help` for the full install notes for each shell.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,8 +30,17 @@ Reasons about exploit paths, and drafts remediations.
 
 Run "cynative" with no arguments to start an interactive session, or pass a task
 to seed it. Use -p/--print to run a single task non-interactively and exit
-(pipe input with "cat file | cynative -p \"...\"").`,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+(pipe input with "cat file | cynative -p \"...\"").
+
+Shell completions: "cynative completion bash|zsh|fish|powershell" prints a script
+(no config required; see each subcommand's --help for install instructions).`,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// completion / __complete must work on a fresh install before any
+			// config exists — same short-circuit spirit as --version/--help.
+			if skipsConfigLoad(cmd) {
+				return nil
+			}
+
 			cfg, err := d.loadConfig(cfgFile)
 			if err != nil {
 				return err
@@ -72,6 +81,20 @@ func silenceGracefulStop(cmd *cobra.Command, err error) error {
 	}
 
 	return err
+}
+
+// skipsConfigLoad reports whether cmd is under Cobra's completion tree
+// (`completion` or the hidden `__complete` / `__completeNoDesc` request
+// commands). Those paths must not touch config or credentials.
+func skipsConfigLoad(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "completion", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+			return true
+		}
+	}
+
+	return false
 }
 
 // Execute wires the production dependencies and runs the root command.

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -268,3 +268,117 @@ func TestNewRootCmd_VerboseShorthandWinsOverVersion(t *testing.T) {
 		t.Errorf("--version must carry no shorthand, got -%s", vf.Shorthand)
 	}
 }
+
+func TestSkipsConfigLoad(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "cynative"}                                //nolint:exhaustruct // name only
+	completion := &cobra.Command{Use: "completion"}                        //nolint:exhaustruct // name only
+	bash := &cobra.Command{Use: "bash"}                                    //nolint:exhaustruct // name only
+	complete := &cobra.Command{Use: cobra.ShellCompRequestCmd}             //nolint:exhaustruct // name only
+	completeNoDesc := &cobra.Command{Use: cobra.ShellCompNoDescRequestCmd} //nolint:exhaustruct // name only
+	research := &cobra.Command{Use: "research"}                            //nolint:exhaustruct // unrelated name
+
+	root.AddCommand(completion, complete, completeNoDesc, research)
+	completion.AddCommand(bash)
+
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{"root", root, false},
+		{"unrelated", research, false},
+		{"completion", completion, true},
+		{"completion bash", bash, true},
+		{"__complete", complete, true},
+		{"__completeNoDesc", completeNoDesc, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := skipsConfigLoad(tc.cmd); got != tc.want {
+				t.Errorf("skipsConfigLoad(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewRootCmd_CompletionSkipsConfigLoad(t *testing.T) {
+	t.Parallel()
+
+	shells := []struct {
+		name    string
+		args    []string
+		markers []string
+	}{
+		{"bash", []string{"completion", "bash"}, []string{"bash", "cynative"}},
+		{"zsh", []string{"completion", "zsh"}, []string{"compdef", "cynative"}},
+		{"fish", []string{"completion", "fish"}, []string{"complete", "cynative"}},
+		{"powershell", []string{"completion", "powershell"}, []string{"Register-ArgumentCompleter", "cynative"}},
+	}
+
+	for _, shell := range shells {
+		t.Run(shell.name, func(t *testing.T) {
+			t.Parallel()
+
+			configLoaded := false
+			d := testDeps()
+			d.loadConfig = func(string) (config.Config, error) {
+				configLoaded = true
+
+				return config.Config{}, errors.New(
+					"config must not load for completion",
+				) //nolint:exhaustruct // error path
+			}
+
+			buf, err := runWithArgs(t, d, shell.args)
+			if err != nil {
+				t.Fatalf("completion %s: %v", shell.name, err)
+			}
+			if configLoaded {
+				t.Fatalf("completion %s must not call loadConfig", shell.name)
+			}
+
+			out := buf.String()
+			if out == "" {
+				t.Fatalf("completion %s produced empty script", shell.name)
+			}
+			for _, marker := range shell.markers {
+				if !strings.Contains(out, marker) {
+					t.Errorf("completion %s script missing %q; got %d bytes", shell.name, marker, len(out))
+				}
+			}
+		})
+	}
+}
+
+func TestNewRootCmd_CompletionHelpListsShells(t *testing.T) {
+	t.Parallel()
+
+	configLoaded := false
+	d := testDeps()
+	d.loadConfig = func(string) (config.Config, error) {
+		configLoaded = true
+
+		return config.Config{}, errors.New(
+			"config must not load for completion help",
+		) //nolint:exhaustruct // error path
+	}
+
+	buf, err := runWithArgs(t, d, []string{"completion", "--help"})
+	if err != nil {
+		t.Fatalf("completion --help: %v", err)
+	}
+	if configLoaded {
+		t.Fatal("completion --help must not call loadConfig")
+	}
+
+	out := buf.String()
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		if !strings.Contains(out, shell) {
+			t.Errorf("completion help missing %q; got:\n%s", shell, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Enable Cobra's `cynative completion {bash,zsh,fish,powershell}` so operators get flag/subcommand tab-complete after install.
- Skip config/credential loading on the completion tree (including `__complete`), matching `--version`/`--help` so a fresh install works before `~/.cynative/config.yaml` exists.
- Document session and permanent install one-liners in the README; tests pin non-empty scripts plus the no-config-load invariant for every shell.

Closes #166

## Test plan
- [x] `make check-go` (generate, lint, shell-complexity, format-diff, race tests + 100% core coverage, windows amd64/arm64 cross-build)
- [x] Built binary: `cynative completion bash|zsh|fish|powershell` emits real scripts with expected markers; stderr empty
- [x] `cynative completion --help` lists all four shells without loading config
- [x] Unit tests: `TestSkipsConfigLoad`, `TestNewRootCmd_CompletionSkipsConfigLoad`, `TestNewRootCmd_CompletionHelpListsShells`
- [ ] CI `Lint & Test` / `Validate PR title` / `pkg-tools` / `Live LLM gate` on this PR