### PR TITLE
ci: grant llm-smoke the api-key secrets across workflow_call

### DIFF
--- a/.github/workflows/llm-smoke.yaml
+++ b/.github/workflows/llm-smoke.yaml
@@ -27,12 +27,23 @@ on:
       gate_sha:
         description: The SHA for which the full LLM gate succeeded. Empty means it did not.
         value: ${{ jobs.gate-assert.outputs.gate_sha }}
+    secrets:
+      OPENAI_API_KEY:
+        required: true
+      ANTHROPIC_API_KEY:
+        required: true
   workflow_dispatch:
 
-# No workflow_call secrets. OPENAI_API_KEY and ANTHROPIC_API_KEY are ENVIRONMENT secrets
-# of llm-api-keys / llm-api-keys-release, resolved inside the jobs below. Declaring them
-# as call secrets would create a path that looks wired but is silently overridden: an
-# environment secret always wins over a same-named caller-passed secret.
+# OPENAI_API_KEY and ANTHROPIC_API_KEY are ENVIRONMENT secrets of llm-api-keys (dispatch)
+# and llm-api-keys-release (release). They MUST be declared under on.workflow_call.secrets
+# above and forwarded by the caller, even though the value the caller forwards is empty: a
+# called workflow's secrets context is populated ONLY by the caller's grant, so on a
+# workflow_call they resolve EMPTY without it (actions/runner#1490, closed works-as-designed).
+# The grant is all the caller supplies; the api-key-release job's environment then provides
+# the real value, since a same-named environment secret wins over the caller-passed one. On a
+# dispatch there is no caller and they resolve directly from the job's environment. make
+# sh-test pins the secrets.* references in this file to exactly these two names, so inheriting
+# or forwarding cannot silently widen what the gate can read.
 permissions: {}
 
 # The gate path is keyed on the run id. A called workflow's concurrency group is evaluated

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -555,6 +555,16 @@ jobs:
     uses: ./.github/workflows/llm-smoke.yaml
     with:
       ref: ${{ needs.release.outputs.sha }}
+    # These forward EMPTY from here (this job is not in the llm-api-keys-release
+    # environment). Their only purpose is to grant the called workflow a secrets
+    # context: without a caller grant, a workflow_call job resolves environment
+    # secrets as empty (actions/runner#1490). The api-key-release job's own
+    # environment then supplies the real values, since a same-named environment
+    # secret wins over a caller-passed one. This is NOT `secrets: inherit`: only
+    # these two names cross the boundary, never the App key/signing/PAT secrets.
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -206,15 +206,26 @@ sh-test:
 		esac; \
 	done
 	@# The api-key legs read exactly two secrets across the workflow_call boundary.
-	@# release.yaml forwards ONLY these two names (not secrets: inherit), so pin the
-	@# full set of secrets.<NAME> references in llm-smoke.yaml: a new one would widen
-	@# what the gate can read, and this fails closed if the sorted-unique set is ever
-	@# anything other than exactly ANTHROPIC_API_KEY + OPENAI_API_KEY. `sed 's/#.*//'`
-	@# drops comments (full-line AND inline) so a secret named only in prose never counts.
-	@got=$$(sed 's/#.*//' .github/workflows/llm-smoke.yaml | grep -oE 'secrets\.[A-Za-z0-9_]+' | sed 's/^secrets\.//' | sort -u | xargs); \
+	@# release.yaml forwards ONLY these two names, never secrets: inherit. Pin the
+	@# boundary from both sides, comments stripped (sed 's/#.*//') so prose never counts:
+	@#   llm-smoke.yaml - the sorted-unique set of secrets.<NAME> refs must be exactly
+	@#     the two keys, and bracket-form secrets[...] is rejected outright since it
+	@#     would evade the dot-form scan;
+	@#   release.yaml - `secrets: inherit` must never appear, or a future edit could
+	@#     hand every release secret (App key, signing, PAT) to the gate.
+	@smoke=$$(sed 's/#.*//' .github/workflows/llm-smoke.yaml); \
+	if printf '%s\n' "$$smoke" | grep -q 'secrets\['; then \
+		echo "FAIL: llm-smoke.yaml uses bracket-form secrets[...]; only dot-form secrets.NAME is allowed so this pin can enforce the exact set."; \
+		exit 1; \
+	fi; \
+	got=$$(printf '%s\n' "$$smoke" | grep -oE 'secrets\.[A-Za-z0-9_]+' | sed 's/^secrets\.//' | sort -u | xargs); \
 	want="ANTHROPIC_API_KEY OPENAI_API_KEY"; \
 	if [ "$$got" != "$$want" ]; then \
 		echo "FAIL: llm-smoke.yaml secrets.* references are [$$got], expected exactly [$$want] - a new reference would widen the gate's secret access across workflow_call."; \
+		exit 1; \
+	fi; \
+	if sed 's/#.*//' .github/workflows/release.yaml | grep -qE 'secrets:[[:space:]]*inherit'; then \
+		echo "FAIL: release.yaml uses 'secrets: inherit' - reusable gates must be granted only the exact named secrets they need, never the full set."; \
 		exit 1; \
 	fi
 	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + llm-smoke secret-reference pin)"

--- a/Makefile
+++ b/Makefile
@@ -209,8 +209,9 @@ sh-test:
 	@# release.yaml forwards ONLY these two names (not secrets: inherit), so pin the
 	@# full set of secrets.<NAME> references in llm-smoke.yaml: a new one would widen
 	@# what the gate can read, and this fails closed if the sorted-unique set is ever
-	@# anything other than exactly ANTHROPIC_API_KEY + OPENAI_API_KEY.
-	@got=$$(grep -vE '^[[:space:]]*#' .github/workflows/llm-smoke.yaml | grep -oE 'secrets\.[A-Za-z0-9_]+' | sed 's/^secrets\.//' | sort -u | paste -sd' ' -); \
+	@# anything other than exactly ANTHROPIC_API_KEY + OPENAI_API_KEY. `sed 's/#.*//'`
+	@# drops comments (full-line AND inline) so a secret named only in prose never counts.
+	@got=$$(sed 's/#.*//' .github/workflows/llm-smoke.yaml | grep -oE 'secrets\.[A-Za-z0-9_]+' | sed 's/^secrets\.//' | sort -u | xargs); \
 	want="ANTHROPIC_API_KEY OPENAI_API_KEY"; \
 	if [ "$$got" != "$$want" ]; then \
 		echo "FAIL: llm-smoke.yaml secrets.* references are [$$got], expected exactly [$$want] - a new reference would widen the gate's secret access across workflow_call."; \

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,18 @@ sh-test:
 		*) echo "FAIL: the publish gate in release.yaml is missing the required term [$$term]."; exit 1 ;; \
 		esac; \
 	done
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check)"
+	@# The api-key legs read exactly two secrets across the workflow_call boundary.
+	@# release.yaml forwards ONLY these two names (not secrets: inherit), so pin the
+	@# full set of secrets.<NAME> references in llm-smoke.yaml: a new one would widen
+	@# what the gate can read, and this fails closed if the sorted-unique set is ever
+	@# anything other than exactly ANTHROPIC_API_KEY + OPENAI_API_KEY.
+	@got=$$(grep -vE '^[[:space:]]*#' .github/workflows/llm-smoke.yaml | grep -oE 'secrets\.[A-Za-z0-9_]+' | sed 's/^secrets\.//' | sort -u | paste -sd' ' -); \
+	want="ANTHROPIC_API_KEY OPENAI_API_KEY"; \
+	if [ "$$got" != "$$want" ]; then \
+		echo "FAIL: llm-smoke.yaml secrets.* references are [$$got], expected exactly [$$want] - a new reference would widen the gate's secret access across workflow_call."; \
+		exit 1; \
+	fi
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + llm-smoke secret-reference pin)"
 
 SHELL_COMPLEXITY_MAX := 6
 


### PR DESCRIPTION
## Why

The `api-key-release` legs of the live LLM gate read `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the `llm-api-keys-release` environment. On the release path, `llm-smoke.yaml` runs as a reusable **`workflow_call`** from `release.yaml`, and a called workflow's `secrets` context is populated **only** by the caller's grant. With no grant, environment secrets resolve **empty** ([actions/runner#1490](https://github.com/actions/runner/issues/1490), closed *works-as-designed*). That's why this gate has failed on every release run and passed only on **direct dispatch** (which has no caller boundary). The OIDC legs (bedrock/vertex) are unaffected - they mint tokens, they don't read `secrets`.

The old header comment had it backwards: it said declaring call secrets would be "silently overridden" and pointless. The override is real, but it's the *mechanism* - the grant is what lets the environment secret resolve at all, and the environment's value (the real key) is what wins.

## What

- `llm-smoke.yaml`: declare the two keys under `on.workflow_call.secrets`; rewrite the stale comment.
- `release.yaml`: forward them from the `llm-smoke` call. The forwarded value is **empty** (that job isn't in the environment) - its only purpose is to establish the grant; the `api-key-release` job's own `environment:` supplies the real value.
- **Not `secrets: inherit`**: only these two names cross the boundary - never the App key, signing material, or the release PAT.
- `Makefile`: a `sh-test` pin that fails closed if `llm-smoke.yaml` ever references any `secrets.*` beyond these two names, so a future edit can't silently widen the gate's secret access.

The fail-closed empty-key preflight in the smoke step stays as the backstop: if resolution is ever wrong again, the release blocks loudly instead of skipping green.

## Verification

Consulted two independent analyses; both confirmed the root cause. Local: YAML parses, the new pin passes, and the roster/gate-contract goldens are unaffected. The true end-to-end proof is the next release run (the manual-dispatch path is untouched).