### PR TITLE
ci: use the PAT for ensure-tag too, to unblock v1.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,7 +116,11 @@ jobs:
       - name: Ensure release tag
         if: ${{ steps.release-please.outputs.release_created == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          # TEMPORARY recovery override (revert with the release-please token):
+          # ensure-tag.sh creates the tag ref, and a GitHub App token cannot
+          # create a ref at a non-HEAD commit. The v1.7.0 recovery advanced main
+          # past the release commit, so the App 403s here; a PAT is not.
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
           TAG: ${{ steps.release-please.outputs.tag_name }}
           SHA: ${{ steps.release-please.outputs.sha }}
         run: |
@@ -612,7 +616,10 @@ jobs:
       - name: Re-verify tag before publish
         if: ${{ needs.release.outputs.release_created == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.publish-token.outputs.token }}
+          # TEMPORARY recovery override (see the release job's Ensure release
+          # tag step): the App token cannot create/verify the tag ref at the
+          # non-HEAD release commit, so this re-verify uses the PAT too.
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
           TAG: ${{ needs.release.outputs.tag_name }}
           SHA: ${{ needs.release.outputs.sha }}
         run: scripts/release/ensure-tag.sh "${GITHUB_REPOSITORY}" "${TAG}" "${SHA}"


### PR DESCRIPTION
## Why

Follow-up to #203. With release-please on the PAT, the v1.7.0 run got further and then failed at **Ensure release tag** (`Resource not accessible by integration`, 403). `ensure-tag.sh` does a create-first `POST /git/refs`, and a GitHub App token cannot create a ref at a non-HEAD commit - the same restriction that blocked release-please. Because the recovery advanced main past the release commit (`513c16c`), the App 403s here, and the 403 masks the normal "Reference already exists" path, so the script fails even though the tag is present at the right SHA.

## What

Points **both** `ensure-tag.sh` invocations at `secrets.RELEASE_PLEASE_PAT`:
- `release` job - **Ensure release tag**
- `publish` job - **Re-verify tag before publish** (same script, same wall)

Everything else stays on the App token: goreleaser adopts the existing draft and only uploads assets, and the publish PATCH flips an existing draft whose tag already exists - none of those create a ref/release at a non-HEAD commit.

## Temporary

Recovery-only override, reverted together with #203's release-please override once v1.7.0 ships. Tracked in #202.