### PR TITLE
ci: add a safe manual re-trigger for the release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,25 @@ on:
   push:
     branches:
       - main
+  # Recovery entry point (cynative#202). A failed pre-publish gate leaves the draft
+  # intact, but re-running that run reuses the secret values snapshotted when it was
+  # created (cli/cli#13522), so recovery needs a FRESH run. This trigger provides one
+  # without an artificial push to main: scripts/release/retrigger.sh.
+  #
+  # repository_dispatch rather than workflow_dispatch, deliberately. A dispatched
+  # workflow_dispatch run executes the definition from the CALLER's ref with repository
+  # secrets available, so any write-access user could dispatch a doctored branch copy
+  # and exfiltrate the release App key or the macOS signing secrets. A
+  # repository_dispatch run always executes the default branch's definition, so that
+  # path does not exist.
+  #
+  # Nothing in this workflow reads github.sha, github.ref, or github.event, so the
+  # dispatch path is behaviourally identical to the push path: every SHA flows from
+  # release-please's outputs, and the reusable gates pin their caller by
+  # github.workflow_ref, which still resolves to this file on refs/heads/main.
+  repository_dispatch:
+    types:
+      - release-retry
 
 permissions:
   contents: read
@@ -72,22 +91,25 @@ jobs:
       #       repos/cynative/cynative/issues/<pr>/labels/autorelease%3A%20tagged
       #     gh api repos/cynative/cynative/issues/<pr>/labels \
       #       -f "labels[]=autorelease: pending"
-      #   Then trigger a fresh run so release-please recreates the draft. If
-      #   the failure was a secret that had to be created or fixed, start a
-      #   NEW run (a push to main), do NOT re-run the failed one: GitHub
-      #   snapshots secret values at workflow-run-create time, so a re-run
-      #   reuses the stale values and fails the same way (cli/cli#13522).
-      #   That fresh run is a new push, so main HEAD advances past the release
-      #   PR's SHA, and a GitHub App token cannot create a release or tag ref at
-      #   a non-HEAD target_commitish (403 "Resource not accessible by
-      #   integration"). The same wall can appear WITHOUT a recovery: if the
-      #   release-PR-merge run is coalesced away by a later push in the
-      #   release-pipeline concurrency group, the run that executes re-derives
-      #   the release at the older release-PR SHA while starting at a newer HEAD.
-      #   BREAK-GLASS for either case, until a repository_dispatch re-trigger
-      #   (#202) and HEAD-safe targeting remove the need: temporarily point this
-      #   step's `token` and both ensure-tag `GH_TOKEN`s at a short-lived PAT
-      #   (contents + pull-requests write), recover, then revert and delete it.
+      #   Then start a FRESH run so release-please recreates the draft:
+      #     GH_TOKEN=<contents:write token> scripts/release/retrigger.sh \
+      #       cynative/cynative
+      #   Do NOT re-run the failed run: GitHub snapshots secret values at
+      #   workflow-run-create time, so a re-run reuses the stale values and
+      #   fails the same way (cli/cli#13522). The dispatch starts a genuinely
+      #   new run without advancing main, which a recovery push would do.
+      #
+      #   If the release/tag creation itself 403s with "Resource not
+      #   accessible by integration", the cause is the workflow-file guard,
+      #   NOT the release SHA being behind HEAD (non-HEAD targeting is not
+      #   restricted; verified by experiment). GitHub requires a token
+      #   authorized to modify workflows whenever the target commit's
+      #   .github/workflows/ content differs from the DEFAULT BRANCH's, on all
+      #   four of POST/PATCH /git/refs and /releases. The App holds
+      #   workflows: write and the four cynative token mints in this file pass
+      #   no permission-* inputs, so each inherits it; if this ever returns,
+      #   check that grant first (a mint that starts downscoping its
+      #   permissions would silently drop it).
       #   The pre-publish gate spans the release job, the smoke and e2e gates
       #   (macos-pkg-smoke, archive-smoke, connector-e2e, llm-smoke), and the
       #   publish job; a failure in any of them, up to and including the publish

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,21 @@ sh-test:
 		*) echo "FAIL: the publish gate in release.yaml is missing the required term [$$term]."; exit 1 ;; \
 		esac; \
 	done
+	@# The recovery path (cynative#202) is a workflow trigger, which nothing else
+	@# exercises: no test can dispatch it, and its absence is invisible until an
+	@# operator needs it mid-incident. Pin both triggers, comments stripped
+	@# (sed 's/#.*//') so the prose above them never satisfies the check:
+	@#   repository_dispatch/release-retry - the recovery entry point itself;
+	@#   push/main - so the recovery trigger can never be added in PLACE of the
+	@#     normal release path, which would stop releases entirely.
+	@release_on=$$(sed 's/#.*//' .github/workflows/release.yaml | \
+		awk '/^[a-zA-Z]/ && !/^on:/ {inon=0} /^on:/{inon=1} inon{print}'); \
+	for term in "repository_dispatch:" "- release-retry" "push:" "- main"; do \
+		case "$$release_on" in \
+		*"$$term"*) ;; \
+		*) echo "FAIL: release.yaml's on: block is missing [$$term] - the recovery re-trigger (scripts/release/retrigger.sh) or the normal push trigger would not fire."; exit 1 ;; \
+		esac; \
+	done
 	@# The api-key legs read exactly two secrets across the workflow_call boundary.
 	@# release.yaml forwards ONLY these two names, never secrets: inherit. Pin the
 	@# boundary from both sides, comments stripped (sed 's/#.*//') so prose never counts:
@@ -229,7 +244,7 @@ sh-test:
 		echo "FAIL: release.yaml uses 'secrets: inherit' - reusable gates must be granted only the exact named secrets they need, never the full set."; \
 		exit 1; \
 	fi
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + retrigger unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + llm-smoke secret-reference pin)"
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + retrigger unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + release trigger pin + llm-smoke secret-reference pin)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ sh-test:
 	@sh test/ci-gate-contract.unit.test.sh
 	@sh test/ci-gate-assert.unit.test.sh
 	@sh test/llm-smoke-roster.unit.test.sh
+	@sh test/retrigger.unit.test.sh
 	@PYTHONDONTWRITEBYTECODE=1 sh -c 'for f in test/lib/connector-audit-parser.py test/lib/connector_audit/*.py test/lib/connector_audit/specs/*.py; do python3 -B -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$$f" || { echo "FAIL: python syntax error in $$f"; exit 1; }; done'
 	@files=$$(git ls-files 'test/connector.*.e2e.test.sh') || { echo "git ls-files failed for connector selftests" >&2; exit 1; }; \
 	 [ -n "$$files" ] || { echo "no connector e2e selftests matched test/connector.*.e2e.test.sh" >&2; exit 1; }; \
@@ -228,7 +229,7 @@ sh-test:
 		echo "FAIL: release.yaml uses 'secrets: inherit' - reusable gates must be granted only the exact named secrets they need, never the full set."; \
 		exit 1; \
 	fi
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + llm-smoke secret-reference pin)"
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + retrigger unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + llm-smoke secret-reference pin)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/scripts/release/retrigger.sh
+++ b/scripts/release/retrigger.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Start a FRESH Release Pipeline run without pushing to main.
+#
+# Why this exists: a failed pre-publish gate leaves the draft intact and recoverable,
+# but re-running the failed run does not help when the fix was a secret. GitHub
+# snapshots secret values at workflow-run-create time, not at re-run time
+# (cli/cli#13522), so a re-run reuses the stale values and fails the same way.
+#
+# repository_dispatch, not workflow_dispatch: a repository_dispatch run always executes
+# the workflow definition from the default branch, never a caller-selected ref, so there
+# is no path for a doctored branch copy to reach the release App key or the macOS
+# signing secrets.
+#
+# release-please phase 1 acts only on a pending release PR, so a dispatch with nothing
+# pending is a no-op rather than a spurious release.
+#
+# Usage: retrigger.sh <owner/repo>   (requires GH_TOKEN with contents: write)
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: retrigger.sh <owner/repo>   (requires GH_TOKEN)" >&2
+  exit 1
+fi
+repo=$1
+
+# Require owner/name. A bare name would make gh resolve the path against the current
+# directory's git remote, which is not necessarily the repo the operator meant.
+case "${repo}" in
+*/*) ;;
+*)
+  echo "::error::repo must be owner/name, got '${repo}'" >&2
+  exit 1
+  ;;
+esac
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::error::GH_TOKEN is not set; a dispatch needs a token with contents: write" >&2
+  exit 1
+fi
+
+if ! gh api -X POST "repos/${repo}/dispatches" -f event_type=release-retry; then
+  echo "::error::dispatch to ${repo} failed; no run was started" >&2
+  exit 1
+fi
+
+echo "dispatched release-retry to ${repo}: a fresh Release Pipeline run is starting"
+echo "watch it with: gh run list --workflow=release.yaml --repo ${repo} --limit 3"

--- a/scripts/release/retrigger.sh
+++ b/scripts/release/retrigger.sh
@@ -15,7 +15,7 @@
 # pending is a no-op rather than a spurious release.
 #
 # Usage: retrigger.sh <owner/repo>   (requires GH_TOKEN with contents: write)
-set -eu
+set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
   echo "usage: retrigger.sh <owner/repo>   (requires GH_TOKEN)" >&2

--- a/test/retrigger.unit.test.sh
+++ b/test/retrigger.unit.test.sh
@@ -30,7 +30,7 @@ run() {
 		PATH="$bindir:$PATH"
 		GH_TOKEN=${GH_TOKEN-stub-token}
 		export PATH GH_TOKEN
-		sh "$script" "$@"
+		bash "$script" "$@"
 	)
 }
 
@@ -75,7 +75,7 @@ write_gh 'exit 0'
 	PATH="$bindir:$PATH"
 	unset GH_TOKEN
 	export PATH
-	sh "$script" cynative/cynative
+	bash "$script" cynative/cynative
 ) >"$out" 2>"$err" && rc=0 || rc=$?
 check "$rc" 1 "missing GH_TOKEN exits 1"
 

--- a/test/retrigger.unit.test.sh
+++ b/test/retrigger.unit.test.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Unit tests for scripts/release/retrigger.sh, the release-pipeline re-trigger. Offline
+# and hermetic: a stub gh on PATH stands in for every API call, so no test can reach
+# GitHub.
+#
+# What matters here is that the script fails closed. A re-trigger that silently does
+# nothing (bad repo argument, missing token, a dispatch the API rejected) would leave an
+# operator believing recovery is under way while the draft sits untouched.
+# shellcheck disable=SC2030,SC2031
+set -eu
+
+script=scripts/release/retrigger.sh
+fails=0
+
+bindir=$(mktemp -d)
+out=$(mktemp)
+err=$(mktemp)
+cleanup() { rm -rf "$bindir" "$out" "$err"; }
+trap cleanup EXIT
+
+# write_gh BODY - install a stub gh whose behaviour is BODY.
+write_gh() {
+	printf '#!/bin/sh\n%s\n' "$1" >"$bindir/gh"
+	chmod +x "$bindir/gh"
+}
+
+# run ARGS... - run the script with the stub gh first on PATH.
+run() {
+	(
+		PATH="$bindir:$PATH"
+		GH_TOKEN=${GH_TOKEN-stub-token}
+		export PATH GH_TOKEN
+		sh "$script" "$@"
+	)
+}
+
+check() {
+	if [ "$1" = "$2" ]; then
+		printf '  ok: %s\n' "$3"
+	else
+		printf 'FAIL: %s (expected exit %s, got %s)\n' "$3" "$2" "$1" >&2
+		sed 's/^/    stderr: /' "$err" >&2
+		fails=$((fails + 1))
+	fi
+}
+
+# A dispatch the API accepts is the success path.
+write_gh 'exit 0'
+run cynative/cynative >"$out" 2>"$err" && rc=0 || rc=$?
+check "$rc" 0 "accepted dispatch exits 0"
+if ! grep -q 'release-retry' "$out"; then
+	printf 'FAIL: success output does not name the release-retry event type\n' >&2
+	fails=$((fails + 1))
+fi
+
+# A rejected dispatch must fail, never report success.
+write_gh 'echo "{\"message\":\"Not Found\"}" >&2; exit 1'
+run cynative/cynative >"$out" 2>"$err" && rc=0 || rc=$?
+check "$rc" 1 "rejected dispatch exits 1"
+
+# A missing repo argument is a usage error, not a dispatch against an empty repo.
+write_gh 'exit 0'
+run >"$out" 2>"$err" && rc=0 || rc=$?
+check "$rc" 1 "missing repo argument exits 1"
+
+# A repo argument that is not owner/name is rejected before any API call: a bare name
+# would otherwise POST to a path gh resolves against the current directory's remote.
+write_gh 'exit 0'
+run cynative >"$out" 2>"$err" && rc=0 || rc=$?
+check "$rc" 1 "repo argument without a slash exits 1"
+
+# No GH_TOKEN means no dispatch: failing here is clearer than a gh auth error.
+write_gh 'exit 0'
+(
+	PATH="$bindir:$PATH"
+	unset GH_TOKEN
+	export PATH
+	sh "$script" cynative/cynative
+) >"$out" 2>"$err" && rc=0 || rc=$?
+check "$rc" 1 "missing GH_TOKEN exits 1"
+
+if [ "$fails" -ne 0 ]; then
+	printf 'FAIL: %s retrigger.sh unit test(s) failed\n' "$fails" >&2
+	exit 1
+fi
+printf 'OK: retrigger.sh unit tests\n'

--- a/test/retrigger.unit.test.sh
+++ b/test/retrigger.unit.test.sh
@@ -28,7 +28,11 @@ write_gh() {
 run() {
 	(
 		PATH="$bindir:$PATH"
-		GH_TOKEN=${GH_TOKEN-stub-token}
+		# Colon form, so an ambient GH_TOKEN= (empty, not unset) still gets the
+		# stub. The no-colon form would preserve the empty value and the script
+		# would exit on its own token check before reaching the stub gh, failing
+		# a test that is supposed to be hermetic.
+		GH_TOKEN=${GH_TOKEN:-stub-token}
 		export PATH GH_TOKEN
 		bash "$script" "$@"
 	)


### PR DESCRIPTION
Closes #202.

## What

- `repository_dispatch` trigger (`release-retry`) on the Release Pipeline, plus
  `scripts/release/retrigger.sh` to start a fresh run with one command.
- Corrected RECOVERY notes in the release job, and the temporary PAT break-glass removed.
- `make sh-test` now pins both the recovery trigger and the normal push trigger.

## Why repository_dispatch and not workflow_dispatch

A `workflow_dispatch` run executes the workflow definition from the dispatched ref with repository
secrets available, so any write-access user could dispatch a doctored branch copy and exfiltrate
the release App key or the macOS signing secrets. A `repository_dispatch` run always executes the
default branch's definition, so that path does not exist.

This is a drop-in change because nothing in `release.yaml` reads `github.sha`, `github.ref`, or
`github.event`: every SHA flows from release-please's outputs, and the reusable gates pin their
caller by `github.workflow_ref`, which still resolves to this file on `refs/heads/main`.

## The recovery notes were wrong

The notes said a GitHub App installation token cannot create a release or tag ref at a non-HEAD
`target_commitish`. That is false, and it is what sent the v1.7.0 recovery down the PAT path. An
experiment against this repository (throwaway tags at pinned SHAs, run twice, cleaned up) showed an
App token creates both at older commits without complaint. The real rule, documented on all four of
`POST`/`PATCH` `/git/refs` and `/releases`, is the workflow-file guard: the token must be authorized
to modify workflows when the target commit's `.github/workflows/` content differs from the **default
branch's**.

| target | workflows differ from main | App without `workflows` | App with `workflows` |
|---|---|---|---|
| main HEAD | no | created | created |
| older commit | no | created | created |
| older commit | yes | 403 | created |

v1.7.0 fits exactly: PR #201's recovery push itself edited `release.yaml`, so the release SHA
diverged from main under `.github/workflows/` and the App (which then held no `workflows`
permission) was refused on both `POST /releases` and `POST /git/refs`. "Non-HEAD" was a
coincidence, since every failing run was also a workflow-editing run.

`cynative-deploy-bot` now holds `workflows: write`, and the four cynative token mints in this
workflow pass no `permission-*` inputs so each inherits it, which is why no wiring change is needed
here. The rewritten notes say to check that grant first if the 403 ever returns.

## Deliberately not included

- **No concurrency change.** A per-SHA group would remove the run-coalescing hazard but make
  concurrent release-please invocations routine: a push landing mid-release would let the phase-2
  `candidate-pr` job race phase-1 on the same release-PR labels. The grant already defuses what made
  coalescing dangerous, so serialization is worth more.
- **No preflight workflow-diff check**, for the same reason.

## Checks

`make check` green locally. The new pin was verified to fail closed: removing the trigger, removing
the `push` trigger, and leaving the trigger only inside a comment each produce a `FAIL:` line.

Note the trigger cannot be exercised until it is on the default branch, since `repository_dispatch`
only fires for workflow files on the default branch. Post-merge check is one dispatch with no
release PR pending, which should be a clean no-op.