### PR TITLE
ci: harden the shared release-gate scripts and llm-smoke roster golden

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -556,7 +556,10 @@ jobs:
   # an editable draft: any failure leaves nothing published and nothing
   # immutable. The compound if - !cancelled() plus explicit `== 'success'`
   # result checks (not `!= 'failure'`) - is what makes a skipped or cancelled
-  # gate block the publish rather than wave it through. On a plain push
+  # gate block the publish rather than wave it through.
+  # The explicit non-empty release-SHA term keeps the two gate_sha equality checks
+  # from ever being satisfied degenerately as '' == ''.
+  # On a plain push
   # (release_created != 'true') this skips: nothing is published, and the
   # candidate-pr job below computes the next-release candidate instead. A
   # green `publish` therefore means "published + verified + tap pushed",
@@ -564,7 +567,7 @@ jobs:
   publish:
     name: Publish release
     needs: [release, macos-pkg-smoke, archive-smoke, connector-e2e, llm-smoke]
-    if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.release_created == 'true' && needs.macos-pkg-smoke.result == 'success' && needs.archive-smoke.result == 'success' && needs.connector-e2e.result == 'success' && needs.connector-e2e.outputs.gate_sha == needs.release.outputs.sha && needs.llm-smoke.result == 'success' && needs.llm-smoke.outputs.gate_sha == needs.release.outputs.sha }}
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.release_created == 'true' && needs.release.outputs.sha != '' && needs.macos-pkg-smoke.result == 'success' && needs.archive-smoke.result == 'success' && needs.connector-e2e.result == 'success' && needs.connector-e2e.outputs.gate_sha == needs.release.outputs.sha && needs.llm-smoke.result == 'success' && needs.llm-smoke.outputs.gate_sha == needs.release.outputs.sha }}
     runs-on: ubuntu-latest
     # Budget: the capped steps (artifact download 5, re-assert 5, verify 5)
     # plus every short step with slack, so the job limit can never fire

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,11 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
   `test/archive.smoke.test.ps1` + Pester unit tests +
   `sh-test` (the POSIX `install.sh` unit tests, a `python3`-backed loopback smoke
   test of the `CYNATIVE_BASE_URL` download-base seam and its non-loopback-HTTP reject, the
-  live-e2e guardrails unit tests, the connector-e2e orchestration unit tests, the connector-e2e
-  invocation-contract unit tests, the connector-e2e gate-assert unit tests, the connector-e2e
-  trusted-caller pin check, the shared audit-parser python syntax gate, all three connector
-  suites' offline audit-parser selftests, and the shared-machinery selftest).
+  live-e2e guardrails unit tests, the connector-e2e orchestration unit tests, the shared
+  release-gate invocation-contract and gate-assert unit tests, the llm-smoke workflow golden,
+  the gate trusted-caller pin check, the release publish-gate pin check, the shared
+  audit-parser python syntax gate, all three connector suites' offline audit-parser
+  selftests, and the shared-machinery selftest).
   Install-free: asserts each pinned tool or module is present and fails with an install hint
   otherwise (needs `shellcheck`, PowerShell 7, `python3`). The pinned
   shellcheck/Pester/PSScriptAnalyzer versions live in the `Makefile` and are bumped by hand;
@@ -696,10 +697,14 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   ambient environment; that assertion exists ONLY in the no-tool suite, so
   `SMOKE_REQUIRE_NO_CONNECTORS` is derived from the suite inside the run step rather than
   carried as a matrix key, and `SMOKE_REQUIRE_RUN` is a hardcoded `"1"` with no optional
-  legs. `test/llm-smoke-roster.unit.test.sh` pins the canonical six-leg roster as a
+  legs. `test/llm-smoke-roster.unit.test.sh` pins the workflow's static contract as a
   golden under `make sh-test`, replacing the deleted JSON manifest and its Go validator:
-  it pins each leg's full id/family/suite/provider/model-variable tuple, because ids
-  alone would let a leg silently change suite or provider while staying green.
+  each leg's full id/family/suite/provider/model-variable tuple (ids alone would let a
+  leg silently change suite or provider while staying green), the gate-assert
+  ROSTER/JOBS/PROOFS literals derived from the same canonical rows (a leg dropped from
+  the fan-in is invisible to the runtime checks while the remaining legs stay green),
+  and each smoke step's operational seam (the matrix suite/provider/model bindings and
+  the suite dispatcher that derives the connector-dark tripwire).
 - Releases are automated by **release-please** (`release-please-config.json`,
   `.release-please-manifest.json`); Conventional Commit prefixes in PR titles determine the
   version bump, enforced by `semantic-pr.yaml`. Dependency bumps use the `deps:` type
@@ -769,8 +774,10 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   release rather than waving it through. The fail-closed logic, the invocation contract and the
   roster assertion, lives in `scripts/ci/ci-gate-contract.sh` and `scripts/ci/ci-gate-assert.sh`,
   each with offline unit tests gated by `make sh-test`, so it is exercised on every PR rather
-  than only on a live release run; `make sh-test` also asserts the trusted-caller pin in
-  `connector-e2e.yaml` directly. Both scripts are now shared with the LLM gate: the connector
+  than only on a live release run; `make sh-test` also asserts the trusted-caller pin in both
+  gate workflows directly and pins the publish gate's required conjuncts (the two gate result
+  and gate_sha terms plus the non-empty release SHA) against `release.yaml`. Both scripts are
+  now shared with the LLM gate: the connector
   gate passes `DISPATCH_POLICY: filtered` (a dispatch must carry a selector from an allowlist),
   while the LLM gate passes `full-only` (a dispatch must not carry one). The
   `publish` job re-asserts the

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,29 @@ sh-test:
 			exit 1; \
 		fi; \
 	done
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + connector-e2e trusted-caller pin check)"
+	@# The publish gate's compound if is the sole consumer of the two gate proofs; a
+	@# term dropped there (or a gate_sha comparison edited away) would let a red or
+	@# absent gate publish anyway, and nothing else would notice before a live
+	@# release. Scoped to the publish job's own if: line, never a whole-file grep,
+	@# which a comment or a dead job could satisfy.
+	@publish_if=$$(awk '/^  publish:$$/{injob=1} injob && /^    if: /{print; exit}' .github/workflows/release.yaml); \
+	if [ -z "$$publish_if" ]; then \
+		echo "FAIL: could not locate the publish job's if: line in release.yaml - the publish-gate pin has nothing to check."; \
+		exit 1; \
+	fi; \
+	for term in \
+		"needs.connector-e2e.result == 'success'" \
+		"needs.connector-e2e.outputs.gate_sha == needs.release.outputs.sha" \
+		"needs.llm-smoke.result == 'success'" \
+		"needs.llm-smoke.outputs.gate_sha == needs.release.outputs.sha" \
+		"needs.release.outputs.sha != ''" \
+	; do \
+		case "$$publish_if" in \
+		*"$$term"*) ;; \
+		*) echo "FAIL: the publish gate in release.yaml is missing the required term [$$term]."; exit 1 ;; \
+		esac; \
+	done
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,10 @@ sh-test:
 	@# term dropped there (or a gate_sha comparison edited away) would let a red or
 	@# absent gate publish anyway, and nothing else would notice before a live
 	@# release. Scoped to the publish job's own if: line, never a whole-file grep,
-	@# which a comment or a dead job could satisfy.
-	@publish_if=$$(awk '/^  publish:$$/{injob=1} injob && /^    if: /{print; exit}' .github/workflows/release.yaml); \
+	@# which a comment or a dead job could satisfy. The scan resets at every job
+	@# header, so a publish job missing its if: reports the locate failure below
+	@# instead of latching onto a later job's if: line.
+	@publish_if=$$(awk '/^  [A-Za-z0-9_-]+:$$/{injob=($$0=="  publish:")} injob && /^    if: /{print; exit}' .github/workflows/release.yaml); \
 	if [ -z "$$publish_if" ]; then \
 		echo "FAIL: could not locate the publish job's if: line in release.yaml - the publish-gate pin has nothing to check."; \
 		exit 1; \

--- a/scripts/ci/ci-gate-assert.sh
+++ b/scripts/ci/ci-gate-assert.sh
@@ -43,6 +43,12 @@
 #                job actually depends on.
 set -eu
 
+# set -f for the whole script: globbing is never wanted here. Every word list (JOBS,
+# ROSTER, jobs_from_needs, the accumulated job/family sets) is deliberately expanded
+# unquoted to split on spaces, and -f keeps a glob character in any token literal
+# instead of expanding it against the caller's working directory.
+set -f
+
 : "${ROSTER:?ROSTER is required}"
 : "${JOBS:?JOBS is required}"
 : "${RESULTS:?RESULTS is required}"
@@ -189,16 +195,10 @@ else
 fi
 
 if [ "$needs_parse_ok" -eq 1 ]; then
-	# jobs_from_needs is a deliberately space-separated word list meant to be split on
-	# iteration, so it is intentionally unquoted here; set -f disables globbing for the
-	# duration so a job name containing a glob character expands to nothing but itself,
-	# never to filenames in the working directory.
-	set -f
 	for job in $jobs_from_needs; do
 		contains_word "$all_jobs" "$job" ||
 			fail "job '$job' is a dependency in needs but missing from JOBS, so it would never be gated"
 	done
-	set +f
 	for job in $all_jobs; do
 		contains_word "$jobs_from_needs" "$job" ||
 			fail "job '$job' is in JOBS but nothing in needs depends on it"

--- a/scripts/ci/ci-gate-assert.sh
+++ b/scripts/ci/ci-gate-assert.sh
@@ -114,12 +114,30 @@ for triple in $JOBS; do
 	rest=${triple#*:}
 	family=${rest%%:*}
 	policy=${rest##*:}
+	# Exact-reconstruction arity check: with four or more fields the three extractions
+	# above no longer cover the whole token, and an empty field survives
+	# reconstruction, so both are rejected explicitly rather than trusting the parse.
+	if [ "$job:$family:$policy" != "$triple" ] ||
+		[ -z "$job" ] || [ -z "$family" ] || [ -z "$policy" ]; then
+		fail "JOBS entry '$triple' is not job:family:policy"
+		continue
+	fi
 	case "$policy" in
 	always | release | manual) ;;
 	*) fail "job '$job' has unknown policy '$policy'" ;;
 	esac
 	contains_word "$all_jobs" "$job" && fail "job '$job' is listed twice in JOBS"
 	all_jobs="$all_jobs $job"
+done
+
+# ROSTER entries have the same silent-swallow hazard as JOBS triples: leg takes the
+# first field and family the last, so a middle field or an empty half vanishes.
+for pair in $ROSTER; do
+	leg=${pair%%:*}
+	family=${pair##*:}
+	if [ "$leg:$family" != "$pair" ] || [ -z "$leg" ] || [ -z "$family" ]; then
+		fail "ROSTER entry '$pair' is not leg:family"
+	fi
 done
 
 # active_job_for FAMILY - echo the sole job active in this mode, or return 1.
@@ -219,7 +237,6 @@ done
 for triple in $JOBS; do
 	job=${triple%%:*}
 	rest=${triple#*:}
-	family=${rest%%:*}
 	policy=${rest##*:}
 	[ "$policy" = always ] || [ "$policy" = "$MODE" ] && continue
 	if result=$(lookup "$RESULTS" "$job"); then

--- a/scripts/ci/ci-gate-assert.sh
+++ b/scripts/ci/ci-gate-assert.sh
@@ -206,9 +206,11 @@ if [ "$needs_parse_ok" -eq 1 ]; then
 fi
 
 # ---- family coupling ------------------------------------------------------
-# Every family named in JOBS must be gated by at least one ROSTER leg, and every family
-# a ROSTER leg names must have a job in JOBS. Together with the JOBS/needs comparison
-# above, this leaves no job that is real but ungated.
+# The load-bearing direction is JOBS -> ROSTER: a family with jobs but no ROSTER leg
+# is never examined by the per-leg loop, so together with the JOBS/needs comparison
+# above this is what leaves no job that is real but ungated. The reverse direction (a
+# ROSTER family with no job in JOBS) would also surface later, per leg, via
+# active_job_for; checking it here just fails earlier with a clearer message.
 roster_families=
 for pair in $ROSTER; do
 	family=${pair##*:}
@@ -247,12 +249,18 @@ for triple in $JOBS; do
 	fi
 done
 
+selector_matched=0
 for pair in $ROSTER; do
 	leg=${pair%%:*}
 	family=${pair##*:}
 
 	if [ -z "$SELECTOR" ] || [ "$SELECTOR" = "$leg" ]; then
 		selected=1
+		# Exact-equality match only: an empty SELECTOR selects every leg without
+		# "matching" any, and must not satisfy the roster-membership check below.
+		if [ "$SELECTOR" = "$leg" ]; then
+			selector_matched=1
+		fi
 	else
 		selected=0
 	fi
@@ -303,6 +311,14 @@ for pair in $ROSTER; do
 			fail "leg $leg was excluded by the filter but produced a proof, so the filter leaked"
 	fi
 done
+
+# A non-empty selector passed the contract's allowlist, but the allowlist and the
+# roster are maintained separately: a selector no leg carries would leave every leg
+# "excluded", every job legitimately skipped, and the gate green having tested
+# nothing.
+if [ -n "$SELECTOR" ] && [ "$selector_matched" -eq 0 ]; then
+	fail "selector '$SELECTOR' matches no roster leg, so nothing was gated"
+fi
 
 [ "$fails" = 0 ] || exit 1
 

--- a/scripts/ci/ci-gate-contract.sh
+++ b/scripts/ci/ci-gate-contract.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # ci-gate-contract.sh - validate how a release-gate workflow was invoked and emit the
 # resolved contract. Shared by every gate built on this contract (today: the connector
-# e2e gate); each gate picks a DISPATCH_POLICY that fits its own selector shape.
+# e2e gate and the live LLM gate); each gate picks a DISPATCH_POLICY that fits its own
+# selector shape.
 #
 # A called reusable workflow sees the CALLER's github context, so github.event_name is
 # "push" on the release path and cannot identify it. The discriminator is structural:
@@ -26,6 +27,10 @@
 #   selector=<leg, or empty meaning every leg>
 #   checkout_sha=<40 hex>
 set -eu
+# set -f for the whole script: nothing here wants globbing, and the allowlist loop
+# below deliberately word-splits $SELECTORS unquoted, so -f keeps a glob character in
+# a selector token literal instead of expanding it against the working directory.
+set -f
 
 die() {
 	printf '::error::gate contract: %s\n' "$*" >&2
@@ -77,7 +82,7 @@ if [ "$CALLER_WORKFLOW_REF" != "$JOB_WORKFLOW_REF" ]; then
 	[ "$CALLER_WORKFLOW_REF" = "$EXPECTED_CALLER" ] ||
 		die "unexpected reusable-workflow caller $CALLER_WORKFLOW_REF"
 	[ -z "$SELECTOR" ] ||
-		die "a workflow_call must not carry a connector selector"
+		die "a workflow_call must not carry a selector"
 	is_sha "$CALL_REF" ||
 		die "call ref is not a 40-hex SHA"
 	mode=release

--- a/test/ci-gate-assert.unit.test.sh
+++ b/test/ci-gate-assert.unit.test.sh
@@ -130,6 +130,17 @@ github-app=skipped' 'gcp-wif.gcp=
 aws-oidc.aws=
 github-app.github='
 
+# A selector that names no roster leg must fail closed. Every leg is "excluded",
+# every job legitimately skipped, and today the script exits 0 while claiming the
+# selected leg ran; allowlist/roster drift on a filtered dispatch would go green
+# while testing nothing.
+case_ 1 "a selector naming no roster leg fails closed" ghost 'gcp-wif=skipped
+aws-oidc=skipped
+github-app=skipped' 'gcp-wif.gcp=
+aws-oidc.aws=
+github-app.github=' "$ROSTER" "$NEEDS_JSON_DEFAULT" "$JOBS" manual \
+	"matches no roster leg"
+
 # ---- duplicate-key and metacharacter safety --------------------------------
 # A script whose whole purpose is fail-closed must not agree with a result it only
 # partly read. A duplicate key must be a hard failure, not a silent first-match. Both

--- a/test/ci-gate-assert.unit.test.sh
+++ b/test/ci-gate-assert.unit.test.sh
@@ -193,6 +193,31 @@ case_ 0 "a metacharacter-bearing key reaches lookup and matches only its literal
 gcp*wif=success' 'gcp*wif.meta=success' \
 	"$META_ROSTER" "$(needs_json "$META_JOBS")" "$META_JOBS"
 
+# ---- set -f: the word-split loops must never glob ---------------------------
+# JOBS carries the glob token g*:gcp-wif:always and the cwd contains a file whose
+# name that pattern matches. Under set -f the token stays literal: gcp-wif is then a
+# needs dependency missing from JOBS, so the run fails. Without set -f the token
+# expands against the cwd into the VALID triple and the whole run passes, so this
+# case flips outcome on set -f itself; the metacharacter case above only pins
+# lookup() quoting.
+globdir=$(mktemp -d)
+: >"$globdir/gcp-wif:gcp-wif:always"
+abs_script=$PWD/$script
+_got=0
+( cd "$globdir" && SELECTOR="" ROSTER="$ROSTER" RESULTS="$ALL_OK" PROOFS="$ALL_PROOF" \
+	NEEDS_JSON="$NEEDS_JSON_DEFAULT" \
+	JOBS='g*:gcp-wif:always aws-oidc:aws-oidc:always github-app:github-app:always' \
+	MODE=release sh "$abs_script" >/tmp/ga_out 2>/tmp/ga_err ) || _got=$?
+if [ "$_got" = 1 ] && grep -F -q -- "missing from JOBS" /tmp/ga_err; then
+	printf 'ok   %s\n' "a glob-bearing JOBS token stays literal instead of matching cwd files"
+else
+	printf 'FAIL %s (want exit 1 + missing-from-JOBS, got exit %s)\n' \
+		"a glob-bearing JOBS token stays literal instead of matching cwd files" "$_got"
+	sed 's/^/       /' /tmp/ga_err
+	fails=1
+fi
+rm -rf "$globdir"
+
 # ---- roster vs job-graph cross-check ---------------------------------------
 # needs is the actual dependency graph (toJSON(needs)); JOBS is a hand-maintained
 # parallel list. Nothing else binds them, so a job added to one and forgotten in the

--- a/test/ci-gate-assert.unit.test.sh
+++ b/test/ci-gate-assert.unit.test.sh
@@ -154,6 +154,29 @@ case_ 1 "a job listed under two families in JOBS fails" "" "$ALL_OK" "$ALL_PROOF
 	'gcp-wif:gcp-wif:always gcp-wif:aws-oidc:always github-app:github-app:always' \
 	release "is listed twice in JOBS"
 
+# ---- entry arity: a malformed token must never silently drop a field --------
+# Four fields parse as job=gcp-wif, family=gcp-wif, policy=always today, silently
+# swallowing "bogus"; without the guard this case is all green.
+case_ 1 "a JOBS entry with a stowaway fourth field fails" "" "$ALL_OK" "$ALL_PROOF" \
+	"$ROSTER" "$NEEDS_JSON_DEFAULT" \
+	'gcp-wif:gcp-wif:bogus:always aws-oidc:aws-oidc:always github-app:github-app:always' \
+	release "is not job:family:policy"
+
+# An empty field survives the exact-reconstruction check, so it needs its own guard.
+case_ 1 "a JOBS entry with an empty family fails" "" "$ALL_OK" "$ALL_PROOF" \
+	"$ROSTER" "$NEEDS_JSON_DEFAULT" \
+	'gcp-wif::always aws-oidc:aws-oidc:always github-app:github-app:always' \
+	release "is not job:family:policy"
+
+# leg takes the first field and family the last, so a middle field vanishes today.
+case_ 1 "a ROSTER entry with a stowaway middle field fails" "" "$ALL_OK" "$ALL_PROOF" \
+	'gcp:bogus:gcp-wif aws:aws-oidc github:github-app' "$NEEDS_JSON_DEFAULT" "$JOBS" \
+	release "is not leg:family"
+
+case_ 1 "a ROSTER entry with an empty family fails" "" "$ALL_OK" "$ALL_PROOF" \
+	'gcp: aws:aws-oidc github:github-app' "$NEEDS_JSON_DEFAULT" "$JOBS" \
+	release "is not leg:family"
+
 # A job name containing a shell glob character must match only its own literal line in
 # lookup(), never wildcard onto an unrelated one. JOBS/ROSTER/needs all declare the same
 # metacharacter-bearing family so the job reaches lookup() at all (a mismatched shape

--- a/test/ci-gate-assert.unit.test.sh
+++ b/test/ci-gate-assert.unit.test.sh
@@ -26,7 +26,7 @@ needs_json() {
 }
 NEEDS_JSON_DEFAULT=$(needs_json "$JOBS")
 
-# case_ WANT DESC SELECTOR RESULTS PROOFS [ROSTER] [NEEDS_JSON] [JOBS] [MODE]
+# case_ WANT DESC SELECTOR RESULTS PROOFS [ROSTER] [NEEDS_JSON] [JOBS] [MODE] [STDERR_SUBSTR]
 case_() {
 	_want=$1
 	_desc=$2
@@ -37,6 +37,11 @@ case_() {
 	# a release-mode one and make it pass for the wrong reason.
 	_mode=${9-release}
 	_needs=${7-$NEEDS_JSON_DEFAULT}
+	# Optional literal stderr substring. Some guards share their exit code with later,
+	# unrelated failures (removing the guard still exits 1 via a different message), so
+	# the exit status alone cannot pin them; the diagnostic is the distinguishing
+	# signal.
+	_stderr=${10-}
 	# Capture the REAL exit status, never a collapsed 0/1: the retained empty-NEEDS_JSON
 	# case asserts exit 2, and flattening every nonzero to 1 would turn it into a false
 	# pass. `|| _got=$?` rather than a bare if/else so the distinction survives.
@@ -44,12 +49,16 @@ case_() {
 	( SELECTOR="$3" ROSTER="$_roster" RESULTS="$4" PROOFS="$5" \
 		NEEDS_JSON="$_needs" JOBS="$_jobs" MODE="$_mode" \
 		sh "$script" >/tmp/ga_out 2>/tmp/ga_err ) || _got=$?
-	if [ "$_got" = "$_want" ]; then
-		printf 'ok   %s\n' "$_desc"
-	else
+	if [ "$_got" != "$_want" ]; then
 		printf 'FAIL %s (want exit %s, got %s)\n' "$_desc" "$_want" "$_got"
 		sed 's/^/       /' /tmp/ga_err
 		fails=1
+	elif [ -n "$_stderr" ] && ! grep -F -q -- "$_stderr" /tmp/ga_err; then
+		printf 'FAIL %s (stderr does not contain "%s")\n' "$_desc" "$_stderr"
+		sed 's/^/       /' /tmp/ga_err
+		fails=1
+	else
+		printf 'ok   %s\n' "$_desc"
 	fi
 }
 
@@ -137,6 +146,14 @@ gcp-wif.gcp=success
 aws-oidc.aws=success
 github-app.github=success'
 
+# The same physical job listed under two different families must be rejected by the
+# duplicate-JOBS guard itself. The families differ, so a guard loosened to dedupe on
+# the (job, family) pair rather than the job name alone would wave this through.
+case_ 1 "a job listed under two families in JOBS fails" "" "$ALL_OK" "$ALL_PROOF" \
+	"$ROSTER" "$NEEDS_JSON_DEFAULT" \
+	'gcp-wif:gcp-wif:always gcp-wif:aws-oidc:always github-app:github-app:always' \
+	release "is listed twice in JOBS"
+
 # A job name containing a shell glob character must match only its own literal line in
 # lookup(), never wildcard onto an unrelated one. JOBS/ROSTER/needs all declare the same
 # metacharacter-bearing family so the job reaches lookup() at all (a mismatched shape
@@ -197,6 +214,23 @@ aws.awsx=success' \
 case_ 1 "malformed NEEDS_JSON fails" "" "$ALL_OK" "$ALL_PROOF" "$ROSTER" 'not json'
 
 case_ 1 "a NEEDS_JSON that is valid JSON but not an object fails" "" "$ALL_OK" "$ALL_PROOF" "$ROSTER" '["prepare"]'
+
+# A NEEDS_JSON that is a JSON ARRAY of exactly the job names is the case only the type
+# guard can catch: iterating a list yields the same job set as iterating a dict's
+# keys, so with the isinstance check removed the downstream JOBS/needs cross-check
+# would pass and the whole run would go green. (The not-an-object case above still
+# documents the general shape, but its exit 1 also arises downstream, so it cannot
+# pin the guard by itself.)
+case_ 1 "a NEEDS_JSON array of the job names fails on the type guard" "" "$ALL_OK" "$ALL_PROOF" \
+	"$ROSTER" '["aws-oidc","gcp-wif","github-app"]' "$JOBS" release \
+	"NEEDS_JSON is missing, empty, or not a JSON object"
+
+# An empty JSON object means toJSON(needs) saw no dependencies at all. Removing the
+# `or not needs` half still exits 1 via the downstream cross-check, so the case pins
+# the guard's own diagnostic, not just the exit code.
+case_ 1 "an empty NEEDS_JSON object fails on the type guard" "" "$ALL_OK" "$ALL_PROOF" \
+	"$ROSTER" '{}' "$JOBS" release \
+	"NEEDS_JSON is missing, empty, or not a JSON object"
 
 # NEEDS_JSON is a required env var (a fatal shell parameter-expansion error, exit 2),
 # so an empty value fails closed before the cross-check even runs.
@@ -289,6 +323,16 @@ aws-oidc=success
 api-key-release=success
 api-key-manual=failure' \
 	"$LLM_PROOFS" "$LLM_ROSTER" "$LLM_NEEDS" "$LLM_JOBS" 'release'
+
+# An inactive job that vanishes from RESULTS entirely (not merely non-skipped) must be
+# caught by the inactive-job loop's own missing-key branch: every other check in this
+# fixture is green, so nothing else reports it.
+case_ 1 'an inactive job missing from RESULTS fails' '' \
+	'gcp-wif=success
+aws-oidc=success
+api-key-release=success' \
+	"$LLM_PROOFS" "$LLM_ROSTER" "$LLM_NEEDS" "$LLM_JOBS" 'release' \
+	'job api-key-manual is missing from the results'
 
 # NOTE the PROOFS argument is present. Omitting it shifts every later argument by one,
 # which silently supplies a different JOBS/MODE than the case name claims.

--- a/test/ci-gate-contract.unit.test.sh
+++ b/test/ci-gate-contract.unit.test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Unit tests for scripts/ci/ci-gate-contract.sh, the invocation contract shared by the
-# consolidated connector e2e gate and any other gate built on the same contract. Offline
-# and hermetic.
+# consolidated connector e2e gate and the live LLM gate. Offline and hermetic.
 #
 # The contract is what stops a caller weakening the release gate: every workflow_call is
 # the full gate, so a call that tries to narrow the roster must be rejected outright.
@@ -74,6 +73,34 @@ run_dispatch() {
 		export REPOSITORY EXPECTED_REPOSITORY EVENT CALLER_WORKFLOW_REF \
 			JOB_WORKFLOW_REF EXPECTED_CALLER SELECTORS DISPATCH_POLICY TRIGGER_SHA \
 			CALL_REF SELECTOR
+		sh "$script"
+	)
+}
+
+# run_dispatch_unset_policy - the dispatch shape with DISPATCH_POLICY truly UNSET (not
+# merely empty). The wrappers above default it via ${DISPATCH_POLICY-filtered}, so no
+# wrapper-driven case can ever exercise unset; this composes the env by hand and
+# unsets the variable immediately before the script runs. The script's own
+# ${DISPATCH_POLICY:-} resolves unset to empty, which the policy case rejects like
+# any other unknown value.
+run_dispatch_unset_policy() {
+	(
+		REPOSITORY=cynative/cynative
+		EXPECTED_REPOSITORY=cynative/cynative
+		EVENT=workflow_dispatch
+		CALLER_WORKFLOW_REF=$SELF
+		JOB_WORKFLOW_REF=$SELF
+		EXPECTED_CALLER=$CALLER
+		# shellcheck disable=SC2030  # intentional, see run_release above: this
+		# subshell-local assignment composes the isolated env for this one
+		# invocation and is never meant to propagate back to the caller.
+		SELECTORS='gcp aws github'
+		TRIGGER_SHA=$SHA
+		CALL_REF=
+		SELECTOR=gcp
+		export REPOSITORY EXPECTED_REPOSITORY EVENT CALLER_WORKFLOW_REF \
+			JOB_WORKFLOW_REF EXPECTED_CALLER SELECTORS TRIGGER_SHA CALL_REF SELECTOR
+		unset DISPATCH_POLICY
 		sh "$script"
 	)
 }
@@ -202,6 +229,8 @@ expect_status 1 'unknown DISPATCH_POLICY is rejected' run_dispatch gcp
 
 DISPATCH_POLICY=''
 expect_status 1 'empty DISPATCH_POLICY is rejected' run_dispatch gcp
+
+expect_status 1 'an unset DISPATCH_POLICY is rejected' run_dispatch_unset_policy
 
 # A workflow_call may never carry a selector under EITHER policy.
 DISPATCH_POLICY=filtered

--- a/test/llm-smoke-roster.unit.test.sh
+++ b/test/llm-smoke-roster.unit.test.sh
@@ -45,7 +45,7 @@ EOF
 # It also asserts each row's OPERATIONAL model expression equals `${{ vars.<model_var> }}`
 # for that row's own model_var. Pinning model_var alone would leave the diagnostic label
 # canonical while the consumed expression pointed elsewhere.
-python3 - "$workflow" >"$tmp/actual" <<'PY'
+python3 - "$workflow" "$tmp/expected" >"$tmp/actual" <<'PY'
 import re
 import sys
 
@@ -116,6 +116,118 @@ while i < len(lines):
                     i += 1
         continue
     i += 1
+
+# ---- gate-assert fan-in literals -------------------------------------------
+# The canonical rows (argv[2]) are the anchor; the gate-assert env's ROSTER, JOBS,
+# and PROOFS are DERIVED from them plus this job->policy map and compared as sorted
+# multisets. The map is part of the anchor: policies are not derivable from the
+# matrix. A leg dropped from the fan-in is invisible to the runtime checks (the
+# remaining legs still pass), which is exactly why these literals need a golden.
+policy_map = {
+    "gcp-wif": "always",
+    "aws-oidc": "always",
+    "api-key-release": "release",
+    "api-key-manual": "manual",
+}
+
+canonical = []
+for raw in open(sys.argv[2]).read().splitlines():
+    if raw.strip():
+        canonical.append(raw.split("|"))
+for parts in canonical:
+    if len(parts) != 6:
+        problems.append(
+            "canonical row %r is not job|leg|family|suite|provider|model_var" % "|".join(parts)
+        )
+
+# Derivation self-guards: a stale policy map or an ambiguous family mapping must fail
+# the golden itself, not silently derive a wrong expectation.
+canonical_jobs = sorted({parts[0] for parts in canonical})
+if sorted(policy_map) != canonical_jobs:
+    problems.append(
+        "policy map keys %s do not equal the canonical job set %s"
+        % (sorted(policy_map), canonical_jobs)
+    )
+for what, idx in (("job", 0), ("leg", 1)):
+    fams = {}
+    for parts in canonical:
+        fams.setdefault(parts[idx], set()).add(parts[2])
+    for name, seen in sorted(fams.items()):
+        if len(seen) != 1:
+            problems.append("%s %s maps to multiple families %s" % (what, name, sorted(seen)))
+
+want_roster = sorted({parts[1] + ":" + parts[2] for parts in canonical})
+want_jobs = sorted(
+    {parts[0] + ":" + parts[2] + ":" + policy_map.get(parts[0], "<unmapped>") for parts in canonical}
+)
+want_proofs = sorted(
+    parts[0] + "." + parts[1] + "=${{ needs." + parts[0]
+    + ".outputs.proof_" + parts[1].replace("-", "_") + " }}"
+    for parts in canonical
+)
+
+def job_slice(name):
+    start = None
+    for i, line in enumerate(lines):
+        if line == "  %s:" % name:
+            start = i + 1
+            break
+    if start is None:
+        problems.append("job %s not found in the workflow" % name)
+        return []
+    end = len(lines)
+    for i in range(start, len(lines)):
+        if re.match(r"^  [A-Za-z0-9_-]+:\s*$", lines[i]) or re.match(r"^\S", lines[i]):
+            end = i
+            break
+    return lines[start:end]
+
+def scalars(chunk, key):
+    out = []
+    for line in chunk:
+        m = re.match(r"^\s*%s:\s*(.+?)\s*$" % re.escape(key), line)
+        if m:
+            out.append(m.group(1))
+    return out
+
+def block(chunk, key):
+    out = []
+    starts = [i for i, l in enumerate(chunk) if re.match(r"^\s*%s:\s*\|\s*$" % re.escape(key), l)]
+    if len(starts) != 1:
+        problems.append("expected exactly one %s block in gate-assert, found %d" % (key, len(starts)))
+        return out
+    indent = len(chunk[starts[0]]) - len(chunk[starts[0]].lstrip())
+    for l in chunk[starts[0] + 1:]:
+        if l.strip() and (len(l) - len(l.lstrip())) <= indent:
+            break
+        if l.strip():
+            out.append(l.strip())
+    return out
+
+ga = job_slice("gate-assert")
+got_roster = scalars(ga, "ROSTER")
+got_jobs = scalars(ga, "JOBS")
+if len(got_roster) != 1:
+    problems.append("expected exactly one ROSTER scalar in gate-assert, found %d" % len(got_roster))
+if len(got_jobs) != 1:
+    problems.append("expected exactly one JOBS scalar in gate-assert, found %d" % len(got_jobs))
+got_proofs = block(ga, "PROOFS")
+
+if got_roster and sorted(got_roster[0].split()) != want_roster:
+    problems.append(
+        "gate-assert ROSTER %s does not match the derived %s"
+        % (sorted(got_roster[0].split()), want_roster)
+    )
+if got_jobs and sorted(got_jobs[0].split()) != want_jobs:
+    problems.append(
+        "gate-assert JOBS %s does not match the derived %s"
+        % (sorted(got_jobs[0].split()), want_jobs)
+    )
+if sorted(got_proofs) != want_proofs:
+    problems.append(
+        "gate-assert PROOFS do not match the derived lines:\n    got  %s\n    want %s"
+        % (sorted(got_proofs), want_proofs)
+    )
 
 if declared != len(rows) or problems:
     for p in problems:

--- a/test/llm-smoke-roster.unit.test.sh
+++ b/test/llm-smoke-roster.unit.test.sh
@@ -1,22 +1,27 @@
 #!/bin/sh
-# Unit tests for the live LLM gate's leg roster. Offline and hermetic.
+# Unit tests for the live LLM gate's static contract in llm-smoke.yaml. Offline and
+# hermetic. Three layers, all anchored to the one canonical roster below:
 #
-# This replaces internal/llm/livellm_manifest_test.go, which validated the deleted JSON
-# manifest under `Lint & Test`. A static matrix has no schema, so without this the first
-# time a bad roster is noticed is a release run.
+#   1. The matrix rows: each physical row's full job/leg/family/suite/provider/
+#      model-variable tuple, plus release/manual parity for the api-key jobs.
+#   2. The gate-assert fan-in: the ROSTER/JOBS/PROOFS literals are derived from the
+#      canonical rows plus the job->policy map and compared as sorted multisets, so a
+#      leg dropped from the fan-in (invisible to the runtime checks: the remaining
+#      legs still pass) fails here instead of going silently ungated.
+#   3. The smoke steps' operational seam: SUITE/provider/model must be consumed from
+#      the matrix and the canonical suite dispatcher must be present, so a row field
+#      cannot degrade into an unused label and the connector-dark tripwire cannot be
+#      disabled while the rows stay green.
 #
 # It is deliberately a GOLDEN, not a relational check. Comparing the workflow's matrix
-# rows against the workflow's own ROSTER string would pass if a whole family were deleted
-# from both, and the remaining legs would still emit gate_sha. The canonical roster below
-# is the independent anchor.
+# rows against the workflow's own ROSTER string would pass if a whole family were
+# deleted from both. The canonical roster is the independent anchor; the policy map is
+# part of that anchor (policies are not derivable from the matrix).
 #
-# It pins each row's full tuple INCLUDING its owning job, not just the leg id: flipping
-# vertex-notool to the tools suite keeps its id, family, live success, and proof while
-# silently dropping the connector-dark tripwire, and repointing openai-tools at Anthropic
-# yields two Anthropic calls, zero OpenAI calls, and a green gate. Job attribution is
-# what makes the release/manual parity check real: without it, two OpenAI rows in one API
-# job and two Anthropic rows in the other satisfy an aggregate multiset while violating
-# parity outright.
+# Rows pin the full tuple INCLUDING the owning job: flipping vertex-notool to the
+# tools suite keeps its id/family/proof while dropping the connector-dark tripwire,
+# and repointing openai-tools at Anthropic yields two Anthropic calls and a green
+# gate. Job attribution is what makes the release/manual parity check real.
 set -eu
 
 workflow=.github/workflows/llm-smoke.yaml
@@ -229,6 +234,81 @@ if sorted(got_proofs) != want_proofs:
         % (sorted(got_proofs), want_proofs)
     )
 
+# ---- per-job smoke-step operational seam -----------------------------------
+# The rows pin what the matrix DECLARES; these pin what the smoke step CONSUMES. A
+# SUITE hardcoded to llm-tools-smoke would keep every row green while silently
+# disabling the connector-dark tripwire, and an unbound provider/model would reduce
+# canonical row fields to unused labels.
+SMOKE_ENV_PINS = {
+    "SMOKE_REQUIRE_RUN": '"1"',
+    "SUITE": "${{ matrix.suite }}",
+    "CYNATIVE_LLM_PROVIDER": "${{ matrix.provider }}",
+    "CYNATIVE_LLM_MODEL": "${{ matrix.model }}",
+}
+DISPATCHER = [
+    'case "$SUITE" in',
+    'llm-smoke) export SMOKE_REQUIRE_NO_CONNECTORS=1; exec make llm-smoke ;;',
+    'llm-tools-smoke) unset SMOKE_REQUIRE_NO_CONNECTORS; exec make llm-tools-smoke ;;',
+    '*) echo "::error::unknown suite: $SUITE" >&2; exit 1 ;;',
+    'esac',
+]
+
+def norm(line):
+    return " ".join(line.split())
+
+def check_smoke(jobname):
+    chunk = job_slice(jobname)
+    smoke = [i for i, l in enumerate(chunk) if norm(l) == "id: smoke"]
+    if len(smoke) != 1:
+        problems.append(
+            "job %s must have exactly one id: smoke step, found %d" % (jobname, len(smoke))
+        )
+        return
+    j = smoke[0]
+    while j < len(chunk) and norm(chunk[j]) != "env:":
+        j += 1
+    if j == len(chunk):
+        problems.append("job %s smoke step has no env block" % jobname)
+        return
+    env_indent = len(chunk[j]) - len(chunk[j].lstrip())
+    env = {}
+    j += 1
+    while j < len(chunk):
+        l = chunk[j]
+        if l.strip() and (len(l) - len(l.lstrip())) <= env_indent:
+            break
+        m = re.match(r"^\s*([A-Za-z0-9_]+):\s*(.*?)\s*$", l)
+        if m and not l.lstrip().startswith("#"):
+            if m.group(1) in env:
+                problems.append("job %s smoke env declares %s twice" % (jobname, m.group(1)))
+            env[m.group(1)] = m.group(2)
+        j += 1
+    for key, want in sorted(SMOKE_ENV_PINS.items()):
+        if env.get(key) != want:
+            problems.append(
+                "job %s smoke env %s is %r, want %r" % (jobname, key, env.get(key), want)
+            )
+    while j < len(chunk) and norm(chunk[j]) != "run: |":
+        j += 1
+    if j == len(chunk):
+        problems.append("job %s smoke step has no run block" % jobname)
+        return
+    run_indent = len(chunk[j]) - len(chunk[j].lstrip())
+    body = []
+    for l in chunk[j + 1:]:
+        if l.strip() and (len(l) - len(l.lstrip())) <= run_indent:
+            break
+        if l.strip():
+            body.append(norm(l))
+    for k in range(len(body) - len(DISPATCHER) + 1):
+        if body[k:k + len(DISPATCHER)] == DISPATCHER:
+            break
+    else:
+        problems.append("job %s smoke run block lacks the canonical suite dispatcher" % jobname)
+
+for jobname in canonical_jobs:
+    check_smoke(jobname)
+
 if declared != len(rows) or problems:
     for p in problems:
         sys.stderr.write("  %s\n" % p)
@@ -266,7 +346,7 @@ if ! cmp -s "$tmp/api_release" "$tmp/api_manual"; then
 fi
 
 if [ "$fails" = 0 ]; then
-	printf 'OK: llm-smoke-roster\n'
+	printf 'OK: llm-smoke-roster (rows + fan-in literals + smoke seam)\n'
 else
 	exit 1
 fi

--- a/test/llm-smoke-roster.unit.test.sh
+++ b/test/llm-smoke-roster.unit.test.sh
@@ -54,7 +54,8 @@ python3 - "$workflow" "$tmp/expected" >"$tmp/actual" <<'PY'
 import re
 import sys
 
-lines = open(sys.argv[1]).read().splitlines()
+with open(sys.argv[1], encoding="utf-8") as workflow_file:
+    lines = workflow_file.read().splitlines()
 
 # Job headers sit at exactly two spaces of indentation, but only inside the top-level
 # `jobs:` block. `on:` has children (workflow_call, workflow_dispatch) at that same
@@ -136,9 +137,10 @@ policy_map = {
 }
 
 canonical = []
-for raw in open(sys.argv[2]).read().splitlines():
-    if raw.strip():
-        canonical.append(raw.split("|"))
+with open(sys.argv[2], encoding="utf-8") as canonical_file:
+    for raw in canonical_file.read().splitlines():
+        if raw.strip():
+            canonical.append(raw.split("|"))
 for parts in canonical:
     if len(parts) != 6:
         problems.append(


### PR DESCRIPTION
## What & why

Follow-up hardening from the LLM smoke publish-gate work, closing the coverage and hygiene gaps in the shared release-gate scripts. None of these were live fail-opens; they are the guards that keep it that way. Closes #190.

Shared scripts:
- `ci-gate-assert.sh`: script-wide `set -f` (every word list is deliberately split unquoted, so a glob character in a token can no longer expand against the working directory), exact-reconstruction arity and non-empty checks on `JOBS` triples and `ROSTER` pairs (a malformed entry like `a:b:c:always` used to silently drop a field), a fail-closed check that a dispatch selector names at least one roster leg (previously a drifted selector exited 0 claiming the leg "ran and passed" while nothing ran), and a dead store removed. The family-coupling comment now says which direction is load-bearing.
- `ci-gate-contract.sh`: script-wide `set -f` and shared-scope wording (the script serves both gates now, and the "connector selector" die message predated that).

Test coverage:
- The gate-assert unit suite gains an optional stderr-diagnostic assertion in its harness, plus cases for the previously untested guards: the duplicate-job guard across families, an inactive job missing from `RESULTS`, both halves of the `NEEDS_JSON` type guard (the array-of-job-names case is the one only `isinstance` can catch; the `{}` case pins the guard's own diagnostic since its exit code is reachable downstream), the new arity guards, the no-match selector, and a distinguishing glob fixture that flips outcome on `set -f` itself.
- The contract suite now exercises a truly unset `DISPATCH_POLICY` (only empty was covered).
- The roster golden now also derives the gate-assert `ROSTER`/`JOBS`/`PROOFS` literals from the same canonical block that anchors the matrix rows (a leg dropped from the fan-in is invisible to the runtime checks because the remaining legs still pass), and pins each smoke step's operational seam: the `SUITE`/provider/model matrix bindings and the full suite dispatcher, so the connector-dark tripwire cannot be disabled while the rows stay green.

Publish gate:
- `release.yaml`: an explicit `needs.release.outputs.sha != ''` conjunct, closing the degenerate `'' == ''` satisfaction of the two `gate_sha` equality checks.
- `Makefile`: `sh-test` now pins the publish gate's five required conjuncts against the extracted live `publish` job `if:` line (never a whole-file grep, which a comment or dead job could satisfy), alongside the existing trusted-caller pin.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed