### PR TITLE
docs: fix document title and serial comma in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Security
+# Security Policy
 
 Please do **not** open a public GitHub issue for security reports. Use either private channel:
 
@@ -8,10 +8,10 @@ Please do **not** open a public GitHub issue for security reports. Use either pr
 
 Include:
 
-- the Cynative version, please confirm it's the latest;
+- The Cynative version (please confirm it's the latest);
 - how it was installed;
 - a clear description of the issue and its security impact;
 - steps to trigger the behavior;
 - relevant logs.
 
-**Do not include live credentials, tokens, secrets or customer data in a report.**
+**Do not include live credentials, tokens, secrets, or customer data in a report.**


### PR DESCRIPTION
## Description
This PR updates the H1 document title, list item formatting, and serial comma in `SECURITY.md`.

## Details
1. Updated document title (`# Security` $\to$ `# Security Policy`).
2. Improved parenthetical list formatting (`the Cynative version, please confirm...` $\to$ `The Cynative version (please confirm...)`).
3. Added serial Oxford comma in warning text (`secrets or customer data` $\to$ `secrets, or customer data`).