### PR TITLE
feat: add optional --live-llm probe to cynative doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Cynative calls your stack using the credentials already in your shell - it keeps
 
 Cynative prints a short operational footer (timing, token usage) to **stderr** - redirecting stdout (`cynative -p "..." > out.txt`) keeps the captured answer clean. `--version` prints version, commit, build date, Go version, and platform.
 
-`cynative doctor` validates configuration and connector readiness without starting a research session.
+`cynative doctor` validates configuration and connector readiness without starting a research session. Pass `--live-llm` to also probe the configured model with a tool-less round-trip.
 
 <details>
 <summary><strong>Resource &amp; cost controls for unattended runs</strong></summary>

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,14 +2,13 @@ package cli
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cynative/cynative/internal/config"
+	"github.com/cynative/cynative/internal/redact"
 	"github.com/cynative/cynative/internal/schema"
 	"github.com/cynative/cynative/internal/ui"
 )
@@ -47,7 +46,7 @@ only under --verbose do not change the result.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
-		"Show skipped connectors that are normally hidden (does not change readiness)")
+		"Show skipped connectors; with --live-llm, also print redacted probe errors")
 	cmd.Flags().BoolVar(&liveLLM, "live-llm", false,
 		"Probe the configured LLM with a live tool-less round-trip after structural validation")
 
@@ -131,7 +130,7 @@ func (d *deps) runDoctor(ctx context.Context, cfg config.Config, verbose, liveLL
 	}
 
 	if liveLLM {
-		if err := d.probeLiveLLM(ctx, cfg); err != nil {
+		if err := d.probeLiveLLM(ctx, cfg, verbose); err != nil {
 			fmt.Fprintln(d.errOut, "Doctor: not ready")
 			fmt.Fprintln(d.errOut, "  Connector checks may perform live read-only network calls.")
 
@@ -157,32 +156,32 @@ func (d *deps) runDoctor(ctx context.Context, cfg config.Config, verbose, liveLL
 }
 
 // probeLiveLLM constructs the chat model, sends a tool-less nonce-echo prompt,
-// and requires the nonce in the assistant text. On failure it renders an LLM
-// ✗ status; the caller returns ErrLLMUnavailable. doctorProbeNonce, when set
-// (tests), replaces the random token so fakes can echo it deterministically.
-func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config) error {
+// and requires the nonce in the assistant text (case-insensitive). On failure it
+// renders an LLM ✗ status; when verbose is set it also prints a redacted details
+// line so the "-v for details" hint from llmRuntimeStatus is actionable. The
+// caller returns ErrLLMUnavailable.
+func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool) error {
 	cm, err := d.newChatModel(ctx, cfg, func(schema.Usage) {})
 	if err != nil {
 		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
+		d.printDoctorProbeDetails(verbose, err)
 
 		return err
 	}
 	defer cm.Shutdown()
 
-	nonce := d.doctorProbeNonce
-	if nonce == "" {
-		nonce = newDoctorProbeNonce()
-	}
-
+	nonce := d.newDoctorProbeNonce()
 	msg, err := cm.Generate(ctx, []*schema.Message{
 		schema.UserMessage(fmt.Sprintf(doctorProbePromptFmt, nonce)),
 	}, nil)
 	if err != nil {
 		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
+		d.printDoctorProbeDetails(verbose, err)
 
 		return err
 	}
-	if msg == nil || !strings.Contains(msg.Text(), nonce) {
+	// Case-insensitive: some models normalize token casing in the echo.
+	if msg == nil || !strings.Contains(strings.ToLower(msg.Text()), strings.ToLower(nonce)) {
 		d.ui.RenderLLM(d.errOut, llmDoctorProbeMismatchStatus(cfg))
 
 		return fmt.Errorf("%w: live probe response mismatch", ErrLLMUnavailable)
@@ -191,11 +190,12 @@ func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config) error {
 	return nil
 }
 
-func newDoctorProbeNonce() string {
-	var b [16]byte
-	// crypto/rand.Read fills the whole buffer on success; a failure leaves zeros
-	// and we still emit a stable-shaped token rather than aborting doctor.
-	_, _ = rand.Read(b[:])
-
-	return "DOCTOR-" + hex.EncodeToString(b[:])
+// printDoctorProbeDetails writes a redacted provider error when -v is set.
+// Doctor does not wrap the probe model in RedactingChatModel, so this is the
+// boundary that keeps credential-shaped text off stderr.
+func (d *deps) printDoctorProbeDetails(verbose bool, err error) {
+	if !verbose || err == nil {
+		return
+	}
+	fmt.Fprintf(d.errOut, "  details: %s\n", redact.New().Redact(err.Error()))
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,20 +1,30 @@
 package cli
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cynative/cynative/internal/config"
+	"github.com/cynative/cynative/internal/schema"
 	"github.com/cynative/cynative/internal/ui"
 )
 
+// doctorProbePromptFmt is the tool-less live probe (same spirit as
+// test/llm.smoke.test.sh): the model must echo the nonce.
+const doctorProbePromptFmt = "Reply with exactly this token and nothing else: %s"
+
 // newDoctorCmd returns the `cynative doctor` subcommand. Config is loaded by the
-// root PersistentPreRunE before RunE; doctor never constructs a chat model or
-// runs tools — it only prints the startup inventory and structural LLM status.
+// root PersistentPreRunE before RunE; without --live-llm, doctor never constructs
+// a chat model or runs tools — it only prints the startup inventory and
+// structural LLM status. With --live-llm it additionally performs one tool-less
+// Generate after ValidateLLM passes.
 func newDoctorCmd(d *deps) *cobra.Command {
-	var verbose bool
+	var verbose, liveLLM bool
 
 	cmd := &cobra.Command{ //nolint:exhaustruct // optional cobra fields intentionally omitted
 		Use:   "doctor",
@@ -23,21 +33,23 @@ func newDoctorCmd(d *deps) *cobra.Command {
 
 Prints the same stderr startup inventory as a normal run (banner, connectors,
 LLM structural status). Connector checks may perform live read-only network
-calls. The LLM check is configuration-only (connectivity is not tested). Does
-not call the LLM, open an interactive session, or run tools.
+calls. The LLM check is configuration-only unless --live-llm is set. Does not
+open an interactive session or run tools.
 
-Exit 0 when the LLM block is valid and no actionable connector failures are
-present. Exit 1 on config-load failure, ValidateLLM failure, or an actionable
-connector readiness failure (structural errors and explicitly configured
-connectors that failed live checks). Ambient "no credentials" skips shown only
-under --verbose do not change the result.`,
+Exit 0 when the LLM block is valid (and, with --live-llm, reachable) and no
+actionable connector failures are present. Exit 1 on config-load failure,
+ValidateLLM failure, a failed --live-llm probe (ErrLLMUnavailable), or an
+actionable connector readiness failure. Ambient "no credentials" skips shown
+only under --verbose do not change the result.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return silenceGracefulStop(cmd, d.runDoctor(d.cfg, verbose))
+			return silenceGracefulStop(cmd, d.runDoctor(cmd.Context(), d.cfg, verbose, liveLLM))
 		},
 	}
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
 		"Show skipped connectors that are normally hidden (does not change readiness)")
+	cmd.Flags().BoolVar(&liveLLM, "live-llm", false,
+		"Probe the configured LLM with a live tool-less round-trip after structural validation")
 
 	return cmd
 }
@@ -74,10 +86,34 @@ func llmDoctorOKStatus(cfg config.Config) ui.LLMStatus {
 	}
 }
 
-// runDoctor prints banner → connector inventory → LLM structural status and
-// returns ErrLLMUnavailable or ErrDoctorNotReady when health checks fail.
+// llmDoctorLiveOKStatus is the doctor ✓ line after a successful --live-llm probe.
+func llmDoctorLiveOKStatus(cfg config.Config) ui.LLMStatus {
+	return ui.LLMStatus{ //nolint:exhaustruct // doctor OK: no hint/onboarding fields.
+		State:    ui.ConnectorOK,
+		Provider: cfg.LLM.Provider,
+		Model:    cfg.LLM.Model,
+		Reason:   "configuration valid; connectivity verified",
+	}
+}
+
+// llmDoctorProbeMismatchStatus is the ✗ line when Generate succeeds but the
+// response does not echo the probe nonce (not a GenerateError, so llmRuntimeStatus
+// would mis-bucket it as a connectivity failure).
+func llmDoctorProbeMismatchStatus(cfg config.Config) ui.LLMStatus {
+	return ui.LLMStatus{ //nolint:exhaustruct // mismatch: Reason/Hint only.
+		State:    ui.ConnectorError,
+		Provider: cfg.LLM.Provider,
+		Model:    cfg.LLM.Model,
+		Reason:   "live probe response mismatch",
+		Hint:     "The model answered but did not echo the probe token. Check llm.model and retry.",
+	}
+}
+
+// runDoctor prints banner → connector inventory → LLM status and returns
+// ErrLLMUnavailable or ErrDoctorNotReady when health checks fail.
 // Ambient connector absences (verbose-only) do not fail the command.
-func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
+// With liveLLM, a tool-less Generate runs only after ValidateLLM passes.
+func (d *deps) runDoctor(ctx context.Context, cfg config.Config, verbose, liveLLM bool) error {
 	d.ui.RenderBanner(d.errOut)
 
 	_, views := d.buildProviders(cfg, verbose)
@@ -94,7 +130,18 @@ func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
 		return ErrLLMUnavailable
 	}
 
-	d.ui.RenderLLM(d.errOut, llmDoctorOKStatus(cfg))
+	if liveLLM {
+		if err := d.probeLiveLLM(ctx, cfg); err != nil {
+			fmt.Fprintln(d.errOut, "Doctor: not ready")
+			fmt.Fprintln(d.errOut, "  Connector checks may perform live read-only network calls.")
+
+			return ErrLLMUnavailable
+		}
+		d.ui.RenderLLM(d.errOut, llmDoctorLiveOKStatus(cfg))
+	} else {
+		d.ui.RenderLLM(d.errOut, llmDoctorOKStatus(cfg))
+	}
+
 	fmt.Fprintln(d.errOut, "  Connector checks may perform live read-only network calls.")
 
 	if !health.ok() {
@@ -107,4 +154,48 @@ func (d *deps) runDoctor(cfg config.Config, verbose bool) error {
 	fmt.Fprintln(d.errOut, "Doctor: ready")
 
 	return nil
+}
+
+// probeLiveLLM constructs the chat model, sends a tool-less nonce-echo prompt,
+// and requires the nonce in the assistant text. On failure it renders an LLM
+// ✗ status; the caller returns ErrLLMUnavailable. doctorProbeNonce, when set
+// (tests), replaces the random token so fakes can echo it deterministically.
+func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config) error {
+	cm, err := d.newChatModel(ctx, cfg, func(schema.Usage) {})
+	if err != nil {
+		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
+
+		return err
+	}
+	defer cm.Shutdown()
+
+	nonce := d.doctorProbeNonce
+	if nonce == "" {
+		nonce = newDoctorProbeNonce()
+	}
+
+	msg, err := cm.Generate(ctx, []*schema.Message{
+		schema.UserMessage(fmt.Sprintf(doctorProbePromptFmt, nonce)),
+	}, nil)
+	if err != nil {
+		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
+
+		return err
+	}
+	if msg == nil || !strings.Contains(msg.Text(), nonce) {
+		d.ui.RenderLLM(d.errOut, llmDoctorProbeMismatchStatus(cfg))
+
+		return fmt.Errorf("%w: live probe response mismatch", ErrLLMUnavailable)
+	}
+
+	return nil
+}
+
+func newDoctorProbeNonce() string {
+	var b [16]byte
+	// crypto/rand.Read fills the whole buffer on success; a failure leaves zeros
+	// and we still emit a stable-shaped token rather than aborting doctor.
+	_, _ = rand.Read(b[:])
+
+	return "DOCTOR-" + hex.EncodeToString(b[:])
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -166,9 +166,9 @@ func (d *deps) runDoctor(ctx context.Context, cfg config.Config, verbose, liveLL
 // and requires the nonce in the assistant text (case-insensitive). On failure it
 // renders an LLM ✗ status; when verbose is set it also prints a redacted details
 // line so the "-v for details" hint from llmRuntimeStatus is actionable. The
-// caller returns ErrLLMUnavailable. The whole probe runs under a short deadline
-// (doctorLiveProbeTimeout, overridable via deps.doctorLiveProbeTimeout) so it
-// cannot inherit the research call's multi-minute timeout×retry window.
+// caller returns ErrLLMUnavailable. The probe is isolated from research defaults:
+// a short context deadline, MaxRetries forced to 0, and a request timeout capped
+// to the same window — so a hung or retrying provider cannot block for minutes.
 func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool) error {
 	timeout := d.doctorLiveProbeTimeout
 	if timeout <= 0 {
@@ -177,7 +177,8 @@ func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool
 	pctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cm, err := d.newChatModel(pctx, cfg, func(schema.Usage) {})
+	probeCfg := doctorLiveProbeConfig(cfg, timeout)
+	cm, err := d.newChatModel(pctx, probeCfg, nil)
 	if err != nil {
 		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
 		d.printDoctorProbeDetails(verbose, err)
@@ -204,6 +205,17 @@ func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool
 	}
 
 	return nil
+}
+
+// doctorLiveProbeConfig returns a copy of cfg whose LLM network knobs cannot
+// inherit the research multi-minute timeout×retry window.
+func doctorLiveProbeConfig(cfg config.Config, timeout time.Duration) config.Config {
+	probe := cfg
+	secs := max(int(timeout/time.Second), 1)
+	probe.LLM.NetworkConfig.MaxRetries = 0
+	probe.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds = secs
+
+	return probe
 }
 
 // printDoctorProbeDetails writes a redacted provider error when -v is set.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +17,12 @@ import (
 // doctorProbePromptFmt is the tool-less live probe (same spirit as
 // test/llm.smoke.test.sh): the model must echo the nonce.
 const doctorProbePromptFmt = "Reply with exactly this token and nothing else: %s"
+
+// doctorLiveProbeTimeout bounds doctor --live-llm independently of research
+// defaults (300s request timeout × up to max_retries+1 attempts). A hung or
+// retry-looping endpoint must fail the diagnostic promptly, like other startup
+// probes (credentialProbeTimeout / welcomeTimeout).
+const doctorLiveProbeTimeout = 30 * time.Second
 
 // newDoctorCmd returns the `cynative doctor` subcommand. Config is loaded by the
 // root PersistentPreRunE before RunE; without --live-llm, doctor never constructs
@@ -159,9 +166,18 @@ func (d *deps) runDoctor(ctx context.Context, cfg config.Config, verbose, liveLL
 // and requires the nonce in the assistant text (case-insensitive). On failure it
 // renders an LLM ✗ status; when verbose is set it also prints a redacted details
 // line so the "-v for details" hint from llmRuntimeStatus is actionable. The
-// caller returns ErrLLMUnavailable.
+// caller returns ErrLLMUnavailable. The whole probe runs under a short deadline
+// (doctorLiveProbeTimeout, overridable via deps.doctorLiveProbeTimeout) so it
+// cannot inherit the research call's multi-minute timeout×retry window.
 func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool) error {
-	cm, err := d.newChatModel(ctx, cfg, func(schema.Usage) {})
+	timeout := d.doctorLiveProbeTimeout
+	if timeout <= 0 {
+		timeout = doctorLiveProbeTimeout
+	}
+	pctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cm, err := d.newChatModel(pctx, cfg, func(schema.Usage) {})
 	if err != nil {
 		d.ui.RenderLLM(d.errOut, llmRuntimeStatus(cfg, err))
 		d.printDoctorProbeDetails(verbose, err)
@@ -171,7 +187,7 @@ func (d *deps) probeLiveLLM(ctx context.Context, cfg config.Config, verbose bool
 	defer cm.Shutdown()
 
 	nonce := d.newDoctorProbeNonce()
-	msg, err := cm.Generate(ctx, []*schema.Message{
+	msg, err := cm.Generate(pctx, []*schema.Message{
 		schema.UserMessage(fmt.Sprintf(doctorProbePromptFmt, nonce)),
 	}, nil)
 	if err != nil {

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -276,7 +276,7 @@ func TestDoctor_LiveLLM_OK(t *testing.T) {
 	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
 	d := testDeps()
 	d.ui = u
-	d.doctorProbeNonce = nonce
+	d.newDoctorProbeNonce = func() string { return nonce }
 	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
 		return &fakeChatModel{ //nolint:exhaustruct // errs/calls not pre-set
 			responses: []*schema.Message{schema.AssistantMessage(nonce, nil)},
@@ -299,6 +299,30 @@ func TestDoctor_LiveLLM_OK(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "Doctor: ready") {
 		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
+	}
+}
+
+func TestDoctor_LiveLLM_CaseInsensitiveNonce(t *testing.T) {
+	t.Parallel()
+
+	const nonce = "DOCTOR-AbCdEf"
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.newDoctorProbeNonce = func() string { return nonce }
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &fakeChatModel{ //nolint:exhaustruct // errs unused
+			responses: []*schema.Message{schema.AssistantMessage(strings.ToLower(nonce), nil)},
+		}, nil
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if err != nil {
+		t.Fatalf("doctor --live-llm with case-folded echo: %v", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
+		t.Errorf("llmStatuses = %+v, want one OK status", u.llmStatuses)
 	}
 }
 
@@ -330,7 +354,7 @@ func TestDoctor_LiveLLM_GenerateFailure(t *testing.T) {
 	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
 	d := testDeps()
 	d.ui = u
-	d.doctorProbeNonce = "DOCTOR-TESTNONCE"
+	d.newDoctorProbeNonce = func() string { return "DOCTOR-TESTNONCE" }
 	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
 		return &fakeChatModel{ //nolint:exhaustruct // responses unused
 			errs: []error{errors.New("provider down")},
@@ -346,13 +370,39 @@ func TestDoctor_LiveLLM_GenerateFailure(t *testing.T) {
 	}
 }
 
+func TestDoctor_LiveLLM_VerbosePrintsDetails(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.newDoctorProbeNonce = func() string { return "DOCTOR-TESTNONCE" }
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &fakeChatModel{ //nolint:exhaustruct // responses unused
+			errs: []error{errors.New("upstream timeout from gateway")},
+		}, nil
+	}
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm", "-v"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if !strings.Contains(errBuf.String(), "details: upstream timeout from gateway") {
+		t.Errorf("stderr missing verbose details; got %q", errBuf.String())
+	}
+}
+
 func TestDoctor_LiveLLM_NonceMismatch(t *testing.T) {
 	t.Parallel()
 
 	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
 	d := testDeps()
 	d.ui = u
-	d.doctorProbeNonce = "DOCTOR-EXPECTED"
+	d.newDoctorProbeNonce = func() string { return "DOCTOR-EXPECTED" }
 	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
 		return &fakeChatModel{ //nolint:exhaustruct // errs unused
 			responses: []*schema.Message{schema.AssistantMessage("unrelated answer", nil)},
@@ -401,17 +451,5 @@ func TestSilenceGracefulStop_DoctorNotReady(t *testing.T) {
 	}
 	if !cmd.SilenceErrors {
 		t.Error("SilenceErrors should be set for ErrDoctorNotReady")
-	}
-}
-
-func TestNewDoctorProbeNonce(t *testing.T) {
-	t.Parallel()
-
-	a, b := newDoctorProbeNonce(), newDoctorProbeNonce()
-	if !strings.HasPrefix(a, "DOCTOR-") || len(a) < len("DOCTOR-")+8 {
-		t.Errorf("nonce = %q, want DOCTOR-<hex>", a)
-	}
-	if a == b {
-		t.Error("consecutive nonces must differ")
 	}
 }

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -438,6 +439,53 @@ func TestDoctor_LiveLLM_SkippedWhenValidateLLMFails(t *testing.T) {
 	}
 	if called {
 		t.Fatal("--live-llm must not probe before ValidateLLM passes")
+	}
+}
+
+func TestDoctor_LiveLLM_BoundsProbeContext(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	var remaining time.Duration
+	var hadDeadline bool
+	d.newChatModel = func(ctx context.Context, _ config.Config, _ func(schema.Usage)) (chatModel, error) {
+		if dl, ok := ctx.Deadline(); ok {
+			hadDeadline = true
+			remaining = time.Until(dl)
+		}
+
+		return &fakeChatModel{ //nolint:exhaustruct // errs unused
+			responses: []*schema.Message{schema.AssistantMessage("DOCTOR-TEST-DEFAULT", nil)},
+		}, nil
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if err != nil {
+		t.Fatalf("doctor --live-llm: %v", err)
+	}
+	// Pin the production const (~30s): a wrong default would hang diagnostics.
+	if !hadDeadline || remaining <= 29*time.Second || remaining > 30*time.Second {
+		t.Fatalf("hadDeadline=%v remaining=%v, want in (29s, 30s]", hadDeadline, remaining)
+	}
+}
+
+func TestDoctor_LiveLLM_ProbeTimeout(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.doctorLiveProbeTimeout = time.Millisecond
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &seqBlockThenAnswerModel{answer: "unused"}, nil //nolint:exhaustruct // calls zero
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorError {
+		t.Errorf("llmStatuses = %+v, want one Error status", u.llmStatuses)
 	}
 }
 

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -241,7 +241,7 @@ func TestDoctor_Help(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"Validate configuration", "connector", "verbose", "live read-only"} {
+	for _, want := range []string{"Validate configuration", "connector", "verbose", "live-llm", "live read-only"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("doctor help missing %q; got:\n%s", want, out)
 		}
@@ -268,6 +268,129 @@ func TestDoctor_DoesNotCallChatModel(t *testing.T) {
 	}
 }
 
+func TestDoctor_LiveLLM_OK(t *testing.T) {
+	t.Parallel()
+
+	const nonce = "DOCTOR-TESTNONCE"
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.doctorProbeNonce = nonce
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &fakeChatModel{ //nolint:exhaustruct // errs/calls not pre-set
+			responses: []*schema.Message{schema.AssistantMessage(nonce, nil)},
+		}, nil
+	}
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if err != nil {
+		t.Fatalf("doctor --live-llm: %v", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorOK {
+		t.Errorf("llmStatuses = %+v, want one OK status", u.llmStatuses)
+	}
+	if got := u.llmStatuses[0].Reason; got != "configuration valid; connectivity verified" {
+		t.Errorf("LLM Reason = %q, want connectivity-verified wording", got)
+	}
+	if !strings.Contains(errBuf.String(), "Doctor: ready") {
+		t.Errorf("stderr missing Doctor: ready; got %q", errBuf.String())
+	}
+}
+
+func TestDoctor_LiveLLM_InitFailure(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return nil, errors.New("bifrost init failed")
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorError {
+		t.Errorf("llmStatuses = %+v, want one Error status", u.llmStatuses)
+	}
+	if ExitCodeFor(err) != 1 {
+		t.Errorf("ExitCodeFor = %d, want 1", ExitCodeFor(err))
+	}
+}
+
+func TestDoctor_LiveLLM_GenerateFailure(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.doctorProbeNonce = "DOCTOR-TESTNONCE"
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &fakeChatModel{ //nolint:exhaustruct // responses unused
+			errs: []error{errors.New("provider down")},
+		}, nil
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].State != ui.ConnectorError {
+		t.Errorf("llmStatuses = %+v, want one Error status", u.llmStatuses)
+	}
+}
+
+func TestDoctor_LiveLLM_NonceMismatch(t *testing.T) {
+	t.Parallel()
+
+	u := &fakeUI{} //nolint:exhaustruct // recorders zero.
+	d := testDeps()
+	d.ui = u
+	d.doctorProbeNonce = "DOCTOR-EXPECTED"
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return &fakeChatModel{ //nolint:exhaustruct // errs unused
+			responses: []*schema.Message{schema.AssistantMessage("unrelated answer", nil)},
+		}, nil
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if len(u.llmStatuses) != 1 || u.llmStatuses[0].Reason != "live probe response mismatch" {
+		t.Errorf("llmStatuses = %+v, want mismatch reason", u.llmStatuses)
+	}
+}
+
+func TestDoctor_LiveLLM_SkippedWhenValidateLLMFails(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	d := testDeps()
+	d.loadConfig = func(string) (config.Config, error) {
+		return config.Config{}, nil //nolint:exhaustruct // empty LLM triggers ValidateLLM
+	}
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		called = true
+
+		return nil, errors.New("must not construct")
+	}
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	if called {
+		t.Fatal("--live-llm must not probe before ValidateLLM passes")
+	}
+}
+
 func TestSilenceGracefulStop_DoctorNotReady(t *testing.T) {
 	t.Parallel()
 
@@ -278,5 +401,17 @@ func TestSilenceGracefulStop_DoctorNotReady(t *testing.T) {
 	}
 	if !cmd.SilenceErrors {
 		t.Error("SilenceErrors should be set for ErrDoctorNotReady")
+	}
+}
+
+func TestNewDoctorProbeNonce(t *testing.T) {
+	t.Parallel()
+
+	a, b := newDoctorProbeNonce(), newDoctorProbeNonce()
+	if !strings.HasPrefix(a, "DOCTOR-") || len(a) < len("DOCTOR-")+8 {
+		t.Errorf("nonce = %q, want DOCTOR-<hex>", a)
+	}
+	if a == b {
+		t.Error("consecutive nonces must differ")
 	}
 }

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -397,6 +397,60 @@ func TestDoctor_LiveLLM_VerbosePrintsDetails(t *testing.T) {
 	}
 }
 
+func TestDoctor_LiveLLM_InitFailureVerbosePrintsDetails(t *testing.T) {
+	t.Parallel()
+
+	const leak = "sk-ABCDEFGHIJ0123456789abcd"
+	d := testDeps()
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return nil, errors.New("bifrost init failed: Incorrect API key: " + leak)
+	}
+
+	var errBuf bytes.Buffer
+
+	d.errOut = &errBuf
+
+	_, err := runWithArgs(t, d, []string{"doctor", "--live-llm", "-v"})
+	if !errors.Is(err, ErrLLMUnavailable) {
+		t.Fatalf("err = %v, want ErrLLMUnavailable", err)
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "details:") {
+		t.Errorf("stderr missing verbose details; got %q", out)
+	}
+	if strings.Contains(out, leak) {
+		t.Errorf("verbose details must redact credential-shaped text; got %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED:llm-api-key]") {
+		t.Errorf("verbose details missing llm-api-key redaction; got %q", out)
+	}
+}
+
+func TestDoctorLiveProbeConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := validCfg()
+	cfg.LLM.NetworkConfig.MaxRetries = 3
+	cfg.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds = 300
+
+	got := doctorLiveProbeConfig(cfg, 30*time.Second)
+	if got.LLM.NetworkConfig.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0", got.LLM.NetworkConfig.MaxRetries)
+	}
+	if got.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds != 30 {
+		t.Errorf("timeout = %d, want 30", got.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds)
+	}
+	if cfg.LLM.NetworkConfig.MaxRetries != 3 {
+		t.Error("doctorLiveProbeConfig must not mutate the caller's config")
+	}
+
+	tiny := doctorLiveProbeConfig(cfg, time.Millisecond)
+	if tiny.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds != 1 {
+		t.Errorf("sub-second timeout must clamp to 1s, got %d",
+			tiny.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds)
+	}
+}
+
 func TestDoctor_LiveLLM_NonceMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -448,11 +502,15 @@ func TestDoctor_LiveLLM_BoundsProbeContext(t *testing.T) {
 	d := testDeps()
 	var remaining time.Duration
 	var hadDeadline bool
-	d.newChatModel = func(ctx context.Context, _ config.Config, _ func(schema.Usage)) (chatModel, error) {
+	gotRetries := -1
+	var gotTimeout int
+	d.newChatModel = func(ctx context.Context, cfg config.Config, _ func(schema.Usage)) (chatModel, error) {
 		if dl, ok := ctx.Deadline(); ok {
 			hadDeadline = true
 			remaining = time.Until(dl)
 		}
+		gotRetries = cfg.LLM.NetworkConfig.MaxRetries
+		gotTimeout = cfg.LLM.NetworkConfig.DefaultRequestTimeoutInSeconds
 
 		return &fakeChatModel{ //nolint:exhaustruct // errs unused
 			responses: []*schema.Message{schema.AssistantMessage("DOCTOR-TEST-DEFAULT", nil)},
@@ -466,6 +524,12 @@ func TestDoctor_LiveLLM_BoundsProbeContext(t *testing.T) {
 	// Pin the production const (~30s): a wrong default would hang diagnostics.
 	if !hadDeadline || remaining <= 29*time.Second || remaining > 30*time.Second {
 		t.Fatalf("hadDeadline=%v remaining=%v, want in (29s, 30s]", hadDeadline, remaining)
+	}
+	if gotRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0 for the live probe", gotRetries)
+	}
+	if gotTimeout != 30 {
+		t.Errorf("DefaultRequestTimeoutInSeconds = %d, want 30", gotTimeout)
 	}
 }
 

--- a/internal/cli/doctor_nonce_shell.go
+++ b/internal/cli/doctor_nonce_shell.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// doctorProbeNonce builds a unique token for doctor --live-llm. Lives in the
+// shell so the gated doctor core never reaches crypto/rand directly.
+func doctorProbeNonce() string {
+	var b [16]byte
+	// crypto/rand.Read fills the whole buffer on success; a failure leaves zeros
+	// and we still emit a stable-shaped token rather than aborting doctor.
+	_, _ = rand.Read(b[:])
+
+	return "DOCTOR-" + hex.EncodeToString(b[:])
+}

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -163,6 +163,7 @@ type deps struct {
 	readStdin            func() (data string, truncated bool, err error)
 	interrupter          agent.Interrupter
 	version              string // pre-rendered `--version` output; resolved in newDeps.
+	doctorProbeNonce     string // test-only: fixed --live-llm probe token (empty → random).
 }
 
 // runRoot reads any piped stdin, resolves the invocation, and dispatches to run.

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -163,7 +163,9 @@ type deps struct {
 	readStdin            func() (data string, truncated bool, err error)
 	interrupter          agent.Interrupter
 	version              string // pre-rendered `--version` output; resolved in newDeps.
-	doctorProbeNonce     string // test-only: fixed --live-llm probe token (empty → random).
+	// newDoctorProbeNonce returns the nonce doctor --live-llm asks the model to
+	// echo. Production wires crypto/rand in the shell; tests inject a fixed value.
+	newDoctorProbeNonce func() string
 }
 
 // runRoot reads any piped stdin, resolves the invocation, and dispatches to run.

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -166,6 +166,9 @@ type deps struct {
 	// newDoctorProbeNonce returns the nonce doctor --live-llm asks the model to
 	// echo. Production wires crypto/rand in the shell; tests inject a fixed value.
 	newDoctorProbeNonce func() string
+	// doctorLiveProbeTimeout, when > 0, overrides doctorLiveProbeTimeout for
+	// doctor --live-llm so tests can assert deadline behavior without waiting 30s.
+	doctorLiveProbeTimeout time.Duration
 }
 
 // runRoot reads any piped stdin, resolves the invocation, and dispatches to run.

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -209,15 +209,16 @@ func testDeps() *deps {
 		newAuditSink: func(config.Config) (audit.Sink, func() error, error) {
 			return nil, func() error { return nil }, nil
 		},
-		newAgent:    agent.New,
-		ui:          &fakeUI{}, //nolint:exhaustruct // empty script: PromptUserInput EOFs immediately
-		out:         io.Discard,
-		errOut:      io.Discard,
-		cfg:         validCfg(),
-		stdinIsTTY:  true,
-		hasTerminal: true,
-		readStdin:   func() (string, bool, error) { return "", false, nil },
-		version:     "cynative 9.9.9\n  commit:   deadbeefcafe",
+		newAgent:            agent.New,
+		ui:                  &fakeUI{}, //nolint:exhaustruct // empty script: PromptUserInput EOFs immediately
+		out:                 io.Discard,
+		errOut:              io.Discard,
+		cfg:                 validCfg(),
+		stdinIsTTY:          true,
+		hasTerminal:         true,
+		readStdin:           func() (string, bool, error) { return "", false, nil },
+		version:             "cynative 9.9.9\n  commit:   deadbeefcafe",
+		newDoctorProbeNonce: func() string { return "DOCTOR-TEST-DEFAULT" },
 	}
 	d.run = d.runResearch
 

--- a/internal/cli/wire_shell.go
+++ b/internal/cli/wire_shell.go
@@ -131,16 +131,17 @@ func newDeps() *deps {
 
 			return audit.New(w, audit.WithActor(cfg.LLM.Provider+"/"+cfg.LLM.Model)), w.Close, nil
 		},
-		newAgent:    agent.New,
-		ui:          newUI(inR, promptW, editor, ctrl, state.Interrupted),
-		out:         os.Stdout,
-		errOut:      os.Stderr,
-		cfg:         config.Config{}, //nolint:exhaustruct // populated by PersistentPreRunE.
-		stdinIsTTY:  stdinIsTTY,
-		hasTerminal: hasTerminal,
-		readStdin:   readStdin,
-		interrupter: interrupter,
-		version:     versionString(),
+		newAgent:            agent.New,
+		ui:                  newUI(inR, promptW, editor, ctrl, state.Interrupted),
+		out:                 os.Stdout,
+		errOut:              os.Stderr,
+		cfg:                 config.Config{}, //nolint:exhaustruct // populated by PersistentPreRunE.
+		stdinIsTTY:          stdinIsTTY,
+		hasTerminal:         hasTerminal,
+		readStdin:           readStdin,
+		interrupter:         interrupter,
+		version:             versionString(),
+		newDoctorProbeNonce: doctorProbeNonce,
 	}
 	d.run = d.runResearch
 


### PR DESCRIPTION
## Summary
- Adds `--live-llm` (boolean, no shorthand) to `cynative doctor` per maintainer guidance on #193.
- Probe runs **only after** `ValidateLLM` passes: one tool-less nonce-echo `Generate`, then `Shutdown`.
- Success reason: `configuration valid; connectivity verified`. Failures render via `llmRuntimeStatus` (or a mismatch-specific status) and return `ErrLLMUnavailable` → exit 1.
- Default `doctor` unchanged (still does not construct a chat model).
- README one-liner documents the flag.

## Test plan
- [x] `go test ./internal/cli/ -run 'Doctor|NewDoctorProbeNonce'`
- [x] `golangci-lint run ./internal/cli/`
- [x] `make check-go` / Lint & Test on the PR
- [x] Optional manual: `cynative doctor --live-llm` with real `CYNATIVE_LLM_*`

Closes #193