### PR TITLE
feat: publish a cosign signature alongside the release archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,13 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # id-token: write lets cosign mint a keyless Fulcio certificate to sign
+    # checksums.txt (the signs block in .goreleaser.yaml). A job-level permissions
+    # block REPLACES the workflow-level one rather than extending it - every
+    # permission left unnamed becomes none - so contents: read is restated here.
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       # Consumed directly by the pre-publish smoke, publish, candidate-pr,
       # and post-publish channel jobs below (each lists `release` in its own
@@ -47,7 +54,8 @@ jobs:
       release_id: ${{ steps.draft.outputs.release_id }}
     # Bound the job: the concurrency group means a wedged run blocks later
     # releases for the default 360 minutes otherwise. The budget covers the
-    # capped long steps (goreleaser 35, pkg build/notarize 20, audit 10) plus
+    # capped long steps (goreleaser 35, pkg build/notarize 20, audit 10, cosign
+    # bootstrap 5, signature verification 5) plus
     # every short step with slack to spare, so the job limit can never fire
     # mid-step. Publish and its verification live in the downstream publish
     # job, gated on the pre-publish gates (macos-pkg-smoke, archive-smoke,
@@ -192,6 +200,46 @@ jobs:
           chmod 600 "${d}/app.p12" "${d}/app.pw"
           { echo "MACOS_SIGN_P12_FILE=${d}/app.p12"; echo "MACOS_SIGN_PASSWORD_FILE=${d}/app.pw"; } >> "${GITHUB_ENV}"
 
+      # Pinned cosign, downloaded and SHA-256 verified, mirroring ci.yaml's shellcheck
+      # bootstrap. sigstore/cosign-installer is deliberately not used: this job handles
+      # the App private key and the Apple signing material, and a pinned download does
+      # the same work without adding a third-party action to its trusted set (it is
+      # also not on the repo's Actions allowlist). The release_created guard is
+      # required: on an ordinary push the checkout above is skipped, so there would be
+      # no Makefile for `make print-*` to read.
+      - name: Bootstrap pinned cosign
+        if: ${{ steps.release-please.outputs.release_created == 'true' }}
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          # Version and digest come from the Makefile (single source of truth).
+          ver="$(make -s print-COSIGN_VERSION)"
+          sha="$(make -s print-COSIGN_SHA256)"
+          curl -sSfL --max-time 240 \
+            "https://github.com/sigstore/cosign/releases/download/v${ver}/cosign-linux-amd64" \
+            -o /tmp/cosign
+          echo "${sha}  /tmp/cosign" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 /tmp/cosign "$HOME/.local/bin/cosign"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # GITHUB_PATH only applies to LATER steps, so call it by path here.
+          "$HOME/.local/bin/cosign" version
+
+      # Refresh the installation token immediately before GoReleaser's uploads. The
+      # token minted at job start has a 60-minute lifetime, and the cosign bootstrap
+      # plus the signing round-trip to Fulcio and Rekor lengthen the run before the
+      # first draft-critical write. The separate pre-publish refresh further down still
+      # covers the pkg upload and the draft assertions.
+      - name: Refresh App Token (goreleaser)
+        id: goreleaser-token
+        if: ${{ steps.release-please.outputs.release_created == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cynative
+
       # Builds and signs darwin binaries via goreleaser hooks (signing material
       # is available via MACOS_SIGN_P12_FILE/MACOS_SIGN_PASSWORD_FILE exported
       # in the previous step). GoReleaser no longer notarizes; the dedicated
@@ -203,10 +251,33 @@ jobs:
         # ever schedule (publication itself happens in the publish job).
         timeout-minutes: 35
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.goreleaser-token.outputs.token }}
         run: |
           set -o pipefail
           go tool goreleaser release --clean 2>&1 | tee /tmp/goreleaser.log
+
+      # Scorecard's Signed-Releases check scores a filename and never opens the file,
+      # so a correctly named but malformed bundle would look signed while proving
+      # nothing. Verify what goreleaser just produced, pinned to this workflow's own
+      # Fulcio identity and issuer, while the release is still an editable draft: a bad
+      # bundle, a signature bound to an unexpected identity, or a missing transparency
+      # log entry stops the release here with nothing published.
+      #
+      # The identity is this workflow's job_workflow_ref, which is stable across both
+      # triggers: push runs on main, and repository_dispatch always uses the default
+      # branch's ref. Checking out the release SHA does not change it.
+      - name: Verify the release signature
+        if: ${{ steps.release-please.outputs.release_created == 'true' }}
+        timeout-minutes: 5
+        env:
+          COSIGN_IDENTITY: https://github.com/cynative/cynative/.github/workflows/release.yaml@refs/heads/main
+          COSIGN_ISSUER: https://token.actions.githubusercontent.com
+        run: |
+          set -euo pipefail
+          cosign verify-blob dist/checksums.txt \
+            --bundle dist/checksums.txt.sigstore.json \
+            --certificate-identity "${COSIGN_IDENTITY}" \
+            --certificate-oidc-issuer "${COSIGN_ISSUER}"
 
       # Assert the release binary is version-stamped, not "dev". The Go linker
       # silently ignores an unknown -X symbol path, so a typo'd, renamed, or
@@ -339,8 +410,10 @@ jobs:
       # Hand-off to the pre-publish smoke jobs and the publish job. Sole
       # producer of this artifact (downstream jobs only consume it):
       # macos-pkg-smoke consumes the pkgs, archive-smoke consumes the
-      # Linux/Windows archives plus checksums.txt, and the publish job
-      # re-asserts the draft against these manifests. "Assert exact asset
+      # Linux/Windows archives plus checksums.txt, the cosign bundle rides
+      # along unread (it is in the manifest, so the publish job's re-assert
+      # covers it), and the publish job re-asserts the draft against these
+      # manifests. "Assert exact asset
       # set" above proved the draft assets' sha256 digests equal these local
       # bytes, so smoking the artifact is provenance-equivalent to smoking
       # the draft assets, with no token handed to the smoke jobs. Staged

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,6 +39,34 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+# Sign checksums.txt with cosign keyless (Fulcio + Rekor, authenticated by the GitHub
+# Actions OIDC token) into a single Sigstore bundle. Signing the manifest authenticates
+# every archive transitively: verify the bundle, then check an archive's sha256 against
+# its row. This is what makes a release verifiable without the gh CLI, and the only part
+# of the pipeline's integrity story that OpenSSF Scorecard can see.
+#
+# goreleaser uploads the bundle to the adopted draft alongside the archives, so it needs
+# no separate upload path, but scripts/release/assert-assets.sh must admit the
+# "Signature" artifact type or the exact-asset-set gate rejects it as surplus.
+#
+# No `certificate:` field on purpose: the bundle already carries the Fulcio certificate
+# and the transparency-log proof, and a certificate artifact is one the asset gate
+# deliberately does not admit.
+#
+# No --new-bundle-format: it exists in cosign v3.1.2 but already defaults to true and is
+# deprecated because that will become the only format. No --oidc-provider either:
+# sign-blob builds its KeyOpts without copying it (unlike `sign`), so the flag is
+# silently ignored on this path. Ambient discovery is the working route.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    artifacts: checksum
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "--yes"
+      - "${artifact}"
+
 scoops:
   - repository:
       owner: cynative

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,13 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
   Then the Scoop-manifest
   renderer and both strict asset-digest lookups (`sha_for` over the manifest TSV,
   `sha_for_checksums` over `checksums.txt`; each must fail on a duplicate row rather than return
-  the first match) unit tests, the release asset-set assertion's
-  fail-closed-on-missing-digest unit tests, the per-package changelog override renderer unit
+  the first match) unit tests, the release asset-set assertion's unit tests (the
+  fail-closed-on-missing-digest branches plus the generate-mode artifact-type allowlist:
+  Archive, Checksum and Signature, never Binary or Certificate), the release signing contract
+  pins (`test/release-signing.unit.test.sh`, tying the `.goreleaser.yaml` signs stanza, the
+  asset gate's admitted type set, the snapshot sign skip, and the release workflow's OIDC
+  permission, guarded steps and pinned verification identity together, since drift between
+  them would first fail during a live release), the per-package changelog override renderer unit
   tests, the shared audit-parser python syntax gate, all three connector suites' offline
   audit-parser selftests, and the shared-machinery selftest).
   Install-free: presence-checks `shellcheck`, PowerShell 7, and `python3` up front and fails with
@@ -67,8 +72,10 @@ writes the gitignored `*_mock_test.go` mocks. **Run `make generate` before
 - Run a single test: `go test ./internal/agent -run TestName` (add `-v` for output, `-count=1`
   to skip cache).
 - Build the binary: `go build ./cmd/cynative` (or `go run ./cmd/cynative -p "..."`).
-- `make snapshot`: builds the release archives via a goreleaser snapshot (no publish; goreleaser
-  runs no before-hook, so snapshot and release share one prep path, and dependency tidiness is
+- `make snapshot`: builds the release archives via a goreleaser snapshot (no publish, and
+  `--skip=sign` because cosign keyless signing needs a GitHub Actions OIDC token no local run
+  has; goreleaser runs no before-hook, so snapshot and release otherwise share one prep path,
+  and dependency tidiness is
   enforced separately, non-mutating, by `mod-tidy-check` in the gate). `make install-e2e`:
   standalone release-confidence check, not part of `make check`; builds the snapshot, then runs
   the real `install.sh` against a loopback fixture server (`test/install.e2e.test.sh`, needs
@@ -895,7 +902,7 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   degrading. `deps` commits
   still cut patch releases; `release-please-config.json` pins the visible section list
   explicitly, so re-check it when release-please is bumped. `.goreleaser.yaml` handles binary
-  builds for release tags, with four contracts worth treating as untouchable:
+  builds for release tags, with five contracts worth treating as untouchable:
   `draft: true` + `use_existing_draft: true` + `mode: keep-existing` is the **draft-adoption
   handshake** (goreleaser adopts release-please's draft, matched by draft title == the git tag
   string, keeps its changelog body, uploads, and stops; with `draft: true` its publish step is a
@@ -903,11 +910,27 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   `scoops[0].skip_upload: true` makes goreleaser's local Scoop manifest inert, since
   `render-scoop.sh` is the authoritative renderer; the darwin post-build hook
   `scripts/release/sign-darwin-binary.sh` (snapshot-skips, asserts a Developer ID Application
-  cert, verifies hardened-runtime flags before replacing the binary); and
+  cert, verifies hardened-runtime flags before replacing the binary);
   `.goreleaser/entitlements.plist`'s `allow-unsigned-executable-memory` — **without it the
   notarized macOS binary is SIGKILLed on the first Bifrost JSON marshal**, because
   bytedance/sonic JIT-compiles serializers onto non-MAP_JIT executable pages that the hardened
-  runtime forbids. The Release Pipeline splits at the publish boundary: the `release`
+  runtime forbids; and the `signs:` block, which signs `checksums.txt` with cosign keyless
+  into `checksums.txt.sigstore.json`. That asset is what makes a release verifiable offline
+  without `gh`, and the only part of the integrity story OpenSSF Scorecard can see (it scores
+  filenames only, per release rather than per asset, averaged over the last five releases, so
+  the score climbs gradually and the file is never opened). Three things hold it together and
+  are pinned by `test/release-signing.unit.test.sh`: the `release` job's own `permissions:`
+  block (`contents: read` **and** `id-token: write`, since a job-level block replaces the
+  workflow-level one rather than extending it), `assert-assets.sh` admitting the `Signature`
+  artifact type (without it the bundle is surplus and the exact-asset-set gate rejects the
+  release), and the pre-publish `cosign verify-blob` pinned to this workflow's own Fulcio
+  identity, which is what stops a correctly named but worthless bundle from shipping. cosign
+  is a hand-bumped pinned binary (`COSIGN_VERSION`/`COSIGN_SHA256` in the `Makefile`,
+  downloaded and SHA-256 verified in the job) rather than an action or a `go tool`:
+  `sigstore/cosign-installer` is not on the Actions allowlist and this is the one job holding
+  the App key and the Apple signing material, while promoting cosign to the tool block would
+  add 82 module requirements and a 4-minute cold build to every release. The Release Pipeline
+  splits at the publish boundary: the `release`
   job builds, signs, and statically asserts everything, then hands the draft's exact asset set
   (pkgs, archives, manifests) to downstream jobs as the `release-artifacts` workflow artifact;
   the `macos-pkg-smoke` job (pinned `macos-26` + `macos-26-intel`, no secrets) runs

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ SHELLCHECK_SHA256 := 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e2
 PESTER_VERSION := 5.7.1
 PSSCRIPTANALYZER_VERSION := 1.25.0
 
+# Pinned release tooling. Same story as the check-scripts pins above (no Dependabot
+# ecosystem for raw binaries, so bump by hand), but a separate block because these are
+# used by the release pipeline rather than by check-scripts. Bump to the latest cosign
+# release and take the digest from the cosign-linux-amd64 row of that release's
+# checksums file.
+COSIGN_VERSION := 3.1.2
+COSIGN_SHA256 := f7622ed3cf22e55e1ae6377c080979ff77a22da9981c11df222a2e444991e7cf
+
 # Every workflow that is callable as a release gate. Each must carry exactly one
 # EXPECTED_CALLER pin naming TRUSTED_CALLER; sh-test enforces that.
 GATE_WORKFLOWS := .github/workflows/connector-e2e.yaml .github/workflows/llm-smoke.yaml
@@ -281,8 +289,15 @@ print-%:
 # so the local install-e2e target and the CI install-e2e jobs share one definition of
 # the goreleaser flags (no drift between the Makefile and the workflow). goreleaser
 # no longer runs a before-hook, so snapshot and release share one prep path.
+#
+# --skip=sign: the signs block in .goreleaser.yaml signs checksums.txt with cosign
+# keyless, which needs a GitHub Actions OIDC token no local run has. --snapshot only
+# implies skips for publish, announce and validate, and the sign pipe skips only on an
+# explicit --skip=sign, so without this a snapshot (and the install-e2e that shells out
+# to it) would try to sign and fail. goreleaser v2.17.1's signs schema has no `if` field
+# and rejects unknown ones, so this flag is the only route.
 snapshot:
-	go tool goreleaser release --snapshot --clean
+	go tool goreleaser release --snapshot --clean --skip=sign
 
 # install-e2e: real-artifact install e2e for release confidence (issue #41). Standalone
 # (NOT part of `make check`): builds the release archives via `snapshot`, serves the Linux

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,13 @@ pwsh-test:
 # library unit tests (test/lib/e2e-guardrails.sh), the shared connector e2e shell
 # orchestration unit tests (test/lib/connector-e2e.sh: arbitrate + connector_run_phase
 # + e2e_pin_audit_size), the per-package changelog override renderer unit tests
-# (test/dependabot-override.unit.test.sh), the release asset-set assertion script's
-# fail-closed-on-missing-digest unit tests (test/assert-assets.unit.test.sh), an AST
+# (test/dependabot-override.unit.test.sh), the release asset-set assertion script's unit
+# tests (test/assert-assets.unit.test.sh: the fail-closed-on-missing-digest branches plus
+# the generate-mode artifact-type allowlist), the release signing contract pins
+# (test/release-signing.unit.test.sh: the .goreleaser.yaml signs stanza, the asset gate's
+# admitted type set, the snapshot sign skip, and the release workflow's OIDC permission,
+# guarded steps and pinned verification identity, none of which any other gate checks and
+# all of which would first fail during a live release), an AST
 # syntax check of every file in the shared connector audit-parser package
 # (test/lib/connector-audit-parser.py,
 # test/lib/connector_audit/*.py, and its specs/), all three connector suites' offline
@@ -154,6 +159,7 @@ sh-test:
 	@sh test/render-scoop.unit.test.sh
 	@sh test/dependabot-override.unit.test.sh
 	@sh test/assert-assets.unit.test.sh
+	@sh test/release-signing.unit.test.sh
 	@sh test/ci-gate-contract.unit.test.sh
 	@sh test/ci-gate-assert.unit.test.sh
 	@sh test/llm-smoke-roster.unit.test.sh
@@ -252,7 +258,7 @@ sh-test:
 		echo "FAIL: release.yaml uses 'secrets: inherit' - reusable gates must be granted only the exact named secrets they need, never the full set."; \
 		exit 1; \
 	fi
-	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + retrigger unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + release trigger pin + llm-smoke secret-reference pin)"
+	@echo "OK: sh-test (install.sh unit + loopback smoke + e2e guardrails unit + connector-e2e unit + render-scoop unit + dependabot-override unit + assert-assets unit + release-signing contract pins + ci-gate-contract unit + ci-gate-assert unit + llm-smoke roster unit + retrigger unit + python syntax gate + connector audit parsers + shared-machinery selftest + gate trusted-caller pin check + release publish-gate pin check + release trigger pin + llm-smoke secret-reference pin)"
 
 SHELL_COMPLEXITY_MAX := 6
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ scoop install cynative
 **macOS (manual):** download `cynative_Darwin_arm64.pkg` (Apple Silicon) or `cynative_Darwin_x86_64.pkg` (Intel) from the [releases page](https://github.com/cynative/cynative/releases) and install with `sudo installer -pkg <file> -target /` (or double-click). These are signed, notarized and **stapled** - no first-run Gatekeeper prompt. The raw `cynative_Darwin_*.tar.gz` archives remain for scripting/CI; a quarantined tarball binary's first GUI launch needs internet for the online notarization check (terminal/`install.sh`/Homebrew use is unaffected).
 
 **Linux / Windows (manual):** download a prebuilt binary and `checksums.txt` from the [releases page](https://github.com/cynative/cynative/releases), verify the SHA-256, and put the binary on your `PATH`. Single static binary, no dependencies.
+
+**Verify a release signature (optional).** New releases ship `checksums.txt.sigstore.json`, a [Sigstore](https://www.sigstore.dev/) bundle signing `checksums.txt` with a keyless certificate bound to this repo's release workflow. Authenticate the manifest, then check your archive against it:
+
+```bash
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity "https://github.com/cynative/cynative/.github/workflows/release.yaml@refs/heads/main" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+grep cynative_Linux_x86_64.tar.gz checksums.txt | sha256sum -c -      # Linux
+grep cynative_Darwin_arm64.tar.gz checksums.txt | shasum -a 256 -c -  # macOS
+```
+```powershell
+(Get-FileHash .\cynative_Windows_x86_64.zip -Algorithm SHA256).Hash.ToLower()
+Select-String -Path checksums.txt -Pattern cynative_Windows_x86_64.zip
+```
+
+This covers the archives named in `checksums.txt`. The `.pkg` installers are Developer ID signed, notarized and stapled instead, and every asset is additionally covered by the GitHub release attestation (`gh release verify <tag>`). Two limits worth knowing: `cosign` fetches Sigstore's trust root over the network unless you pass `--trusted-root`, and because the file names carry no version, the signature proves origin and integrity but not which release a loose set of files came from - the release URL or `gh release verify` is what binds a version.
 </details>
 
 ## LLM providers

--- a/scripts/release/assert-assets.sh
+++ b/scripts/release/assert-assets.sh
@@ -8,7 +8,11 @@
 #   assert-assets.sh generate <dist-dir>
 #     Print the expected release-asset manifest as sorted TSV
 #     "name<TAB>sha256<TAB>path", derived from goreleaser's dist/artifacts.json.
-#     Covers exactly what goreleaser uploads: archives and the checksums file.
+#     Covers exactly what goreleaser uploads: archives, the checksums file, and the
+#     cosign bundle signing it (type "Signature"). "Certificate" is deliberately not
+#     admitted: the bundle form emits none, so if a `certificate:` field is ever added
+#     to .goreleaser.yaml's signs block the release fails closed on the surplus asset
+#     rather than publishing an unasserted one.
 #     Columns 1-2 are the assertion key (assert mode below); column 3 is the
 #     local path the release job stages into the release-artifacts hand-off
 #     (downstream consumers never dereference it).
@@ -21,7 +25,7 @@ if [ "${1:-}" = "generate" ]; then
   dist=$2
 
   jq -r '.[]
-    | select(.type == "Archive" or .type == "Checksum")
+    | select(.type == "Archive" or .type == "Checksum" or .type == "Signature")
     | [.name, .path] | @tsv' "${dist}/artifacts.json" |
     while IFS=$'\t' read -r name path; do
       # Bare assignment so a sha256sum failure aborts the script (an argument

--- a/test/assert-assets.unit.test.sh
+++ b/test/assert-assets.unit.test.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 # assert-assets.unit.test.sh - offline unit tests for the release asset-set
-# assertion script (scripts/release/assert-assets.sh), cynative#155 item 3.
+# assertion script (scripts/release/assert-assets.sh), cynative#155 item 3 and #180.
 #
-# Hermetic: no network, no credentials, no real gh CLI. Stubs `gh` on PATH to
-# serve a fixed release-assets listing, exercising the branch where the GitHub
-# API reports a null/empty digest for an asset: the script must fail closed
-# (nonzero exit, an ::error line) rather than falling back to downloading the
-# asset body and hashing it locally. Run by `make sh-test`.
+# Hermetic: no network, no credentials, no real gh CLI. Two halves:
+#   assert mode - stubs `gh` on PATH to serve a fixed release-assets listing,
+#   exercising the branch where the GitHub API reports a null/empty digest for an
+#   asset: the script must fail closed (nonzero exit, an ::error line) rather than
+#   falling back to downloading the asset body and hashing it locally.
+#   generate mode - drives a synthetic dist/artifacts.json and pins the artifact-type
+#   allowlist (Archive, Checksum, Signature; never Binary or Certificate), the
+#   LC_ALL=C row ordering, the frozen digests, and the missing-path abort.
+# Run by `make sh-test`.
 set -eu
 
 here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
@@ -103,6 +107,68 @@ if (
 	grep -q 'no API digest' "$tmp/err2.log" || exit 1  # explicit ::error, not a silent failure
 	exit 0
 ); then pass "assert-assets fails closed on an empty-string digest, never downloads the asset"; else fail "empty digest fail-closed"; fi
+
+# ---- generate: exactly the release-uploadable types, sorted, with real digests ----
+# One deliberately scrambled fixture proves four things at once: the two long-standing
+# inclusions (Archive, Checksum), the signature bundle (Signature), and both intentional
+# exclusions (Binary is not a release asset; Certificate is excluded so that adding a
+# `certificate:` field to .goreleaser.yaml's signs block fails the release closed on a
+# surplus asset instead of publishing an unasserted one). Digests are frozen: the
+# fixture files hold fixed content whose sha256 is hardcoded below, so a change to how
+# the digest is computed fails rather than silently agreeing with itself.
+if (
+	fix="$tmp/fix"
+	mkdir -p "$fix"
+	printf '%s' alpha   > "$fix/darwin"
+	printf '%s' bravo   > "$fix/linux"
+	printf '%s' charlie > "$fix/sums"
+	printf '%s' delta   > "$fix/sig"
+	printf '%s' alpha   > "$fix/bin"
+	printf '%s' alpha   > "$fix/cert"
+
+	cat > "$fix/artifacts.json" <<JSON
+[{"name":"cynative_Linux_x86_64.tar.gz","path":"$fix/linux","type":"Archive"},
+ {"name":"cynative","path":"$fix/bin","type":"Binary"},
+ {"name":"checksums.txt.sigstore.json","path":"$fix/sig","type":"Signature"},
+ {"name":"checksums.txt","path":"$fix/sums","type":"Checksum"},
+ {"name":"checksums.txt.pem","path":"$fix/cert","type":"Certificate"},
+ {"name":"cynative_Darwin_arm64.tar.gz","path":"$fix/darwin","type":"Archive"}]
+JSON
+
+	cat > "$fix/expected.tsv" <<TSV
+checksums.txt	b9dd960c1753459a78115d3cb845a57d924b6877e805b08bd01086ccdf34433c	$fix/sums
+checksums.txt.sigstore.json	4f4a9410ffcdf895c4adb880659e9b5c0dd1f23a30790684340b3eaacb045398	$fix/sig
+cynative_Darwin_arm64.tar.gz	8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8	$fix/darwin
+cynative_Linux_x86_64.tar.gz	f144a6907dc4284d1f9fe6a7d9b9ff53c02c1d07ba68f24d413d7ff7f757a782	$fix/linux
+TSV
+
+	"$assert" generate "$fix" > "$fix/actual.tsv" 2>"$fix/err.log" || exit 1
+	diff "$fix/expected.tsv" "$fix/actual.tsv" >&2 || exit 1
+	exit 0
+); then pass "assert-assets generate emits exactly Archive+Checksum+Signature, sorted, with correct digests"; else fail "generate golden fixture"; fi
+
+# ---- generate: a missing artifact path aborts instead of emitting an empty digest ---
+# The script uses a bare `digest=$(sha256sum ...)` assignment precisely so a failure
+# aborts under `set -euo pipefail`. Rows already flushed to the sort stay on stdout, so
+# assert the exit status and the absence of an empty-digest row, never empty output.
+if (
+	miss="$tmp/miss"
+	mkdir -p "$miss"
+	printf '%s' alpha > "$miss/present"
+	cat > "$miss/artifacts.json" <<JSON
+[{"name":"a_present.tar.gz","path":"$miss/present","type":"Archive"},
+ {"name":"b_gone.txt","path":"$miss/does-not-exist","type":"Checksum"}]
+JSON
+
+	rc=0
+	"$assert" generate "$miss" > "$miss/out.tsv" 2>"$miss/err.log" || rc=$?
+	[ "$rc" -ne 0 ] || exit 1                        # must fail closed
+	# Never an empty digest column. awk with a tab FS, not a grep pattern: grep does
+	# not interpret \t, so a '\t\t' pattern would match a literal backslash-t instead.
+	awk -F'\t' '$2 == "" { bad = 1 } END { exit bad ? 1 : 0 }' "$miss/out.tsv" || exit 1
+	! grep -q 'b_gone.txt' "$miss/out.tsv" || exit 1 # the bad artifact is never emitted
+	exit 0
+); then pass "assert-assets generate fails closed on a missing artifact path"; else fail "generate missing-path fail-closed"; fi
 
 [ "$fails" -eq 0 ] || { printf '%d failure(s)\n' "$fails" >&2; exit 1; }
 printf 'OK: assert-assets unit tests\n'

--- a/test/release-signing.unit.test.sh
+++ b/test/release-signing.unit.test.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# release-signing.unit.test.sh - offline contract pins for the release signing path
+# (cynative#180). Hermetic: reads tracked source files only, no network, no cosign.
+#
+# The contract spans four files and nothing else checks it: .goreleaser.yaml decides what
+# gets signed and what the asset is called, scripts/release/assert-assets.sh decides
+# whether that asset is admitted to the draft, .github/workflows/release.yaml mints the
+# OIDC token and verifies the result, and the Makefile's snapshot target is what keeps
+# local builds out of the signing path. Any drift between them fails for the FIRST time
+# during a live release, so pin each half here. Run by `make sh-test`.
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+root=$(CDPATH='' cd -- "$here/.." && pwd)
+
+goreleaser="$root/.goreleaser.yaml"
+assert="$root/scripts/release/assert-assets.sh"
+release="$root/.github/workflows/release.yaml"
+makefile="$root/Makefile"
+
+fails=0
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+for f in "$goreleaser" "$assert" "$release" "$makefile"; do
+	[ -f "$f" ] || { printf 'FAIL: %s not found\n' "$f" >&2; exit 1; }
+done
+
+# ---- .goreleaser.yaml: exactly one signs stanza, with the pinned shape -------------
+signs_count=$(grep -cE '^signs:' "$goreleaser" || true)
+if [ "$signs_count" -eq 1 ]; then
+	pass "exactly one live signs: stanza in .goreleaser.yaml"
+else
+	fail "expected exactly 1 live signs: stanza in .goreleaser.yaml, found $signs_count"
+fi
+
+# Scope every field check to the stanza itself: a whole-file grep would be satisfied by
+# a comment or an unrelated block. The stanza runs to the next top-level key.
+block=$(awk '/^signs:/{f=1;next} f && /^[a-z]/{f=0} f' "$goreleaser")
+
+check_block() { # pattern description
+	n=$(printf '%s\n' "$block" | grep -cE "$1" || true)
+	if [ "$n" -eq 1 ]; then pass "$2"; else fail "$2 (found $n matches)"; fi
+}
+
+check_block '^[[:space:]]+- cmd: cosign$'                               'signs stanza runs cosign'
+check_block '^[[:space:]]+artifacts: checksum$'                         'signs stanza signs the checksum manifest'
+check_block '^[[:space:]]+signature: "\$\{artifact\}\.sigstore\.json"$' 'signs stanza names the bundle .sigstore.json'
+check_block '^[[:space:]]+- sign-blob$'                                 'signs stanza uses sign-blob'
+check_block '^[[:space:]]+- "--bundle=\$\{signature\}"$'                'signs stanza writes the configured bundle path'
+check_block '^[[:space:]]+- "--yes"$'                                   'signs stanza is non-interactive'
+check_block '^[[:space:]]+- "\$\{artifact\}"$'                          'signs stanza signs the artifact'
+
+# A `certificate:` field would emit a second artifact that assert-assets.sh does not
+# admit, so the release would fail closed on a surplus asset. Keep it absent.
+if printf '%s\n' "$block" | grep -qE '^[[:space:]]+certificate:'; then
+	fail "signs stanza must not set certificate: (the bundle carries the cert; a cert artifact is not admitted by the asset gate)"
+else
+	pass "signs stanza sets no certificate: field"
+fi
+
+# ---- assert-assets.sh: the admitted type set is exactly Archive+Checksum+Signature --
+# Exact whole-line match on the live filter, counted. A substring grep would also be
+# satisfied by a commented-out decoy, and a whole-file scan for "Certificate" would match
+# the header comment that explains why Certificate is excluded. The behavioural proof
+# that Binary and Certificate stay excluded is the golden fixture in
+# test/assert-assets.unit.test.sh; this pin is only about the live filter line.
+filter_count=$(grep -cxF '    | select(.type == "Archive" or .type == "Checksum" or .type == "Signature")' "$assert" || true)
+if [ "$filter_count" -eq 1 ]; then
+	pass "assert-assets.sh admits exactly Archive, Checksum and Signature"
+else
+	fail "assert-assets.sh's generate filter must be exactly Archive, Checksum and Signature (found $filter_count exact matches) - otherwise the signature is surplus on the draft, or a type nothing signs is admitted"
+fi
+
+# ---- Makefile: snapshot skips signing ---------------------------------------------
+if grep -qxF '	go tool goreleaser release --snapshot --clean --skip=sign' "$makefile"; then
+	pass "make snapshot skips signing (no OIDC token locally)"
+else
+	fail "make snapshot must pass --skip=sign - keyless signing needs a GitHub Actions OIDC token, so a local snapshot (and the install-e2e that shells out to it) would fail"
+fi
+
+# ---- release.yaml: the production run must NOT skip signing ------------------------
+# Strip comments first: a commented-out decoy invocation would otherwise satisfy the
+# locator. Require exactly one live invocation so a second, skipping one cannot hide.
+prod=$(sed 's/#.*//' "$release" | grep -E 'go tool goreleaser release' || true)
+prod_count=$(printf '%s' "$prod" | grep -c . || true)
+if [ "$prod_count" -ne 1 ]; then
+	fail "expected exactly one live goreleaser invocation in release.yaml, found $prod_count"
+elif printf '%s\n' "$prod" | grep -q -- '--skip=sign'; then
+	fail "the production goreleaser invocation must not pass --skip=sign - that would publish an unsigned release that still passes every other gate"
+else
+	pass "the production goreleaser invocation signs"
+fi
+
+# ---- release.yaml: OIDC permission and the guarded steps ---------------------------
+# Scope to the release job: a whole-file grep would latch onto another job's block. The
+# scan resets at every job header, so a missing block fails below rather than borrowing
+# a later job's permissions.
+job=$(awk '/^  [A-Za-z0-9_-]+:$/{injob=($0=="  release:")} injob' "$release")
+
+for perm in 'contents: read' 'id-token: write'; do
+	if printf '%s\n' "$job" | grep -qxF "      ${perm}"; then
+		pass "release job grants ${perm}"
+	else
+		fail "release job must grant ${perm} - a job-level permissions block replaces the workflow-level one, so both have to be stated"
+	fi
+done
+
+# Both signing steps must carry the release-created guard. Without it they run on every
+# ordinary push to main, where the checkout is skipped: the bootstrap would have no
+# Makefile to read and the verification no dist/ to verify.
+guard="if: \${{ steps.release-please.outputs.release_created == 'true' }}"
+for step in 'Bootstrap pinned cosign' 'Verify the release signature'; do
+	# Exactly one step of each name: the guard scan reads the FIRST occurrence, so a
+	# guarded copy plus an unguarded duplicate would otherwise pass.
+	step_count=$(grep -cxF "      - name: $step" "$release" || true)
+	if [ "$step_count" -ne 1 ]; then
+		fail "expected exactly one step named '$step' in release.yaml, found $step_count"
+		continue
+	fi
+	got=$(awk -v s="      - name: $step" -v g="        $guard" \
+		'$0==s{found=1;next} found{print ($0==g) ? "yes" : "no"; exit}' "$release")
+	if [ "$got" = "yes" ]; then
+		pass "step '$step' carries the release-created guard"
+	else
+		fail "step '$step' must be immediately followed by the release-created guard, or it runs on every ordinary push to main where the checkout is skipped"
+	fi
+done
+
+# ---- release.yaml: the verification step's own contract ----------------------------
+# Scoped to the step, not the whole file: a permissive identity regexp, a dropped
+# certificate flag, or verification deleted entirely while the bundle path survives in a
+# comment would all keep a whole-file grep green. The step runs to the next step.
+verify_step=$(awk '/^      - name: Verify the release signature$/{f=1;next} f && /^      - name: /{f=0} f' "$release")
+
+# `--` before the pattern: most of these start with a dash, which grep would otherwise
+# read as its own option.
+check_verify() { # substring description
+	if printf '%s\n' "$verify_step" | grep -qF -- "$1"; then
+		pass "$2"
+	else
+		fail "$2 - missing from the 'Verify the release signature' step"
+	fi
+}
+
+# shellcheck disable=SC2016 # The literal ${COSIGN_*} spellings are exactly what is
+# being pinned in the workflow; expanding them here would defeat the check.
+check_verify 'cosign verify-blob dist/checksums.txt' \
+	'verification runs cosign verify-blob on the checksum manifest'
+# shellcheck disable=SC2016 # As above: pinning the literal workflow text.
+check_verify '--bundle dist/checksums.txt.sigstore.json' \
+	'verification names the bundle it verifies'
+# shellcheck disable=SC2016 # As above: pinning the literal workflow text.
+check_verify '--certificate-identity "${COSIGN_IDENTITY}"' \
+	'verification pins an exact certificate identity'
+# shellcheck disable=SC2016 # As above: pinning the literal workflow text.
+check_verify '--certificate-oidc-issuer "${COSIGN_ISSUER}"' \
+	'verification pins the OIDC issuer'
+check_verify 'COSIGN_IDENTITY: https://github.com/cynative/cynative/.github/workflows/release.yaml@refs/heads/main' \
+	'the pinned identity is this workflow on main'
+check_verify 'COSIGN_ISSUER: https://token.actions.githubusercontent.com' \
+	'the pinned issuer is GitHub Actions'
+
+if printf '%s\n' "$verify_step" | grep -q -- '--certificate-identity-regexp'; then
+	fail "verification must pin an exact --certificate-identity, never a regexp - a permissive pattern would accept a signature minted by any workflow in the repo"
+else
+	pass "verification does not fall back to an identity regexp"
+fi
+
+[ "$fails" -eq 0 ] || { printf '%d failure(s)\n' "$fails" >&2; exit 1; }
+printf 'OK: release signing contract pins\n'

--- a/test/release-signing.unit.test.sh
+++ b/test/release-signing.unit.test.sh
@@ -118,12 +118,18 @@ for step in 'Bootstrap pinned cosign' 'Verify the release signature'; do
 		fail "expected exactly one step named '$step' in release.yaml, found $step_count"
 		continue
 	fi
-	got=$(awk -v s="      - name: $step" -v g="        $guard" \
-		'$0==s{found=1;next} found{print ($0==g) ? "yes" : "no"; exit}' "$release")
-	if [ "$got" = "yes" ]; then
+	# Scope to this step's own block, then require the guard at step level (exactly
+	# eight spaces) anywhere inside it. Scoping stops a neighbouring step's guard from
+	# satisfying the check, while not requiring the guard to be the very next line, so
+	# a comment between `- name:` and `if:` is not a spurious failure. The eight-space
+	# anchor is what keeps the same text inside a `run:` block, which is indented
+	# deeper, from counting.
+	step_block=$(awk -v s="      - name: $step" \
+		'$0==s{f=1;next} f && /^      - name: /{f=0} f' "$release")
+	if printf '%s\n' "$step_block" | grep -qxF "        $guard"; then
 		pass "step '$step' carries the release-created guard"
 	else
-		fail "step '$step' must be immediately followed by the release-created guard, or it runs on every ordinary push to main where the checkout is skipped"
+		fail "step '$step' must carry the release-created guard, or it runs on every ordinary push to main where the checkout is skipped"
 	fi
 done
 


### PR DESCRIPTION
## What & why

Closes #180.

Releases now ship `checksums.txt.sigstore.json`, a Sigstore bundle signing `checksums.txt` with a keyless certificate bound to this repo's release workflow. Authenticate the manifest, then any archive's SHA-256 row authenticates the archive.

Two gaps motivated it. There was nothing on the release page a consumer could verify without `gh` and without trusting the GitHub API to serve an honest `checksums.txt`. And OpenSSF Scorecard scored Signed-Releases 0/10, because the check inspects release asset **filenames**; GitHub's immutable-release attestations live behind the attestation API, not as assets, so none of what the pipeline already does was visible to it.

### What Scorecard actually measures

Verified against v5.5.0 source rather than docs, because it shaped the design:

- Signature suffixes `.asc .minisig .sig .sign .sigstore .sigstore.json` score **8**; provenance is `.intoto.jsonl` **only** and scores 10.
- One matching asset per release is enough, and the score is `floor(sum / releases)` over the last five.
- It never opens the file.

Two consequences. Signing only `checksums.txt` scores identically to signing every archive, so coverage is a security question rather than a score question. And because nothing is ever verified by the check, a correctly named but malformed bundle would score 8 while proving nothing, which is why the pipeline verifies its own bundle before publishing.

We stop at 8. The remaining two points require an asset literally named `*.intoto.jsonl`. Reaching that either means adopting `slsa-github-generator`'s reusable-workflow trust model and restructuring around this pipeline's exact-manifest flow, or naming a Sigstore bundle `.intoto.jsonl`, which is not the DSSE JSONL that name implies and which `slsa-verifier` would reject. Neither buys security here: the immutable-release attestation already binds tag, commit and every asset.

## Changes

- **`.goreleaser.yaml`**: a `signs:` block, `artifacts: checksum`, cosign `sign-blob --bundle`. No `certificate:` field, deliberately.
- **`release.yaml`**: the `release` job gets its own `permissions:` block (`contents: read` **and** `id-token: write`, since a job-level block replaces the workflow-level one); a pinned cosign bootstrap; a fresh App token immediately before goreleaser; and a pre-publish `cosign verify-blob` pinned to this workflow's Fulcio identity and issuer.
- **`assert-assets.sh`**: `generate` admits the `Signature` artifact type. Without this the bundle is a **surplus** asset and the exact-asset-set gate fails the release.
- **`Makefile`**: `COSIGN_VERSION`/`COSIGN_SHA256` pins, and `--skip=sign` on `make snapshot`. `--snapshot` only implies skips for publish, announce and validate, so without it a local snapshot (and the `install-e2e` that shells out to it) would attempt a keyless signature with no OIDC token.
- **Tests**: `generate` mode had zero coverage, so it gets a golden fixture plus the missing-path abort; and a new `test/release-signing.unit.test.sh` pins the contract, which spans four files and would otherwise first fail during a live release.

cosign is a hand-bumped pinned binary rather than an action or a `go tool`. `sigstore/cosign-installer` is not on the Actions allowlist and this is the one job holding the App key and the Apple signing material, so a pinned SHA-256-verified download avoids widening its trusted-action set. Promoting cosign to the tool block was measured instead of guessed: 82 new module requirements, 277 more `go.sum` lines, and a 4m14s cold build per release.

## Verification

A temporary branch-scoped workflow exercised the signing path for real, then was removed (run `30348604162`):

- cosign `v3.1.2` bootstrapped, SHA-256 verified.
- goreleaser signed: `signing cmd=cosign artifact=checksums.txt signature=dist/checksums.txt.sigstore.json`.
- Exactly one `Signature` artifact, named `checksums.txt.sigstore.json`. This confirms against the pinned goreleaser the type string the filter change depends on.
- `assert-assets.sh generate` emitted the bundle row with a well-formed digest.
- `cosign verify-blob` returned `Verified OK`.
- The issued SAN was `URI:https://github.com/cynative/cynative/.github/workflows/tmp-cosign-harness.yaml@refs/heads/feat/release-signature-assets`, confirming the identity is `https://github.com/{job_workflow_ref}` and so the shipping pin's shape is correct.

Each of the new tripwire pins was also confirmed to fail when violated, and `make install-e2e` passes on the `--skip=sign` path.

## Security review of the new capability

`id-token: write` on the `release` job is the one new capability here, in the job that also handles the App private key and the Apple signing material. Both cloud trust relationships were audited directly, and neither would accept a token minted from `release.yaml`.

**GCP.** The Workload Identity Federation provider's attribute condition is:

```
assertion.repository=='cynative/cynative' && (
  assertion.job_workflow_ref.startsWith('cynative/cynative/.github/workflows/llm-smoke.yaml@') ||
  assertion.job_workflow_ref.startsWith('cynative/cynative/.github/workflows/connector-e2e.yaml@'))
```

`release.yaml` is not in that set.

**AWS.** Exactly one role in the account trusts the GitHub OIDC provider, and its condition is an exact `StringEquals`, not a `StringLike`:

```
"token.actions.githubusercontent.com:sub": "repo:cynative/cynative:environment:aws-ci"
"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
```

Every AWS-federating job declares `environment: aws-ci`, so its subject matches that string. The `release` job declares no environment, so its subject is `repo:cynative/cynative:ref:refs/heads/main`, which cannot satisfy an exact-match condition.

## Known limits

- The Scorecard score climbs roughly 1, 3, 4, 6, 8 across five releases. Published releases are immutable and cannot be retrofitted.
- The bundle covers the archives in `checksums.txt`, not the two `.pkg` installers. Those are Developer ID signed, notarized and stapled, and covered by the release attestation. The docs say so rather than overclaiming.
- The signature proves origin and integrity, not freshness: the file names carry no version, so an offline verifier handed a loose file set cannot distinguish it from an older valid release. Documented.
- The production `release.yaml@refs/heads/main` identity and the `repository_dispatch` recovery path are proven only by the first real release. The harness proved the mechanics and the SAN shape.
- Signing adds a network dependency on Fulcio and Rekor to the release path. Failure is safe: the draft stays unpublished and the existing recovery notes apply unchanged.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed
