### PR TITLE
ci: revert the temporary release-please/ensure-tag PAT overrides

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,11 +80,14 @@ jobs:
       #   That fresh run is a new push, so main HEAD advances past the release
       #   PR's SHA, and a GitHub App token cannot create a release or tag ref at
       #   a non-HEAD target_commitish (403 "Resource not accessible by
-      #   integration"). BREAK-GLASS until #202 lands a repository_dispatch
-      #   re-trigger (which recovers WITHOUT advancing HEAD, so the release SHA
-      #   stays == HEAD and the App works): temporarily point this step's `token`
-      #   and both ensure-tag `GH_TOKEN`s at a short-lived PAT (contents +
-      #   pull-requests write), recover, then revert and delete the PAT.
+      #   integration"). The same wall can appear WITHOUT a recovery: if the
+      #   release-PR-merge run is coalesced away by a later push in the
+      #   release-pipeline concurrency group, the run that executes re-derives
+      #   the release at the older release-PR SHA while starting at a newer HEAD.
+      #   BREAK-GLASS for either case, until a repository_dispatch re-trigger
+      #   (#202) and HEAD-safe targeting remove the need: temporarily point this
+      #   step's `token` and both ensure-tag `GH_TOKEN`s at a short-lived PAT
+      #   (contents + pull-requests write), recover, then revert and delete it.
       #   The pre-publish gate spans the release job, the smoke and e2e gates
       #   (macos-pkg-smoke, archive-smoke, connector-e2e, llm-smoke), and the
       #   publish job; a failure in any of them, up to and including the publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,14 @@ jobs:
       #   NEW run (a push to main), do NOT re-run the failed one: GitHub
       #   snapshots secret values at workflow-run-create time, so a re-run
       #   reuses the stale values and fails the same way (cli/cli#13522).
+      #   That fresh run is a new push, so main HEAD advances past the release
+      #   PR's SHA, and a GitHub App token cannot create a release or tag ref at
+      #   a non-HEAD target_commitish (403 "Resource not accessible by
+      #   integration"). BREAK-GLASS until #202 lands a repository_dispatch
+      #   re-trigger (which recovers WITHOUT advancing HEAD, so the release SHA
+      #   stays == HEAD and the App works): temporarily point this step's `token`
+      #   and both ensure-tag `GH_TOKEN`s at a short-lived PAT (contents +
+      #   pull-requests write), recover, then revert and delete the PAT.
       #   The pre-publish gate spans the release job, the smoke and e2e gates
       #   (macos-pkg-smoke, archive-smoke, connector-e2e, llm-smoke), and the
       #   publish job; a failure in any of them, up to and including the publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,14 +89,7 @@ jobs:
       - id: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          # TEMPORARY recovery override (revert to the App token after v1.7.0
-          # ships). A GitHub App installation token cannot create a release
-          # whose target_commitish is not the branch HEAD; it fails with
-          # "Resource not accessible by integration". The v1.7.0 recovery
-          # advanced main past the release commit, so the App can no longer
-          # create that release. A PAT is not subject to that restriction. Only
-          # this step needs it: every later step operates on the existing draft.
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           skip-github-pull-request: true
 
       # The tag does not exist yet, so check out the exact SHA release-please
@@ -116,11 +109,7 @@ jobs:
       - name: Ensure release tag
         if: ${{ steps.release-please.outputs.release_created == 'true' }}
         env:
-          # TEMPORARY recovery override (revert with the release-please token):
-          # ensure-tag.sh creates the tag ref, and a GitHub App token cannot
-          # create a ref at a non-HEAD commit. The v1.7.0 recovery advanced main
-          # past the release commit, so the App 403s here; a PAT is not.
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           TAG: ${{ steps.release-please.outputs.tag_name }}
           SHA: ${{ steps.release-please.outputs.sha }}
         run: |
@@ -626,10 +615,7 @@ jobs:
       - name: Re-verify tag before publish
         if: ${{ needs.release.outputs.release_created == 'true' }}
         env:
-          # TEMPORARY recovery override (see the release job's Ensure release
-          # tag step): the App token cannot create/verify the tag ref at the
-          # non-HEAD release commit, so this re-verify uses the PAT too.
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+          GH_TOKEN: ${{ steps.publish-token.outputs.token }}
           TAG: ${{ needs.release.outputs.tag_name }}
           SHA: ${{ needs.release.outputs.sha }}
         run: scripts/release/ensure-tag.sh "${GITHUB_REPOSITORY}" "${TAG}" "${SHA}"


### PR DESCRIPTION
Restores the App installation token on the release-please step and both `ensure-tag` steps, undoing the temporary `RELEASE_PLEASE_PAT` overrides from #203 and #204.

Those were a one-time workaround while recovering a stuck v1.7.0 publish: the recovery triggered a fresh run by merging to main, which advanced HEAD past the release commit, and a GitHub App installation token cannot create a release or tag ref at a non-HEAD `target_commitish` (403 `Resource not accessible by integration`). A normal release runs with HEAD == the release SHA, so the App works natively and the PAT isn't needed.

The `RELEASE_PLEASE_PAT` repo secret is removed separately once this merges. The unrelated `workflow_call` secrets fix (#205) stays.