### PR TITLE
feat: add cynative doctor for config and connector readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ configuration reference.
 
 `cynative` with no arguments opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`).
 
+`cynative doctor` validates configuration and connector readiness without starting a research session: it prints the same stderr startup inventory (banner, connectors, LLM structural status) and exits `0` when the LLM block is valid (or `1` on config / `ValidateLLM` failure). It does not call the LLM or run tools. Use `-v` to also show normally-hidden skipped connectors.
+
 Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
 
 **Approvals:** each tool call waits for a single keystroke: `y` runs it once, `a` clears every later call to *that tool* for the session (scripts still print before running), any other key denies. With no controlling terminal, use `--auto-approve`.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ configuration reference.
 
 `cynative` with no arguments opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`).
 
-`cynative doctor` validates configuration and connector readiness without starting a research session: it prints the same stderr startup inventory (banner, connectors, LLM structural status) and exits `0` when the LLM block is valid (or `1` on config / `ValidateLLM` failure). It does not call the LLM or run tools. Use `-v` to also show normally-hidden skipped connectors.
+`cynative doctor` validates configuration and connector readiness without starting a research session: it prints the same stderr startup inventory (banner, connectors, LLM structural status). The LLM check is configuration-only (`configuration valid; connectivity not tested`); connector checks may perform live read-only network calls. Exit `0` / `Doctor: ready` only when the LLM block is valid **and** there are no actionable connector failures (structural errors or explicitly configured connectors that failed readiness). Ambient “no credentials” skips shown only under `-v` do not change the result. Exit `1` on config / `ValidateLLM` / actionable connector failure. It does not call the LLM or run tools.
 
 Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,6 @@ configuration reference.
 
 `cynative` with no arguments opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`).
 
-`cynative doctor` validates configuration and connector readiness without starting a research session: it prints the same stderr startup inventory (banner, connectors, LLM structural status). The LLM check is configuration-only (`configuration valid; connectivity not tested`); connector checks may perform live read-only network calls. Exit `0` / `Doctor: ready` only when the LLM block is valid **and** there are no actionable connector failures (structural errors or explicitly configured connectors that failed readiness). Ambient “no credentials” skips shown only under `-v` do not change the result. Exit `1` on config / `ValidateLLM` / actionable connector failure. It does not call the LLM or run tools.
-
 Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
 
 **Approvals:** each tool call waits for a single keystroke: `y` runs it once, `a` clears every later call to *that tool* for the session (scripts still print before running), any other key denies. With no controlling terminal, use `--auto-approve`.
@@ -242,6 +240,8 @@ See `cynative completion <shell> --help` for the full install notes for each she
 
 Finding verification (`verify_findings` tool) makes extra model calls - budget for them on any run that produces findings.
 </details>
+
+`cynative doctor` validates configuration and connector readiness without starting a research session.
 
 ## Connectors
 

--- a/internal/auth/registration.go
+++ b/internal/auth/registration.go
@@ -73,12 +73,16 @@ const identityProbeTimeout = credentialProbeTimeout
 
 // skipOutcome builds a single-status outcome for a skipped connector, computing
 // visibility from the (already-escalated) policy via the same shouldEmit primitive
-// the prior emit path used — preserving ambient-quiet.
+// the prior emit path used — preserving ambient-quiet. Actionable mirrors
+// visibility at verbose=false so health checks ignore ambient absences even when
+// --verbose surfaces them in the inventory.
 func skipOutcome(name string, explicit, verbose bool, policy emitPolicy, reason string) connectorOutcome {
 	return connectorOutcome{
 		providers: nil,
-		statuses:  []ConnectorStatus{{Name: name, Reason: reason}}, //nolint:exhaustruct // skip: Available=false.
-		visible:   []bool{shouldEmit(policy, explicit, verbose)},
+		statuses: []ConnectorStatus{{ //nolint:exhaustruct // skip: Available=false.
+			Name: name, Reason: reason, Actionable: shouldEmit(policy, explicit, false),
+		}},
+		visible: []bool{shouldEmit(policy, explicit, verbose)},
 	}
 }
 

--- a/internal/auth/skip_internal_test.go
+++ b/internal/auth/skip_internal_test.go
@@ -176,3 +176,38 @@ func TestKubeSkipResult(t *testing.T) {
 		}
 	})
 }
+
+func TestSkipOutcome_ActionableIndependentOfVerbose(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		explicit, verbose bool
+		policy            emitPolicy
+		wantActionable    bool
+		wantVisible       bool
+	}{
+		{"structural always loud", false, false, emitAlways, true, true},
+		{"structural verbose", false, true, emitAlways, true, true},
+		{"ambient quiet", false, false, emitWhenExplicitOrVerbose, false, false},
+		{"ambient verbose surfaces but not actionable", false, true, emitWhenExplicitOrVerbose, false, true},
+		{"explicit quiet", true, false, emitWhenExplicitOrVerbose, true, true},
+		{"explicit verbose", true, true, emitWhenExplicitOrVerbose, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := skipOutcome("aws", tc.explicit, tc.verbose, tc.policy, "reason")
+			if len(out.statuses) != 1 || len(out.visible) != 1 {
+				t.Fatalf("statuses/visible len = %d/%d", len(out.statuses), len(out.visible))
+			}
+			if out.statuses[0].Actionable != tc.wantActionable {
+				t.Errorf("Actionable = %v, want %v", out.statuses[0].Actionable, tc.wantActionable)
+			}
+			if out.visible[0] != tc.wantVisible {
+				t.Errorf("visible = %v, want %v", out.visible[0], tc.wantVisible)
+			}
+		})
+	}
+}

--- a/internal/auth/status.go
+++ b/internal/auth/status.go
@@ -14,4 +14,9 @@ type ConnectorStatus struct {
 	// Managed is a managed sub-connector folded onto this line (e.g. "eks");
 	// empty when none. Display-only; does not enter the system-prompt provider list.
 	Managed string
+	// Actionable is set on unavailable connectors that failed for a reason that
+	// should fail health checks (structural error or explicit config). Ambient
+	// "no credentials" skips that are only shown under --verbose are false so
+	// doctor readiness does not change with verbosity.
+	Actionable bool
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cynative/cynative/internal/config"
+	"github.com/cynative/cynative/internal/ui"
 )
 
 // newDoctorCmd returns the `cynative doctor` subcommand. Config is loaded by the
@@ -20,23 +22,61 @@ func newDoctorCmd(d *deps) *cobra.Command {
 		Long: `Validate configuration and connector readiness without starting a research session.
 
 Prints the same stderr startup inventory as a normal run (banner, connectors,
-LLM structural status). Does not call the LLM, open an interactive session, or
-run tools. Exit 0 when the LLM block is valid; exit 1 on config-load or
-ValidateLLM failure.`,
+LLM structural status). Connector checks may perform live read-only network
+calls. The LLM check is configuration-only (connectivity is not tested). Does
+not call the LLM, open an interactive session, or run tools.
+
+Exit 0 when the LLM block is valid and no actionable connector failures are
+present. Exit 1 on config-load failure, ValidateLLM failure, or an actionable
+connector readiness failure (structural errors and explicitly configured
+connectors that failed live checks). Ambient "no credentials" skips shown only
+under --verbose do not change the result.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return silenceGracefulStop(cmd, d.runDoctor(d.cfg, verbose))
 		},
 	}
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
-		"Show skipped connectors that are normally hidden")
+		"Show skipped connectors that are normally hidden (does not change readiness)")
 
 	return cmd
 }
 
+// connectorHealth summarizes inventory outcomes for doctor readiness. Actionable
+// failures are independent of --verbose: ambient absences stay non-actionable
+// even when verbose surfaces them.
+type connectorHealth struct {
+	actionableFailures []string
+}
+
+func connectorHealthFromViews(views []ui.ConnectorView) connectorHealth {
+	var h connectorHealth
+	for _, v := range views {
+		if v.State == ui.ConnectorError && v.Actionable {
+			h.actionableFailures = append(h.actionableFailures, v.Name)
+		}
+	}
+
+	return h
+}
+
+func (h connectorHealth) ok() bool {
+	return len(h.actionableFailures) == 0
+}
+
+// llmDoctorOKStatus is the doctor ✓ line: structural config valid, no live probe.
+func llmDoctorOKStatus(cfg config.Config) ui.LLMStatus {
+	return ui.LLMStatus{ //nolint:exhaustruct // doctor OK: no hint/onboarding fields.
+		State:    ui.ConnectorOK,
+		Provider: cfg.LLM.Provider,
+		Model:    cfg.LLM.Model,
+		Reason:   "configuration valid; connectivity not tested",
+	}
+}
+
 // runDoctor prints banner → connector inventory → LLM structural status and
-// returns ErrLLMUnavailable when ValidateLLM fails. Connector absence is
-// informational and does not fail the command.
+// returns ErrLLMUnavailable or ErrDoctorNotReady when health checks fail.
+// Ambient connector absences (verbose-only) do not fail the command.
 func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
 	d.ui.RenderBanner(d.errOut)
 
@@ -44,14 +84,26 @@ func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
 	if len(views) == 0 {
 		fmt.Fprintln(d.errOut, "  (no connectors detected)")
 	}
+	health := connectorHealthFromViews(views)
 
 	if verr := config.ValidateLLM(&cfg.LLM); verr != nil {
 		d.ui.RenderLLM(d.errOut, llmConfigStatus(cfg, verr))
+		fmt.Fprintln(d.errOut, "Doctor: not ready")
+		fmt.Fprintln(d.errOut, "  Connector checks may perform live read-only network calls.")
 
 		return ErrLLMUnavailable
 	}
 
-	d.ui.RenderLLM(d.errOut, llmOKStatus(cfg))
+	d.ui.RenderLLM(d.errOut, llmDoctorOKStatus(cfg))
+	fmt.Fprintln(d.errOut, "  Connector checks may perform live read-only network calls.")
+
+	if !health.ok() {
+		fmt.Fprintf(d.errOut, "Doctor: not ready (connector failures: %s)\n",
+			strings.Join(health.actionableFailures, ", "))
+
+		return ErrDoctorNotReady
+	}
+
 	fmt.Fprintln(d.errOut, "Doctor: ready")
 
 	return nil

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cynative/cynative/internal/config"
+)
+
+// newDoctorCmd returns the `cynative doctor` subcommand. Config is loaded by the
+// root PersistentPreRunE before RunE; doctor never constructs a chat model or
+// runs tools — it only prints the startup inventory and structural LLM status.
+func newDoctorCmd(d *deps) *cobra.Command {
+	var verbose bool
+
+	cmd := &cobra.Command{ //nolint:exhaustruct // optional cobra fields intentionally omitted
+		Use:   "doctor",
+		Short: "Validate configuration and connector readiness",
+		Long: `Validate configuration and connector readiness without starting a research session.
+
+Prints the same stderr startup inventory as a normal run (banner, connectors,
+LLM structural status). Does not call the LLM, open an interactive session, or
+run tools. Exit 0 when the LLM block is valid; exit 1 on config-load or
+ValidateLLM failure.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return silenceGracefulStop(cmd, d.runDoctor(d.cfg, verbose))
+		},
+	}
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
+		"Show skipped connectors that are normally hidden")
+
+	return cmd
+}
+
+// runDoctor prints banner → connector inventory → LLM structural status and
+// returns ErrLLMUnavailable when ValidateLLM fails. Connector absence is
+// informational and does not fail the command.
+func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
+	d.ui.RenderBanner(d.errOut)
+
+	_, views := d.buildProviders(cfg, verbose)
+	if len(views) == 0 {
+		fmt.Fprintln(d.errOut, "  (no connectors detected)")
+	}
+
+	if verr := config.ValidateLLM(&cfg.LLM); verr != nil {
+		d.ui.RenderLLM(d.errOut, llmConfigStatus(cfg, verr))
+
+		return ErrLLMUnavailable
+	}
+
+	d.ui.RenderLLM(d.errOut, llmOKStatus(cfg))
+	fmt.Fprintln(d.errOut, "Doctor: ready")
+
+	return nil
+}

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cynative/cynative/internal/auth"
 	"github.com/cynative/cynative/internal/config"
 	"github.com/cynative/cynative/internal/schema"
@@ -47,8 +49,15 @@ func TestDoctor_OK(t *testing.T) {
 	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
 		t.Errorf("llmStatuses = %+v, want one OK status", u.llmStatuses)
 	}
-	if !strings.Contains(errBuf.String(), "Doctor: ready") {
-		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
+	if got := u.llmStatuses[0].Reason; got != "configuration valid; connectivity not tested" {
+		t.Errorf("LLM Reason = %q, want connectivity-not-tested wording", got)
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "Doctor: ready") {
+		t.Errorf("stderr missing Doctor: ready; got %q", out)
+	}
+	if !strings.Contains(out, "live read-only network calls") {
+		t.Errorf("stderr missing live-network note; got %q", out)
 	}
 }
 
@@ -110,8 +119,92 @@ func TestDoctor_NoConnectors(t *testing.T) {
 	if !strings.Contains(errBuf.String(), "Doctor: ready") {
 		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
 	}
-	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
-		t.Errorf("llmStatuses = %+v, want OK", u.llmStatuses)
+}
+
+func TestDoctor_ActionableConnectorFailure(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.getProviders = func(_ auth.HardeningConfig, _ bool, onStatus func(auth.ConnectorStatus)) []auth.Provider {
+		onStatus(auth.ConnectorStatus{ //nolint:exhaustruct // actionable skip.
+			Name: "aws", Reason: "aws_hardening: skipped (config load failed): boom", Actionable: true,
+		})
+		onStatus(auth.ConnectorStatus{ //nolint:exhaustruct // healthy connector.
+			Name: "github", Available: true, Identity: "@me",
+		})
+
+		return nil
+	}
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	_, err := runWithArgs(t, d, []string{"doctor"})
+	if !errors.Is(err, ErrDoctorNotReady) {
+		t.Fatalf("err = %v, want ErrDoctorNotReady", err)
+	}
+	if ExitCodeFor(err) != 1 {
+		t.Errorf("ExitCodeFor = %d, want 1", ExitCodeFor(err))
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "Doctor: not ready (connector failures: aws)") {
+		t.Errorf("stderr missing actionable failure summary; got %q", out)
+	}
+	if strings.Contains(out, "Doctor: ready\n") {
+		t.Errorf("must not print Doctor: ready on actionable failure; got %q", out)
+	}
+}
+
+func TestDoctor_AmbientSkipDoesNotFailEvenWhenVerbose(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{{"doctor"}, {"doctor", "-v"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+
+			d := testDeps()
+			d.getProviders = func(_ auth.HardeningConfig, _ bool, onStatus func(auth.ConnectorStatus)) []auth.Provider {
+				// Ambient absence: shown under -v, but Actionable=false so readiness
+				// must stay green either way.
+				onStatus(auth.ConnectorStatus{ //nolint:exhaustruct // ambient skip.
+					Name: "gcp", Reason: "gcp_hardening: skipped (no usable credentials)", Actionable: false,
+				})
+
+				return nil
+			}
+
+			var errBuf bytes.Buffer
+
+			d.errOut = &errBuf
+
+			_, err := runWithArgs(t, d, args)
+			if err != nil {
+				t.Fatalf("%v: %v", args, err)
+			}
+			if !strings.Contains(errBuf.String(), "Doctor: ready") {
+				t.Errorf("%v: want Doctor: ready; got %q", args, errBuf.String())
+			}
+		})
+	}
+}
+
+func TestConnectorHealthFromViews(t *testing.T) {
+	t.Parallel()
+
+	h := connectorHealthFromViews([]ui.ConnectorView{
+		{State: ui.ConnectorOK, Name: "github"},                    //nolint:exhaustruct // ok line
+		{State: ui.ConnectorError, Name: "gcp", Actionable: false}, //nolint:exhaustruct // ambient
+		{State: ui.ConnectorError, Name: "aws", Actionable: true},  //nolint:exhaustruct // fail
+		{State: ui.ConnectorWarn, Name: "gitlab"},                  //nolint:exhaustruct // warn ok
+	})
+	if h.ok() {
+		t.Fatal("health with actionable failure must not be ok")
+	}
+	if got, want := strings.Join(h.actionableFailures, ","), "aws"; got != want {
+		t.Errorf("actionableFailures = %q, want %q", got, want)
 	}
 }
 
@@ -148,7 +241,7 @@ func TestDoctor_Help(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"Validate configuration", "connector", "verbose"} {
+	for _, want := range []string{"Validate configuration", "connector", "verbose", "live read-only"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("doctor help missing %q; got:\n%s", want, out)
 		}
@@ -172,5 +265,18 @@ func TestDoctor_DoesNotCallChatModel(t *testing.T) {
 	}
 	if called {
 		t.Fatal("doctor must not construct a chat model")
+	}
+}
+
+func TestSilenceGracefulStop_DoctorNotReady(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{} //nolint:exhaustruct // SilenceErrors only
+	err := silenceGracefulStop(cmd, ErrDoctorNotReady)
+	if !errors.Is(err, ErrDoctorNotReady) {
+		t.Fatalf("err = %v", err)
+	}
+	if !cmd.SilenceErrors {
+		t.Error("SilenceErrors should be set for ErrDoctorNotReady")
 	}
 }

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cynative/cynative/internal/auth"
+	"github.com/cynative/cynative/internal/config"
+	"github.com/cynative/cynative/internal/schema"
+	"github.com/cynative/cynative/internal/ui"
+)
+
+func TestDoctor_OK(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.getProviders = func(_ auth.HardeningConfig, _ bool, onStatus func(auth.ConnectorStatus)) []auth.Provider {
+		onStatus(auth.ConnectorStatus{ //nolint:exhaustruct // display fields only.
+			Name: "github", Available: true, Identity: "@me", Posture: "default=read",
+		})
+
+		return nil
+	}
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	buf, err := runWithArgs(t, d, []string{"doctor"})
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("doctor must write diagnostics to stderr only; stdout = %q", buf.String())
+	}
+	if u.bannerCalls != 1 {
+		t.Errorf("RenderBanner called %d times, want 1", u.bannerCalls)
+	}
+	if len(u.connectorViews) != 1 || u.connectorViews[0].Name != "github" {
+		t.Errorf("connectorViews = %+v, want one github view", u.connectorViews)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
+		t.Errorf("llmStatuses = %+v, want one OK status", u.llmStatuses)
+	}
+	if !strings.Contains(errBuf.String(), "Doctor: ready") {
+		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
+	}
+}
+
+func TestDoctor_LLMInvalid(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.loadConfig = func(string) (config.Config, error) {
+		return config.Config{}, nil //nolint:exhaustruct // empty LLM triggers ValidateLLM
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if len(u.llmStatuses) != 1 || !u.llmStatuses[0].NotConfigured {
+		t.Errorf("llmStatuses = %+v, want NotConfigured onboarding status", u.llmStatuses)
+	}
+	if ExitCodeFor(err) != 1 {
+		t.Errorf("ExitCodeFor = %d, want 1", ExitCodeFor(err))
+	}
+}
+
+func TestDoctor_ConfigLoadError(t *testing.T) {
+	t.Parallel()
+
+	loadErr := errors.New("no config")
+	d := testDeps()
+	d.loadConfig = func(string) (config.Config, error) {
+		return config.Config{}, loadErr //nolint:exhaustruct // error path
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor"})
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("err = %v, want %v", err, loadErr)
+	}
+}
+
+func TestDoctor_NoConnectors(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	_, err := runWithArgs(t, d, []string{"doctor"})
+	if err != nil {
+		t.Fatalf("doctor with no connectors must succeed when LLM is valid: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "(no connectors detected)") {
+		t.Errorf("stderr missing empty-inventory notice; got %q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Doctor: ready") {
+		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
+		t.Errorf("llmStatuses = %+v, want OK", u.llmStatuses)
+	}
+}
+
+func TestDoctor_VerbosePassedToProviders(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	got := captureHardening(d)
+
+	_, err := runWithArgs(t, d, []string{"doctor", "-v"})
+	if err != nil {
+		t.Fatalf("doctor -v: %v", err)
+	}
+	if !got.verbose {
+		t.Error("doctor -v must pass verbose=true to getProviders")
+	}
+}
+
+func TestDoctor_RejectsExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	_, err := runWithArgs(t, testDeps(), []string{"doctor", "extra"})
+	if err == nil {
+		t.Fatal("doctor with extra args must error")
+	}
+}
+
+func TestDoctor_Help(t *testing.T) {
+	t.Parallel()
+
+	buf, err := runWithArgs(t, testDeps(), []string{"doctor", "--help"})
+	if err != nil {
+		t.Fatalf("doctor --help: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"Validate configuration", "connector", "verbose"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("doctor help missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoctor_DoesNotCallChatModel(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	called := false
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		called = true
+
+		return nil, errors.New("chat model must not be constructed")
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor"})
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if called {
+		t.Fatal("doctor must not construct a chat model")
+	}
+}

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -36,6 +36,10 @@ var (
 	// cause, so the root command silences cobra's duplicate Error line; ExitCodeFor
 	// maps it to 1.
 	ErrLLMUnavailable = errors.New("llm unavailable")
+	// ErrDoctorNotReady is returned by cynative doctor when an actionable connector
+	// readiness failure is present (structural or explicitly configured). The
+	// inventory and Doctor: not ready line already explained the cause.
+	ErrDoctorNotReady = errors.New("doctor: not ready")
 )
 
 // stdinTruncationMarker is appended (outside any <piped_input> fence) when piped
@@ -448,13 +452,15 @@ func modelResponded(acc *metrics.Accumulator, respBefore int) bool {
 func statusToView(s auth.ConnectorStatus) ui.ConnectorView {
 	switch {
 	case !s.Available:
-		return ui.ConnectorView{State: ui.ConnectorError, Name: s.Name, Posture: s.Reason, Identity: "", Managed: ""}
+		return ui.ConnectorView{ //nolint:exhaustruct // error line: Identity empty.
+			State: ui.ConnectorError, Name: s.Name, Posture: s.Reason, Actionable: s.Actionable,
+		}
 	case s.Warn:
-		return ui.ConnectorView{
+		return ui.ConnectorView{ //nolint:exhaustruct // warn: Actionable unused.
 			State: ui.ConnectorWarn, Name: s.Name, Posture: s.Posture, Identity: s.Identity, Managed: s.Managed,
 		}
 	default:
-		return ui.ConnectorView{
+		return ui.ConnectorView{ //nolint:exhaustruct // ok: Actionable unused.
 			State: ui.ConnectorOK, Name: s.Name, Posture: s.Posture, Identity: s.Identity, Managed: s.Managed,
 		}
 	}

--- a/internal/cli/research_cmd_internal_test.go
+++ b/internal/cli/research_cmd_internal_test.go
@@ -205,16 +205,13 @@ func TestRootCmd_HelpShowsPrintFlag(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"--print", "-p", "--auto-approve", "--verbose"} {
+	for _, want := range []string{"--print", "-p", "--auto-approve", "--verbose", "Available Commands", "doctor"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help should mention %q, got:\n%s", want, out)
 		}
 	}
-	// The removed -i flag and the subcommand list must be gone. (The word
-	// "research" still appears in the description, so do not assert on it.)
-	for _, absent := range []string{"--interactive", "Available Commands"} {
-		if strings.Contains(out, absent) {
-			t.Errorf("help should not contain %q, got:\n%s", absent, out)
-		}
+	// The removed -i flag must stay gone.
+	if strings.Contains(out, "--interactive") {
+		t.Errorf("help should not contain --interactive, got:\n%s", out)
 	}
 }

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -275,10 +275,14 @@ func TestStatusToView(t *testing.T) {
 	t.Parallel()
 
 	if v := statusToView(
-		auth.ConnectorStatus{Name: "azure", Reason: "boom"},
-	); v.State != ui.ConnectorError ||
-		v.Posture != "boom" { //nolint:exhaustruct // skip.
+		auth.ConnectorStatus{Name: "azure", Reason: "boom", Actionable: true}, //nolint:exhaustruct // skip.
+	); v.State != ui.ConnectorError || v.Posture != "boom" || !v.Actionable {
 		t.Errorf("error mapping wrong: %+v", v)
+	}
+	if v := statusToView(
+		auth.ConnectorStatus{Name: "gcp", Reason: "no creds", Actionable: false}, //nolint:exhaustruct // ambient.
+	); v.State != ui.ConnectorError || v.Actionable {
+		t.Errorf("ambient error must keep Actionable=false: %+v", v)
 	}
 	if v := statusToView(
 		auth.ConnectorStatus{Name: "github", Available: true, Warn: true, Posture: "default=write", Identity: "@me"},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,10 @@ to seed it. Use -p/--print to run a single task non-interactively and exit
 (pipe input with "cat file | cynative -p \"...\"").
 
 Shell completions: "cynative completion bash|zsh|fish|powershell" prints a script
-(no config required; see each subcommand's --help for install instructions).`,
+(no config required; see each subcommand's --help for install instructions).
+
+Use "cynative doctor" to validate configuration and connector readiness without
+starting a research session.`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// completion / __complete must work on a fresh install before any
 			// config exists — same short-circuit spirit as --version/--help.
@@ -68,6 +71,8 @@ Shell completions: "cynative completion bash|zsh|fish|powershell" prints a scrip
 	// Execute) the -v shorthand is taken and --version gets none (we add no -V).
 	rootCmd.Version = d.version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
+	rootCmd.AddCommand(newDoctorCmd(d))
 
 	return rootCmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -81,7 +81,8 @@ starting a research session.`,
 // operator interrupt — the agent already rendered the stop notice — while still
 // returning the error so ExitCodeFor maps it to 130. Any other error prints as usual.
 func silenceGracefulStop(cmd *cobra.Command, err error) error {
-	if errors.Is(err, agent.ErrInterrupted) || errors.Is(err, ErrLLMUnavailable) {
+	if errors.Is(err, agent.ErrInterrupted) || errors.Is(err, ErrLLMUnavailable) ||
+		errors.Is(err, ErrDoctorNotReady) {
 		cmd.SilenceErrors = true
 	}
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -491,7 +491,8 @@ const (
 )
 
 // ConnectorView is one rendered inventory line. For ConnectorError, Posture holds
-// the skip/error reason and Identity is empty.
+// the skip/error reason and Identity is empty. Actionable mirrors auth's health
+// flag for unavailable connectors (see auth.ConnectorStatus.Actionable).
 type ConnectorView struct {
 	State    ConnectorState
 	Name     string
@@ -500,6 +501,8 @@ type ConnectorView struct {
 	// Managed is a managed sub-connector folded onto this line (e.g. "eks"),
 	// rendered as a "(+eks)" suffix; empty when none.
 	Managed string
+	// Actionable marks an error line that should fail doctor/health checks.
+	Actionable bool
 }
 
 // connectorGlyph maps a state to its leading glyph.


### PR DESCRIPTION
## Summary
- Add `cynative doctor` to validate config and connector readiness without starting a research session.
- Reuses the research startup inventory path (banner → live connector probes → `ValidateLLM`) on stderr; prints `Doctor: ready` on success.
- Does not construct a chat model, call `Generate`, open an interactive session, or run tools/audit.
- Document usage in the README; hermetic tests cover OK / invalid LLM / config-load failure / empty inventory / verbose / no chat-model call.

Closes #168

## Test plan
- [x] `make check-go` (lint, race tests, 100% core coverage, Windows cross-build)
- [x] Unit tests: `TestDoctor_*` + updated root help assertion for `Available Commands` / `doctor`
- [x] Built binary: `cynative doctor --help` documents the command
- [x] Built binary: `cynative doctor` with no LLM config prints onboarding status on stderr, empty stdout, exit `1`
- [ ] CI required checks on this PR