### PR TITLE
ci: clarify release recovery needs a fresh run, not a re-run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,8 +72,12 @@ jobs:
       #       repos/cynative/cynative/issues/<pr>/labels/autorelease%3A%20tagged
       #     gh api repos/cynative/cynative/issues/<pr>/labels \
       #       -f "labels[]=autorelease: pending"
-      #   Then re-run the workflow; release-please recreates the draft. The
-      #   pre-publish gate spans the release job, the smoke and e2e gates
+      #   Then trigger a fresh run so release-please recreates the draft. If
+      #   the failure was a secret that had to be created or fixed, start a
+      #   NEW run (a push to main), do NOT re-run the failed one: GitHub
+      #   snapshots secret values at workflow-run-create time, so a re-run
+      #   reuses the stale values and fails the same way (cli/cli#13522).
+      #   The pre-publish gate spans the release job, the smoke and e2e gates
       #   (macos-pkg-smoke, archive-smoke, connector-e2e, llm-smoke), and the
       #   publish job; a failure in any of them, up to and including the publish
       #   job's re-assertions, leaves the draft intact and these notes apply.


### PR DESCRIPTION
## What

Corrects the RECOVERY notes in the `release` job of `.github/workflows/release.yaml`. Comment-only change; no trigger, job, permission, or gate logic is touched.

## Why

The notes said to "re-run the workflow" after a failed publish. That is wrong when the failure was a secret that had to be created or fixed: GitHub snapshots secret values at **workflow-run-create time**, not at re-run time ([cli/cli#13522](https://github.com/cli/cli/issues/13522)), so a re-run of the failed run reuses the stale values and fails the same way. The recovery must start a **fresh** run (a push to main).

## History

This PR originally added a `workflow_dispatch` trigger for manual re-triggering. Codex correctly flagged that as a P1: `workflow_dispatch` runs the workflow definition from the dispatched ref with repository secrets available, so any write-access user could dispatch a doctored branch copy and exfiltrate the release App key / signing secrets, bypassing the protected-main-only path. Dropped the trigger; a plain PR merge already provides the fresh run this recovery needs. Manual-dispatch support, if wanted, should come later behind a main-restricted protected environment.

## Checks

Local: publish-gate conjunct pin, gate trusted-caller pin, and ci-gate unit tests pass; YAML parses.