### PR TITLE
ci: use a PAT for the release-please token to unblock v1.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,14 @@ jobs:
       - id: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          # TEMPORARY recovery override (revert to the App token after v1.7.0
+          # ships). A GitHub App installation token cannot create a release
+          # whose target_commitish is not the branch HEAD; it fails with
+          # "Resource not accessible by integration". The v1.7.0 recovery
+          # advanced main past the release commit, so the App can no longer
+          # create that release. A PAT is not subject to that restriction. Only
+          # this step needs it: every later step operates on the existing draft.
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           skip-github-pull-request: true
 
       # The tag does not exist yet, so check out the exact SHA release-please


### PR DESCRIPTION
## Why

Recovering the v1.7.0 publish (its pre-publish LLM gate had failed on an empty release-env secret) required a fresh Release Pipeline run. The only trigger is a push to main, so triggering advanced main past the v1.7.0 release commit (`513c16c`). A **GitHub App installation token cannot create a release whose `target_commitish` is not the branch HEAD** - it fails with `Resource not accessible by integration` ([community#69154](https://github.com/orgs/community/discussions/69154)). So release-please (using the App) can no longer create the v1.7.0 release at `513c16c`. Verified in-session: a user PAT creates that release fine; only the App is blocked.

## What

Swaps **only** the release-please step's token (App → `secrets.RELEASE_PLEASE_PAT`). A PAT is not subject to the non-HEAD restriction, so release-please creates the v1.7.0 draft at `513c16c` and the pipeline publishes it. goreleaser (`use_existing_draft: true`, `mode: keep-existing`) adopts the existing draft and the publish job operates on it, so every other step keeps the App token - no non-HEAD creation happens anywhere else.

## Requires

Repo secret `RELEASE_PLEASE_PAT`: fine-grained PAT on `cynative/cynative` with **Contents: write** and **Pull requests: write** (release-please flips #172's label to `autorelease: tagged` after releasing).

## Temporary

This is a one-time recovery override. Follow-up: revert to the App token once v1.7.0 ships, and fix the recovery mechanism so this class of stuck-publish doesn't recur (tracked with #202).