### PR TITLE
ci: harden the Windows install-e2e fixture-server startup wait

### DIFF
--- a/.github/workflows/install-e2e.yaml
+++ b/.github/workflows/install-e2e.yaml
@@ -143,19 +143,38 @@ jobs:
           Copy-Item -Path (Join-Path $repo 'artifact\*') -Destination $srv -Force
           $portfile = Join-Path $env:RUNNER_TEMP 'port'
           if (Test-Path -LiteralPath $portfile) { Remove-Item -LiteralPath $portfile -Force }
+          # Capture the server's output: Start-Process discards it otherwise, leaving a
+          # startup failure with no evidence to debug from.
+          $serverOut = Join-Path $env:RUNNER_TEMP 'serve-fixture.out'
+          $serverErr = Join-Path $env:RUNNER_TEMP 'serve-fixture.err'
           $server = Start-Process python -PassThru `
+            -RedirectStandardOutput $serverOut -RedirectStandardError $serverErr `
             -ArgumentList @((Join-Path $repo 'test\serve-fixture.py'), $srv, $portfile)
 
           $failed = 1
           try {
+            # 30s ceiling: spawning python on a cold Windows runner can outlast the old
+            # 10s window (run 29938300351 flaked exactly this way and passed on rerun,
+            # same image and source). Stop waiting early if the server process dies.
             $port = $null
-            foreach ($i in 1..100) {
+            foreach ($i in 1..300) {
               if ((Test-Path -LiteralPath $portfile) -and ((Get-Item -LiteralPath $portfile).Length -gt 0)) {
                 $port = (Get-Content -Raw -LiteralPath $portfile).Trim(); break
               }
+              if ($server.HasExited) { break }
               Start-Sleep -Milliseconds 100
             }
-            if (-not $port) { throw 'fixture server did not start' }
+            if (-not $port) {
+              if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+              $null = $server.WaitForExit(5000) # release the redirect file handles before reading
+              foreach ($f in @($serverOut, $serverErr)) {
+                if ((Test-Path -LiteralPath $f) -and ((Get-Item -LiteralPath $f).Length -gt 0)) {
+                  Write-Host "--- $(Split-Path -Leaf $f) ---"
+                  Get-Content -LiteralPath $f -ErrorAction SilentlyContinue | Write-Host
+                }
+              }
+              throw 'fixture server did not start'
+            }
 
             # Env for the installer and the Pester test. The base URL is overridden to the
             # loopback fixture, so CYNATIVE_VERSION only names the (unused) URL path; the


### PR DESCRIPTION
## What & why

The Windows install e2e flaked on the release-please PR #172 (run [29938300351](https://github.com/cynative/cynative/actions/runs/29938300351)): the loopback fixture server never wrote its port file within the 10s poll window, the step threw `fixture server did not start`, and there was nothing to debug from because `Start-Process` discards the server's output. The same job had passed on the identical runner image and source four hours earlier, and the failed job passed on rerun, so this was a cold-runner spawn delay rather than a regression.

Three changes to that one step:

- The wait ceiling goes from 10s to 30s; spawning python on a cold Windows runner can outlast 10s.
- The loop stops waiting as soon as the server process dies, instead of burning the rest of the window on a crash.
- The server's stdout/stderr are redirected to files and printed when startup fails, so the next occurrence explains itself instead of leaving a bare timeout.

The Linux suites keep their 10s window: `test/install.e2e.test.sh` backgrounds the server with `&`, so its stderr already lands in the job log, and that spawn path has not flaked.

No green-path behavior change. `make check` passes locally (the diff is workflow-only, so nothing it gates changed); the edited step parses clean under the PowerShell language parser and actionlint.