### PR TITLE
refactor(auth): pass the read-only gates a narrowed request view

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -167,11 +167,14 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
-        # The selector pattern below is proven live by the one
-        # //nolint:forbidigo directive in
-        # internal/transport/transport_internal_test.go, since nolintlint
-        # reports an unused directive; that test reads r.Host on the inbound
-        # (server) side, which is what the directive excuses.
+        # The selector pattern below is proven live by two
+        # //nolint:forbidigo directives, since nolintlint reports an unused
+        # directive if either pattern stops matching:
+        #   - internal/transport/transport_internal_test.go reads r.Host on
+        #     the inbound (server) side.
+        #   - internal/auth/authreq/export_test.go writes req.Host to a
+        #     value that disagrees with the URL, proving the request view
+        #     ignores the field rather than trusting it.
         #
         # The composite-literal pattern has no in-tree canary: nothing in
         # this codebase legitimately sets http.Request.Host today. If the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,20 +477,21 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     don't implement it inherit the fail-safe default: deny internal ranges, loopback,
     link-local including cloud metadata, RFC1918, ULA, IPv4-mapped forms, plus the exact Azure
     WireServer and Alibaba metadata addresses; allow everything else).
-  - The read-only gates take a narrowed value view, not the request.
-    `ActionAuthorizer.AuthorizeAction` and `ResponseAuditor.AuditResponse`
-    receive `authreq.View` / `authreq.AuditView`, projected once in
-    `transport.do` from `req.URL`, a cloned header, and the same string the
-    request body was built from. `InjectAuth` keeps the real `*http.Request`,
-    since it mutates headers and AWS SigV4 signs during it. The view lives in
-    the stdlib-only leaf `internal/auth/authreq` because `internal/auth`
-    imports its own aws/gcp/azure subpackages. It carries `RawQuery` and no
-    query helper on purpose: GitLab parses fail-closed against Rack's `;`
-    handling while the K8s and AWS gates match their Go upstreams' lenient
-    parse. It carries both `Path` and `EscapedPath` because Azure compares them
-    to reject a percent-encoded slash. `rawArgs` is still the full tool-call
-    JSON, so it remains a second full-fidelity channel; narrowing it is
-    separate work.
+  - The read-only gates take a narrowed value view, not the full request, and the two
+    views differ. `ActionAuthorizer.AuthorizeAction` receives `authreq.View`, projected
+    once in `transport.do` before the auth gates run, from `req.URL`, a cloned header,
+    and the same string the request body was built from. `ResponseAuditor.AuditResponse`
+    receives the smaller `authreq.AuditView` instead, carrying only `Method` and
+    `EscapedPath` (no header, no body), built separately after `auth.Inject` runs so the
+    audit observes the request as sent rather than as authorized. `InjectAuth` keeps the
+    real `*http.Request` throughout, since it mutates headers and AWS SigV4 signs during
+    it. Both views live in the stdlib-only leaf `internal/auth/authreq` because
+    `internal/auth` imports its own aws/gcp/azure subpackages. `View` carries `RawQuery`
+    and no query helper on purpose: GitLab parses fail-closed against Rack's `;` handling
+    while the K8s and AWS gates match their Go upstreams' lenient parse. It carries both
+    `Path` and `EscapedPath` because Azure compares them to reject a percent-encoded
+    slash. `rawArgs` is still the full tool-call JSON, so it remains a second
+    full-fidelity channel; narrowing it is separate work.
   - `auth.Inject`, the dispatcher every credentialed request flows through, rejects
     model-supplied credentials before dispatching (`ErrModelSuppliedCredential`):
     `Authorization`/`Proxy-Authorization`/`X-Ms-Authorization-Auxiliary` header values and URL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,20 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     don't implement it inherit the fail-safe default: deny internal ranges, loopback,
     link-local including cloud metadata, RFC1918, ULA, IPv4-mapped forms, plus the exact Azure
     WireServer and Alibaba metadata addresses; allow everything else).
+  - The read-only gates take a narrowed value view, not the request.
+    `ActionAuthorizer.AuthorizeAction` and `ResponseAuditor.AuditResponse`
+    receive `authreq.View` / `authreq.AuditView`, projected once in
+    `transport.do` from `req.URL`, a cloned header, and the same string the
+    request body was built from. `InjectAuth` keeps the real `*http.Request`,
+    since it mutates headers and AWS SigV4 signs during it. The view lives in
+    the stdlib-only leaf `internal/auth/authreq` because `internal/auth`
+    imports its own aws/gcp/azure subpackages. It carries `RawQuery` and no
+    query helper on purpose: GitLab parses fail-closed against Rack's `;`
+    handling while the K8s and AWS gates match their Go upstreams' lenient
+    parse. It carries both `Path` and `EscapedPath` because Azure compares them
+    to reject a percent-encoded slash. `rawArgs` is still the full tool-call
+    JSON, so it remains a second full-fidelity channel; narrowing it is
+    separate work.
   - `auth.Inject`, the dispatcher every credentialed request flows through, rejects
     model-supplied credentials before dispatching (`ErrModelSuppliedCredential`):
     `Authorization`/`Proxy-Authorization`/`X-Ms-Authorization-Auxiliary` header values and URL

--- a/internal/auth/aks.go
+++ b/internal/auth/aks.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 const aksProviderName = "aks"
@@ -207,13 +209,13 @@ func (p *aksProvider) InjectAuth(req *http.Request, rawArgs json.RawMessage) err
 // AuthorizeAction enforces the read-only ClusterRole posture for AKS Kubernetes API
 // requests via the shared k8sGate. It implements the optional
 // auth.ActionAuthorizer interface.
-func (p *aksProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *aksProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	args, err := parseAKSArgs(rawArgs)
 	if err != nil {
 		return err
 	}
 
-	return p.authorizeAction(ctx, req, args)
+	return p.authorizeAction(ctx, v, args)
 }
 
 func (p *aksProvider) CACertData(ctx context.Context, rawArgs json.RawMessage) (string, error) {

--- a/internal/auth/auth_internal_test.go
+++ b/internal/auth/auth_internal_test.go
@@ -27,6 +27,7 @@ import (
 	container "google.golang.org/api/container/v1"
 	"google.golang.org/api/option"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/auth/authtest"
 	awshardening "github.com/cynative/cynative/internal/auth/aws"
 	githubhardening "github.com/cynative/cynative/internal/auth/github"
@@ -3349,20 +3350,33 @@ func TestAuthorizeHost_CaseInsensitive(t *testing.T) {
 
 // --- AuthorizeAction dispatcher tests ---
 
+// actionView builds the narrowed view the action gates take, projecting a
+// request constructed the way the transport constructs one.
+func actionView(t *testing.T, method, rawurl string) authreq.View {
+	t.Helper()
+
+	r, err := http.NewRequestWithContext(t.Context(), method, rawurl, nil)
+	if err != nil {
+		t.Fatalf("new request %q: %v", rawurl, err)
+	}
+
+	return authreq.NewView(r, "")
+}
+
 func TestAuthorizeAction_callsProviderImplementingActionAuthorizer(t *testing.T) {
 	t.Parallel()
 
 	called := false
 	provider := &fakeAuthorizingProvider{
 		name: "aws",
-		authorizeAction: func(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+		authorizeAction: func(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 			called = true
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example/", nil)
+	v := actionView(t, http.MethodGet, "https://example/")
 
-	err := AuthorizeAction(t.Context(), "aws", req, []Provider{provider}, json.RawMessage(`{}`))
+	err := AuthorizeAction(t.Context(), "aws", v, []Provider{provider}, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("AuthorizeAction returned err: %v", err)
 	}
@@ -3375,9 +3389,9 @@ func TestAuthorizeAction_passesThroughWhenProviderDoesNotImplement(t *testing.T)
 	t.Parallel()
 
 	provider := &fakeProviderNoActionAuth{name: "gcp"}
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example/", nil)
+	v := actionView(t, http.MethodGet, "https://example/")
 
-	err := AuthorizeAction(t.Context(), "gcp", req, []Provider{provider}, json.RawMessage(`{}`))
+	err := AuthorizeAction(t.Context(), "gcp", v, []Provider{provider}, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("AuthorizeAction returned err for non-implementer: %v", err)
 	}
@@ -3386,9 +3400,9 @@ func TestAuthorizeAction_passesThroughWhenProviderDoesNotImplement(t *testing.T)
 func TestAuthorizeAction_unknownProviderReturnsError(t *testing.T) {
 	t.Parallel()
 
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example/", nil)
+	v := actionView(t, http.MethodGet, "https://example/")
 
-	err := AuthorizeAction(t.Context(), "nope", req, []Provider{}, json.RawMessage(`{}`))
+	err := AuthorizeAction(t.Context(), "nope", v, []Provider{}, json.RawMessage(`{}`))
 	if !errors.Is(err, ErrUnknownProvider) {
 		t.Fatalf("expected ErrUnknownProvider, got %v", err)
 	}
@@ -3399,13 +3413,13 @@ func TestAuthorizeAction_propagatesActionAuthorizerError(t *testing.T) {
 
 	provider := &fakeAuthorizingProvider{
 		name: "aws",
-		authorizeAction: func(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+		authorizeAction: func(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 			return errors.New("action denied")
 		},
 	}
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example/", nil)
+	v := actionView(t, http.MethodGet, "https://example/")
 
-	err := AuthorizeAction(t.Context(), "aws", req, []Provider{provider}, json.RawMessage(`{}`))
+	err := AuthorizeAction(t.Context(), "aws", v, []Provider{provider}, json.RawMessage(`{}`))
 
 	if err == nil {
 		t.Fatalf("expected error from ActionAuthorizer, got nil")
@@ -3426,13 +3440,13 @@ func TestAuthorizeAction_DispatchesAzure(t *testing.T) {
 	called := false
 	prov := &fakeAuthorizingProvider{
 		name: "azure",
-		authorizeAction: func(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+		authorizeAction: func(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 			called = true
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://management.azure.com/x", nil)
-	if err := AuthorizeAction(t.Context(), "azure", req, []Provider{prov}, nil); err != nil {
+	v := actionView(t, http.MethodGet, "https://management.azure.com/x")
+	if err := AuthorizeAction(t.Context(), "azure", v, []Provider{prov}, nil); err != nil {
 		t.Fatalf("AuthorizeAction: %v", err)
 	}
 	if !called {
@@ -3443,7 +3457,7 @@ func TestAuthorizeAction_DispatchesAzure(t *testing.T) {
 // fakeAuthorizingProvider satisfies both Provider and ActionAuthorizer.
 type fakeAuthorizingProvider struct {
 	name            string
-	authorizeAction func(context.Context, *http.Request, json.RawMessage) error
+	authorizeAction func(context.Context, authreq.View, json.RawMessage) error
 }
 
 func (f *fakeAuthorizingProvider) Name() string                                        { return f.name }
@@ -3454,8 +3468,8 @@ func (f *fakeAuthorizingProvider) AuthorizesHost(_ context.Context, _ string, _ 
 	return true, nil
 }
 
-func (f *fakeAuthorizingProvider) AuthorizeAction(ctx context.Context, req *http.Request, raw json.RawMessage) error {
-	return f.authorizeAction(ctx, req, raw)
+func (f *fakeAuthorizingProvider) AuthorizeAction(ctx context.Context, v authreq.View, raw json.RawMessage) error {
+	return f.authorizeAction(ctx, v, raw)
 }
 
 type fakeProviderNoActionAuth struct{ name string }
@@ -3480,13 +3494,13 @@ func TestAuthorizeAction_DispatchesGCP(t *testing.T) {
 	called := false
 	prov := &fakeAuthorizingProvider{
 		name: "gcp",
-		authorizeAction: func(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+		authorizeAction: func(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 			called = true
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://compute.googleapis.com/x", nil)
-	if err := AuthorizeAction(t.Context(), "gcp", req, []Provider{prov}, nil); err != nil {
+	v := actionView(t, http.MethodGet, "https://compute.googleapis.com/x")
+	if err := AuthorizeAction(t.Context(), "gcp", v, []Provider{prov}, nil); err != nil {
 		t.Fatalf("AuthorizeAction: %v", err)
 	}
 	if !called {
@@ -3497,8 +3511,8 @@ func TestAuthorizeAction_DispatchesGCP(t *testing.T) {
 func TestAWSProvider_AuthorizeAction_nilActionProviderReturnsError(t *testing.T) {
 	t.Parallel()
 	p := newAWSProvider(aws.Config{}, func(_ context.Context) error { return nil })
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://s3.us-east-1.amazonaws.com/", nil)
-	err := p.AuthorizeAction(t.Context(), req, json.RawMessage(`{}`))
+	v := actionView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	err := p.AuthorizeAction(t.Context(), v, json.RawMessage(`{}`))
 	if err == nil {
 		t.Errorf("expected error when actionProvider is nil")
 	}
@@ -3513,9 +3527,9 @@ func TestAWSProvider_AuthorizeAction_delegatesToActionProvider(t *testing.T) {
 		&fakeActionEvaluator{allow: false},
 		"arn:aws:iam::aws:policy/SecurityAudit",
 	)
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://s3.us-east-1.amazonaws.com/", nil)
+	v := actionView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := json.RawMessage(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if !errors.Is(err, awshardening.ErrPolicyDenied) {
 		t.Errorf("err = %v, want ErrPolicyDenied (delegated)", err)
 	}
@@ -3597,10 +3611,10 @@ func TestAWSProvider_AuthorizeAction_triggersLazyOnce(t *testing.T) {
 		calls++
 		return nil
 	})
-	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	v := actionView(t, http.MethodGet, "https://example.com/")
 	rawArgs := json.RawMessage(`{}`)
-	_ = p.AuthorizeAction(t.Context(), req, rawArgs)
-	_ = p.AuthorizeAction(t.Context(), req, rawArgs)
+	_ = p.AuthorizeAction(t.Context(), v, rawArgs)
+	_ = p.AuthorizeAction(t.Context(), v, rawArgs)
 	if calls != 1 {
 		t.Errorf("doLazyResolve called %d times across 2 AuthorizeAction calls, want 1", calls)
 	}
@@ -3757,9 +3771,9 @@ func TestAWSProvider_AuthorizeAction_returnsLazyError(t *testing.T) {
 	p := newAWSProvider(aws.Config{}, func(_ context.Context) error {
 		return wantErr
 	})
-	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	v := actionView(t, http.MethodGet, "https://example.com/")
 	rawArgs := json.RawMessage(`{}`)
-	err := p.AuthorizeAction(t.Context(), req, rawArgs)
+	err := p.AuthorizeAction(t.Context(), v, rawArgs)
 	if !errors.Is(err, wantErr) {
 		t.Errorf("AuthorizeAction err = %v, want wrapped %v", err, wantErr)
 	}
@@ -3784,8 +3798,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err != nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err != nil {
 			t.Fatalf("list pods should be allowed: %v", err)
 		}
 	})
@@ -3794,8 +3808,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/secrets", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/secrets")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("list secrets should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3807,8 +3821,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		p.fetchView = func(_ context.Context, _ *EKSAuthArgs) (*k8sauthz.ViewPolicy, error) {
 			return nil, errors.New("boom")
 		}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err == nil {
 			t.Fatal("fetch error must deny (fail closed)")
 		}
 	})
@@ -3817,8 +3831,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 			t.Fatal("missing cluster_name must error")
 		}
 	})
@@ -3827,8 +3841,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{`)); err == nil {
 			t.Fatal("malformed args must error")
 		}
 	})
@@ -3837,8 +3851,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodPost, "https://example/api/v1/namespaces/d/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodPost, "https://example/api/v1/namespaces/d/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("POST pods should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3847,8 +3861,8 @@ func TestEKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/metrics", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://example/metrics")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("GET /metrics (non-resource) should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3877,8 +3891,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/apis/apps/v1/namespaces/d/deployments", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err != nil {
+		v := actionView(t, http.MethodGet, "https://example/apis/apps/v1/namespaces/d/deployments")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err != nil {
 			t.Fatalf("list deployments should be allowed: %v", err)
 		}
 	})
@@ -3887,8 +3901,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodPost, "https://example/apis/apps/v1/namespaces/d/deployments", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodPost, "https://example/apis/apps/v1/namespaces/d/deployments")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("create should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3897,8 +3911,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/secrets", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/secrets")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("secrets should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3910,8 +3924,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		p.fetchView = func(_ context.Context, _ *GKEAuthArgs) (*k8sauthz.ViewPolicy, error) {
 			return nil, errors.New("boom")
 		}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err == nil {
 			t.Fatal("fetch error must deny (fail closed)")
 		}
 	})
@@ -3920,8 +3934,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 			t.Fatal("missing gke args must error")
 		}
 	})
@@ -3930,8 +3944,8 @@ func TestGKEAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{`)); err == nil {
 			t.Fatal("malformed args must error")
 		}
 	})
@@ -3956,8 +3970,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err != nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err != nil {
 			t.Fatalf("list pods should be allowed: %v", err)
 		}
 	})
@@ -3966,8 +3980,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodPost, "https://example/api/v1/namespaces/d/pods/web/exec", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodPost, "https://example/api/v1/namespaces/d/pods/web/exec")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("pods/exec should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3976,8 +3990,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/secrets", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/secrets")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("secrets should be ErrForbidden, got %v", err)
 		}
 	})
@@ -3989,8 +4003,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		p.fetchView = func(_ context.Context, _ *AKSAuthArgs) (*k8sauthz.ViewPolicy, error) {
 			return nil, errors.New("boom")
 		}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); err == nil {
 			t.Fatal("fetch error must deny (fail closed)")
 		}
 	})
@@ -3999,9 +4013,9 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
 		if err := p.AuthorizeAction(
-			context.Background(), req,
+			context.Background(), v,
 			json.RawMessage(`{"aks_auth":{"cluster_name":"c"}}`),
 		); err == nil {
 			t.Fatal("missing resource_group and subscription_id must error")
@@ -4012,8 +4026,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{`)); err == nil {
 			t.Fatal("malformed args must error")
 		}
 	})
@@ -4022,8 +4036,8 @@ func TestAKSAuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://example/metrics", nil)
-		if err := p.AuthorizeAction(context.Background(), req, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://example/metrics")
+		if err := p.AuthorizeAction(context.Background(), v, rawArgs); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("GET /metrics (non-resource) should be ErrForbidden, got %v", err)
 		}
 	})

--- a/internal/auth/authreq/authreq.go
+++ b/internal/auth/authreq/authreq.go
@@ -1,0 +1,82 @@
+// Package authreq holds the narrowed, read-only projections of an outbound
+// HTTP request that the authorization gates receive instead of a live
+// [http.Request]. It is a stdlib-only leaf: internal/auth imports its own
+// aws/gcp/azure subpackages, so a type declared there could not be shared with
+// them without an import cycle.
+package authreq
+
+import (
+	"net/http"
+	"strings"
+)
+
+// View is the read-only projection of an outbound request handed to the
+// authorization gates. Every field is derived from the [http.Request] the
+// transport will send, and nothing here aliases that request: the header is
+// cloned and the URL is flattened into strings.
+//
+// The query is carried unparsed, as RawQuery. There is deliberately no Query
+// helper: GitLab parses fail-closed because Rack honors ';' as a separator and
+// Go does not, while the Kubernetes and AWS gates match their own Go-based
+// upstreams with the lenient parse. Those are correctly different, and one
+// shared helper would impose a single policy on servers that disagree.
+type View struct {
+	Method      string
+	Hostname    string
+	Port        string
+	Path        string
+	EscapedPath string
+	RawQuery    string
+	Header      http.Header
+	Body        string
+}
+
+// NewView projects req into the View handed to the read-only gates.
+//
+// req must be non-nil and carry a non-nil URL. [http.NewRequestWithContext]
+// guarantees both at the transport's only call site, so this is a documented
+// precondition rather than a validated one: returning an error here would put
+// the projection inside the fail-closed reasoning it exists to stay out of.
+//
+// body is the exact string the request's body reader was built from. It is
+// passed in rather than read from req because reading the request body here
+// would consume the payload the signer and the wire still need.
+//
+// The authority is taken from the URL alone. The request's own authority field
+// is never consulted: it is transport-owned and derived from the URL, and
+// letting the two diverge is what cynative#243 and cynative#247 were.
+func NewView(req *http.Request, body string) View {
+	header := req.Header.Clone()
+	if header == nil {
+		header = http.Header{}
+	}
+
+	return View{
+		Method:      req.Method,
+		Hostname:    strings.ToLower(req.URL.Hostname()),
+		Port:        req.URL.Port(),
+		Path:        req.URL.Path,
+		EscapedPath: req.URL.EscapedPath(),
+		RawQuery:    req.URL.RawQuery,
+		Header:      header,
+		Body:        body,
+	}
+}
+
+// AuditView is the minimal projection handed to a post-response auditor. The
+// audit is advisory and reads only the classified route, so it gets its own
+// type rather than the full View.
+type AuditView struct {
+	Method      string
+	EscapedPath string
+}
+
+// NewAuditView projects req into the AuditView handed to a response auditor.
+// Like NewView it requires a non-nil req with a non-nil URL. It is built after
+// credential injection, preserving that the audit observes the request as sent.
+func NewAuditView(req *http.Request) AuditView {
+	return AuditView{
+		Method:      req.Method,
+		EscapedPath: req.URL.EscapedPath(),
+	}
+}

--- a/internal/auth/authreq/authreq_test.go
+++ b/internal/auth/authreq/authreq_test.go
@@ -1,0 +1,157 @@
+package authreq_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
+)
+
+// mustReq builds a request the way the transport does. It never sets the wire
+// authority field: that is derived from the URL, and the view must take it
+// from there.
+func mustReq(t *testing.T, method, raw string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, raw, nil)
+	if err != nil {
+		t.Fatalf("new request %q: %v", raw, err)
+	}
+
+	return req
+}
+
+func TestNewViewProjectsEveryField(t *testing.T) {
+	t.Parallel()
+
+	req := mustReq(t, http.MethodPost, "https://Api.GitHub.com:8443/repos/o/r%2Fx?a=1&b=2")
+	req.Header.Set("X-Amz-Target", "Svc.Op")
+
+	v := authreq.NewView(req, `{"k":"v"}`)
+
+	for _, tc := range []struct{ name, got, want string }{
+		{"Method", v.Method, http.MethodPost},
+		{"Hostname", v.Hostname, "api.github.com"},
+		{"Port", v.Port, "8443"},
+		{"Path", v.Path, "/repos/o/r/x"},
+		{"EscapedPath", v.EscapedPath, "/repos/o/r%2Fx"},
+		{"RawQuery", v.RawQuery, "a=1&b=2"},
+		{"Body", v.Body, `{"k":"v"}`},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+
+	if got := v.Header.Get("X-Amz-Target"); got != "Svc.Op" {
+		t.Errorf("Header.Get(X-Amz-Target) = %q, want %q", got, "Svc.Op")
+	}
+}
+
+// TestNewViewIgnoresConflictingWireAuthority pins the projection chokepoint:
+// the authority comes from the URL, never from the request's own authority
+// field, so the two can never disagree in what a gate judges. This is the test
+// that carries the weight the #246 lint pin loses when the gates stop taking a
+// request at all.
+func TestNewViewIgnoresConflictingWireAuthority(t *testing.T) {
+	t.Parallel()
+
+	req := mustReq(t, http.MethodGet, "https://api.github.com/user")
+	setConflictingAuthority(req, "codeload.github.com:1234")
+
+	v := authreq.NewView(req, "")
+
+	if v.Hostname != "api.github.com" {
+		t.Errorf("Hostname = %q, want %q (the URL must win)", v.Hostname, "api.github.com")
+	}
+
+	if v.Port != "" {
+		t.Errorf("Port = %q, want %q (the URL carries no port)", v.Port, "")
+	}
+}
+
+func TestNewViewClonesHeader(t *testing.T) {
+	t.Parallel()
+
+	req := mustReq(t, http.MethodGet, "https://api.github.com/user")
+	req.Header.Set("X-Keep", "original")
+
+	v := authreq.NewView(req, "")
+	v.Header.Set("X-Keep", "mutated")
+	v.Header.Set("X-Added", "new")
+
+	if got := req.Header.Get("X-Keep"); got != "original" {
+		t.Errorf("req.Header X-Keep = %q, want %q: a view mutation reached the wire request", got, "original")
+	}
+
+	if got := req.Header.Get("X-Added"); got != "" {
+		t.Errorf("req.Header X-Added = %q, want empty: a view mutation reached the wire request", got)
+	}
+}
+
+// TestNewViewPreservesNonCanonicalHeaderKeys pins what GitLab's Sudo check
+// depends on: cloning keeps key spelling, so raw map iteration still sees a
+// non-canonical key that Header.Get would miss.
+func TestNewViewPreservesNonCanonicalHeaderKeys(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("https://gitlab.com/api/v4/user")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	req := &http.Request{Method: http.MethodGet, URL: u, Header: http.Header{"sudo": []string{"root"}}}
+
+	v := authreq.NewView(req, "")
+
+	var found bool
+
+	for key := range v.Header {
+		if key == "sudo" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("non-canonical header key \"sudo\" did not survive projection")
+	}
+}
+
+// TestNewViewNilHeader covers the normalization branch: a request built by
+// composite literal can carry a nil header, and Header.Clone reports nil for
+// it. Gates iterate the map, so it must be non-nil.
+func TestNewViewNilHeader(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("https://api.github.com/user")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	v := authreq.NewView(&http.Request{Method: http.MethodGet, URL: u}, "")
+
+	if v.Header == nil {
+		t.Fatal("Header is nil, want an empty non-nil header")
+	}
+
+	if got := len(v.Header); got != 0 {
+		t.Errorf("len(Header) = %d, want 0", got)
+	}
+}
+
+func TestNewAuditView(t *testing.T) {
+	t.Parallel()
+
+	req := mustReq(t, http.MethodPatch, "https://api.github.com/repos/o/r%2Fx?a=1")
+
+	av := authreq.NewAuditView(req)
+
+	if av.Method != http.MethodPatch {
+		t.Errorf("Method = %q, want %q", av.Method, http.MethodPatch)
+	}
+
+	if av.EscapedPath != "/repos/o/r%2Fx" {
+		t.Errorf("EscapedPath = %q, want %q", av.EscapedPath, "/repos/o/r%2Fx")
+	}
+}

--- a/internal/auth/authreq/export_test.go
+++ b/internal/auth/authreq/export_test.go
@@ -1,0 +1,11 @@
+package authreq_test
+
+import "net/http"
+
+// setConflictingAuthority sets the wire authority to a value that disagrees
+// with the URL, so the projection can be shown to ignore it. This is the only
+// place in the package that touches the field, and it exists solely to prove
+// the view does not.
+func setConflictingAuthority(req *http.Request, authority string) {
+	req.Host = authority //nolint:forbidigo // proving the view ignores this field is the test's whole purpose.
+}

--- a/internal/auth/aws.go
+++ b/internal/auth/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4signer "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	awshardening "github.com/cynative/cynative/internal/auth/aws"
 )
 
@@ -173,14 +174,14 @@ func signingRegion(awsArgs *AWSAuthArgs, req *http.Request, sdkRegion string) st
 
 // AuthorizeAction implements the auth.ActionAuthorizer optional interface,
 // delegating to the composed awshardening.Provider.
-func (p *awsProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *awsProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	if err := p.ensureReady(ctx); err != nil {
 		return err
 	}
 	if p.actionProvider == nil {
 		return errors.New("aws_hardening: action authorizer not initialized")
 	}
-	return p.actionProvider.AuthorizeAction(ctx, req, rawArgs)
+	return p.actionProvider.AuthorizeAction(ctx, v, rawArgs)
 }
 
 func (p *awsProvider) AuthorizesHost(ctx context.Context, host string, rawArgs json.RawMessage) (bool, error) {

--- a/internal/auth/aws/classifier.go
+++ b/internal/auth/aws/classifier.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // vhostBucketPlaceholder is the synthetic {Bucket} path segment prepended for
@@ -33,13 +36,14 @@ func classificationPath(parsed ParsedHost, rawPath string) string {
 	return "/" + vhostBucketPlaceholder + rawPath
 }
 
-// classifyREST identifies which operation in model matches req. Matching uses
+// classifyREST identifies which operation in model matches v. Matching uses
 // (method, URI template); among multiple matches, the one whose query-flag
-// set is the longest subset of req's query parameters wins. path is the
+// set is the longest subset of the request's query parameters wins. path is the
 // effective classification path (already normalized by classificationPath).
-func classifyREST(model *ServiceModel, req *http.Request, path string) (string, error) {
-	method := strings.ToUpper(req.Method)
-	reqQuery := req.URL.Query()
+func classifyREST(model *ServiceModel, v authreq.View, path string) (string, error) {
+	method := strings.ToUpper(v.Method)
+	// Lenient parse, matching what [net/url.URL.Query] did here before the view.
+	reqQuery, _ := url.ParseQuery(v.RawQuery)
 
 	type candidate struct {
 		name  string
@@ -63,7 +67,7 @@ func classifyREST(model *ServiceModel, req *http.Request, path string) (string, 
 		if !matchURITemplate(tplPath, path) {
 			continue
 		}
-		score, ok := scoreDiscriminators(op, tplQuery, reqQuery, req.Header)
+		score, ok := scoreDiscriminators(op, tplQuery, reqQuery, v.Header)
 		if !ok {
 			continue
 		}

--- a/internal/auth/aws/classifier_internal_test.go
+++ b/internal/auth/aws/classifier_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 func TestMatchURITemplate(t *testing.T) {
@@ -42,8 +44,8 @@ func TestMatchURITemplate(t *testing.T) {
 func TestClassifyREST_ListBucketsAtRoot(t *testing.T) {
 	t.Parallel()
 	model := s3MinModel(t)
-	req := newClassifyReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
-	op, err := classifyREST(model, req, req.URL.Path)
+	v := newClassifyView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	op, err := classifyREST(model, v, v.Path)
 	if err != nil {
 		t.Fatalf("classifyREST: %v", err)
 	}
@@ -55,8 +57,8 @@ func TestClassifyREST_ListBucketsAtRoot(t *testing.T) {
 func TestClassifyREST_GetObject(t *testing.T) {
 	t.Parallel()
 	model := s3MinModel(t)
-	req := newClassifyReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/my-bucket/path/to/key")
-	op, err := classifyREST(model, req, req.URL.Path)
+	v := newClassifyView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/my-bucket/path/to/key")
+	op, err := classifyREST(model, v, v.Path)
 	if err != nil {
 		t.Fatalf("classifyREST: %v", err)
 	}
@@ -88,8 +90,8 @@ func TestClassifyREST_QueryDisambiguator(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
 			t.Parallel()
-			req := newClassifyReq(t, http.MethodGet, c.url)
-			op, err := classifyREST(model, req, req.URL.Path)
+			v := newClassifyView(t, http.MethodGet, c.url)
+			op, err := classifyREST(model, v, v.Path)
 			if err != nil {
 				t.Fatalf("classifyREST: %v", err)
 			}
@@ -103,8 +105,8 @@ func TestClassifyREST_QueryDisambiguator(t *testing.T) {
 func TestClassifyREST_NoMatchReturnsUnknown(t *testing.T) {
 	t.Parallel()
 	model := s3MinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://s3.us-east-1.amazonaws.com/foo")
-	_, err := classifyREST(model, req, req.URL.Path)
+	v := newClassifyView(t, http.MethodPost, "https://s3.us-east-1.amazonaws.com/foo")
+	_, err := classifyREST(model, v, v.Path)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -122,8 +124,8 @@ func TestClassifyREST_HigherScoreCandidateWinsOverEarlierAlphabetical(t *testing
 			"ZZZ": {HTTPMethod: "GET", URITemplate: "/{Bucket}?flag"},
 		},
 	}
-	req := newClassifyReq(t, http.MethodGet, "https://x.amazonaws.com/foo?flag")
-	op, err := classifyREST(model, req, req.URL.Path)
+	v := newClassifyView(t, http.MethodGet, "https://x.amazonaws.com/foo?flag")
+	op, err := classifyREST(model, v, v.Path)
 	if err != nil {
 		t.Fatalf("classifyREST: %v", err)
 	}
@@ -141,8 +143,8 @@ func TestClassifyREST_SkipsOperationsWithoutHTTPMethod(t *testing.T) {
 			"WithGet": {HTTPMethod: "GET", URITemplate: "/"},
 		},
 	}
-	req := newClassifyReq(t, http.MethodGet, "https://x.amazonaws.com/")
-	op, err := classifyREST(model, req, req.URL.Path)
+	v := newClassifyView(t, http.MethodGet, "https://x.amazonaws.com/")
+	op, err := classifyREST(model, v, v.Path)
 	if err != nil {
 		t.Fatalf("classifyREST: %v", err)
 	}
@@ -237,11 +239,11 @@ func TestClassifyREST_MemberBoundDiscriminators(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.method+c.url+c.copySource, func(t *testing.T) {
 			t.Parallel()
-			req := newClassifyReq(t, c.method, c.url)
+			v := newClassifyView(t, c.method, c.url)
 			if c.copySource != "" {
-				req.Header.Set("X-Amz-Copy-Source", c.copySource)
+				v.Header.Set("X-Amz-Copy-Source", c.copySource)
 			}
-			op, err := classifyREST(model, req, req.URL.Path)
+			op, err := classifyREST(model, v, v.Path)
 			if err != nil {
 				t.Fatalf("classifyREST: %v", err)
 			}
@@ -271,8 +273,8 @@ func TestClassifyREST_XIDOnlyDiscriminatorMatchesCanonicalRequest(t *testing.T) 
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
 			t.Parallel()
-			req := newClassifyReq(t, http.MethodGet, c.url)
-			op, err := classifyREST(model, req, req.URL.Path)
+			v := newClassifyView(t, http.MethodGet, c.url)
+			op, err := classifyREST(model, v, v.Path)
 			if err != nil {
 				t.Fatalf("classifyREST: %v", err)
 			}
@@ -337,8 +339,8 @@ func TestClassifyOperation_virtualHostedSynthesizesBucket(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			req := newClassifyReq(t, http.MethodGet, c.url)
-			op, err := ClassifyOperation(model, req, parsed)
+			v := newClassifyView(t, http.MethodGet, c.url)
+			op, err := ClassifyOperation(model, v, parsed)
 			if err != nil {
 				t.Fatalf("ClassifyOperation: %v", err)
 			}
@@ -370,8 +372,8 @@ func TestClassifyOperation_pathStyleUnchanged(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			req := newClassifyReq(t, http.MethodGet, c.url)
-			op, err := ClassifyOperation(model, req, parsed)
+			v := newClassifyView(t, http.MethodGet, c.url)
+			op, err := ClassifyOperation(model, v, parsed)
 			if err != nil {
 				t.Fatalf("ClassifyOperation: %v", err)
 			}
@@ -403,8 +405,8 @@ func TestVhostPlaceholder_NoLiteralFirstSegmentCollision(t *testing.T) {
 			"WriteGetObjectResponse": {HTTPMethod: "POST", URITemplate: "/WriteGetObjectResponse"},
 		},
 	}
-	req := newClassifyReq(t, http.MethodPost, "https://my-bucket.s3.us-east-1.amazonaws.com/")
-	_, err := ClassifyOperation(model, req, ParsedHost{Service: "s3", BucketInHost: true})
+	v := newClassifyView(t, http.MethodPost, "https://my-bucket.s3.us-east-1.amazonaws.com/")
+	_, err := ClassifyOperation(model, v, ParsedHost{Service: "s3", BucketInHost: true})
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp (placeholder must not match the literal op)", err)
 	}
@@ -423,11 +425,11 @@ func s3MinModel(t *testing.T) *ServiceModel {
 	return m
 }
 
-func newClassifyReq(t *testing.T, method, url string) *http.Request {
+func newClassifyView(t *testing.T, method, rawurl string) authreq.View {
 	t.Helper()
-	req, err := http.NewRequestWithContext(t.Context(), method, url, nil)
+	req, err := http.NewRequestWithContext(t.Context(), method, rawurl, nil)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	return req
+	return authreq.NewView(req, "")
 }

--- a/internal/auth/aws/classifier_proto.go
+++ b/internal/auth/aws/classifier_proto.go
@@ -2,17 +2,18 @@ package aws
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // classifyJSONRPC identifies the operation for AWS JSON RPC services
 // (awsJson1_0, awsJson1_1). The operation is encoded in the X-Amz-Target
 // header as "<ServiceName>.<Operation>".
-func classifyJSONRPC(model *ServiceModel, req *http.Request) (string, error) {
-	target := req.Header.Get("X-Amz-Target")
+func classifyJSONRPC(model *ServiceModel, v authreq.View) (string, error) {
+	target := v.Header.Get("X-Amz-Target")
 	if target == "" {
 		return "", fmt.Errorf("%w: X-Amz-Target header missing", ErrClassifierUnknownOp)
 	}
@@ -33,23 +34,26 @@ func classifyJSONRPC(model *ServiceModel, req *http.Request) (string, error) {
 // runs the operation named by the form-body Action on a POST and the URL-query
 // Action on a (legacy) GET, so classification follows the channel AWS executes
 // and fails closed on any ambiguity: exactly one Action, in exactly one place.
-// The method is case-normalized because req.Method is model-supplied and Go does
-// not canonicalize it.
-func classifyQuery(model *ServiceModel, req *http.Request) (string, error) {
-	switch strings.ToUpper(req.Method) {
+// The method is case-normalized because the request method is model-supplied and
+// Go does not canonicalize it.
+func classifyQuery(model *ServiceModel, v authreq.View) (string, error) {
+	switch strings.ToUpper(v.Method) {
 	case http.MethodPost:
-		return classifyQueryBody(model, req)
+		return classifyQueryBody(model, v)
 	case http.MethodGet:
-		return classifyQueryURL(model, req)
+		return classifyQueryURL(model, v)
 	default:
-		return "", fmt.Errorf("%w: method %q not used by the query protocol", ErrClassifierUnknownOp, req.Method)
+		return "", fmt.Errorf("%w: method %q not used by the query protocol", ErrClassifierUnknownOp, v.Method)
 	}
 }
 
 // classifyQueryURL classifies a GET: the URL query is authoritative. Exactly one
-// Action value is required (duplicates deny).
-func classifyQueryURL(model *ServiceModel, req *http.Request) (string, error) {
-	op, err := singleAction(req.URL.Query(), "URL query")
+// Action value is required (duplicates deny). The lenient parse is what
+// [net/url.URL.Query] did.
+func classifyQueryURL(model *ServiceModel, v authreq.View) (string, error) {
+	vals, _ := url.ParseQuery(v.RawQuery)
+
+	op, err := singleAction(vals, "URL query")
 	if err != nil {
 		return "", err
 	}
@@ -58,21 +62,17 @@ func classifyQueryURL(model *ServiceModel, req *http.Request) (string, error) {
 
 // classifyQueryBody classifies a POST: the form body is authoritative and any
 // Action in the URL query is rejected as a smuggling tell (AWS ignores it). The
-// body is rewound for the downstream SigV4 signer.
-func classifyQueryBody(model *ServiceModel, req *http.Request) (string, error) {
-	if req.URL.Query().Has("Action") {
+// body arrives as a string on the view, so this no longer consumes and repairs
+// the request the signer still needs.
+func classifyQueryBody(model *ServiceModel, v authreq.View) (string, error) {
+	query, _ := url.ParseQuery(v.RawQuery)
+	if query.Has("Action") {
 		return "", fmt.Errorf("%w: Action in URL query on a POST (body is authoritative)", ErrClassifierUnknownOp)
 	}
-	if req.Body == nil {
+	if v.Body == "" {
 		return "", fmt.Errorf("%w: POST has no body", ErrClassifierUnknownOp)
 	}
-	body, err := io.ReadAll(req.Body)
-	_ = req.Body.Close()
-	if err != nil {
-		return "", fmt.Errorf("%w: read body: %w", ErrClassifierUnknownOp, err)
-	}
-	req.Body = io.NopCloser(strings.NewReader(string(body)))
-	parsed, err := url.ParseQuery(string(body))
+	parsed, err := url.ParseQuery(v.Body)
 	if err != nil {
 		return "", fmt.Errorf("%w: parse body: %w", ErrClassifierUnknownOp, err)
 	}
@@ -115,14 +115,14 @@ func knownOp(model *ServiceModel, op string) (string, error) {
 // (bucket in the host) match the path-style URI templates; the non-REST
 // classifiers do not use parsed (S3 is the only virtual-hosted service and it is
 // REST). Returns ErrClassifierUnknownOp on no match.
-func ClassifyOperation(model *ServiceModel, req *http.Request, parsed ParsedHost) (string, error) {
+func ClassifyOperation(model *ServiceModel, v authreq.View, parsed ParsedHost) (string, error) {
 	switch model.Protocol {
 	case ProtocolRestXML, ProtocolRestJSON1:
-		return classifyREST(model, req, classificationPath(parsed, req.URL.Path))
+		return classifyREST(model, v, classificationPath(parsed, v.Path))
 	case ProtocolAWSJSON10, ProtocolAWSJSON11:
-		return classifyJSONRPC(model, req)
+		return classifyJSONRPC(model, v)
 	case ProtocolAWSQuery, ProtocolEC2Query:
-		return classifyQuery(model, req)
+		return classifyQuery(model, v)
 	case ProtocolUnknown:
 		return "", fmt.Errorf("%w: unknown service protocol", ErrClassifierUnknownOp)
 	default:

--- a/internal/auth/aws/classifier_proto_internal_test.go
+++ b/internal/auth/aws/classifier_proto_internal_test.go
@@ -2,20 +2,20 @@ package aws
 
 import (
 	"errors"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 func TestClassifyJSONRPC_putItem(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.PutItem")
-	op, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "DynamoDB_20120810.PutItem")
+	op, err := classifyJSONRPC(model, v)
 	if err != nil {
 		t.Fatalf("classifyJSONRPC: %v", err)
 	}
@@ -27,8 +27,8 @@ func TestClassifyJSONRPC_putItem(t *testing.T) {
 func TestClassifyJSONRPC_missingHeader(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	_, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	_, err := classifyJSONRPC(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -37,9 +37,9 @@ func TestClassifyJSONRPC_missingHeader(t *testing.T) {
 func TestClassifyJSONRPC_malformedHeader(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "no-dot-here")
-	_, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "no-dot-here")
+	_, err := classifyJSONRPC(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -48,9 +48,9 @@ func TestClassifyJSONRPC_malformedHeader(t *testing.T) {
 func TestClassifyJSONRPC_trailingDot(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.")
-	_, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "DynamoDB_20120810.")
+	_, err := classifyJSONRPC(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -59,9 +59,9 @@ func TestClassifyJSONRPC_trailingDot(t *testing.T) {
 func TestClassifyJSONRPC_multipleDots(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "Some.Service.PutItem")
-	op, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "Some.Service.PutItem")
+	op, err := classifyJSONRPC(model, v)
 	if err != nil {
 		t.Fatalf("classifyJSONRPC: %v", err)
 	}
@@ -73,9 +73,9 @@ func TestClassifyJSONRPC_multipleDots(t *testing.T) {
 func TestClassifyJSONRPC_multipleDotsWithEmptyTail(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "Some.Service.")
-	_, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "Some.Service.")
+	_, err := classifyJSONRPC(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -84,9 +84,9 @@ func TestClassifyJSONRPC_multipleDotsWithEmptyTail(t *testing.T) {
 func TestClassifyJSONRPC_unknownOperation(t *testing.T) {
 	t.Parallel()
 	model := dynamodbMinModel(t)
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.NoSuchOp")
-	_, err := classifyJSONRPC(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "DynamoDB_20120810.NoSuchOp")
+	_, err := classifyJSONRPC(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -95,28 +95,22 @@ func TestClassifyJSONRPC_unknownOperation(t *testing.T) {
 func TestClassifyQuery_bodyAction(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	body := "Action=ListUsers&Version=2010-05-08"
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = io.NopCloser(strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	op, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	v.Body = "Action=ListUsers&Version=2010-05-08"
+	op, err := classifyQuery(model, v)
 	if err != nil {
 		t.Fatalf("classifyQuery: %v", err)
 	}
 	if op != "ListUsers" {
 		t.Errorf("op = %q, want ListUsers", op)
 	}
-	rest, _ := io.ReadAll(req.Body)
-	if string(rest) != body {
-		t.Errorf("body not restored: got %q want %q", rest, body)
-	}
 }
 
 func TestClassifyQuery_urlAction(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
-	op, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
+	op, err := classifyQuery(model, v)
 	if err != nil {
 		t.Fatalf("classifyQuery: %v", err)
 	}
@@ -128,8 +122,8 @@ func TestClassifyQuery_urlAction(t *testing.T) {
 func TestClassifyQuery_unknownOpInURL(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=NoSuchOp")
-	_, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=NoSuchOp")
+	_, err := classifyQuery(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -139,9 +133,9 @@ func TestClassifyQuery_unknownOpInBody(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	body := "Action=NoSuchOp"
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = io.NopCloser(strings.NewReader(body))
-	_, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	v.Body = body
+	_, err := classifyQuery(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -150,8 +144,8 @@ func TestClassifyQuery_unknownOpInBody(t *testing.T) {
 func TestClassifyQuery_nilBodyAndNoURLAction(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/")
-	_, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/")
+	_, err := classifyQuery(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -161,25 +155,9 @@ func TestClassifyQuery_bodyMissingActionParam(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	body := "Version=2010-05-08"
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = io.NopCloser(strings.NewReader(body))
-	_, err := classifyQuery(model, req)
-	if !errors.Is(err, ErrClassifierUnknownOp) {
-		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
-	}
-}
-
-type failingReader struct{ err error }
-
-func (f *failingReader) Read([]byte) (int, error) { return 0, f.err }
-func (f *failingReader) Close() error             { return nil }
-
-func TestClassifyQuery_bodyReadFails(t *testing.T) {
-	t.Parallel()
-	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = &failingReader{err: errors.New("boom")}
-	_, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	v.Body = body
+	_, err := classifyQuery(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -189,9 +167,9 @@ func TestClassifyQuery_bodyMalformedQueryString(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	// "%ZZ" is an invalid percent escape — url.ParseQuery returns an error.
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = io.NopCloser(strings.NewReader("Action=%ZZ"))
-	_, err := classifyQuery(model, req)
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	v.Body = "Action=%ZZ"
+	_, err := classifyQuery(model, v)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -207,22 +185,22 @@ func TestClassifyOperation_dispatchByProtocol(t *testing.T) {
 	cases := []struct {
 		name   string
 		model  *ServiceModel
-		setup  func(*testing.T) *http.Request
+		setup  func(*testing.T) authreq.View
 		wantOp string
 	}{
 		{
 			"rest-xml", s3,
-			func(t *testing.T) *http.Request {
+			func(t *testing.T) authreq.View {
 				t.Helper()
-				return newClassifyReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+				return newClassifyView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 			},
 			"ListBuckets",
 		},
 		{
 			"json-rpc", dyn,
-			func(t *testing.T) *http.Request {
+			func(t *testing.T) authreq.View {
 				t.Helper()
-				r := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+				r := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
 				r.Header.Set("X-Amz-Target", "DynamoDB_20120810.ListTables")
 				return r
 			},
@@ -230,9 +208,9 @@ func TestClassifyOperation_dispatchByProtocol(t *testing.T) {
 		},
 		{
 			"query", iam,
-			func(t *testing.T) *http.Request {
+			func(t *testing.T) authreq.View {
 				t.Helper()
-				return newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers")
+				return newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers")
 			},
 			"ListUsers",
 		},
@@ -255,8 +233,8 @@ func TestClassifyOperation_restJSON1RoutesThroughREST(t *testing.T) {
 	t.Parallel()
 	m := s3MinModel(t)
 	m.Protocol = ProtocolRestJSON1
-	req := newClassifyReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
-	op, err := ClassifyOperation(m, req, ParsedHost{})
+	v := newClassifyView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	op, err := ClassifyOperation(m, v, ParsedHost{})
 	if err != nil {
 		t.Fatalf("ClassifyOperation: %v", err)
 	}
@@ -269,9 +247,9 @@ func TestClassifyOperation_awsJSON11RoutesThroughJSONRPC(t *testing.T) {
 	t.Parallel()
 	m := dynamodbMinModel(t)
 	m.Protocol = ProtocolAWSJSON11
-	req := newClassifyReq(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
-	req.Header.Set("X-Amz-Target", "X.ListTables")
-	op, err := ClassifyOperation(m, req, ParsedHost{})
+	v := newClassifyView(t, http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/")
+	v.Header.Set("X-Amz-Target", "X.ListTables")
+	op, err := ClassifyOperation(m, v, ParsedHost{})
 	if err != nil {
 		t.Fatalf("ClassifyOperation: %v", err)
 	}
@@ -284,8 +262,8 @@ func TestClassifyOperation_ec2QueryRoutesThroughQuery(t *testing.T) {
 	t.Parallel()
 	m := iamMinModel()
 	m.Protocol = ProtocolEC2Query
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers")
-	op, err := ClassifyOperation(m, req, ParsedHost{})
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers")
+	op, err := ClassifyOperation(m, v, ParsedHost{})
 	if err != nil {
 		t.Fatalf("ClassifyOperation: %v", err)
 	}
@@ -297,7 +275,7 @@ func TestClassifyOperation_ec2QueryRoutesThroughQuery(t *testing.T) {
 func TestClassifyOperation_unknownProtocolFails(t *testing.T) {
 	t.Parallel()
 	model := &ServiceModel{Protocol: ProtocolUnknown, Operations: map[string]Operation{}}
-	_, err := ClassifyOperation(model, newClassifyReq(t, http.MethodGet, "https://example/"), ParsedHost{})
+	_, err := ClassifyOperation(model, newClassifyView(t, http.MethodGet, "https://example/"), ParsedHost{})
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -306,7 +284,7 @@ func TestClassifyOperation_unknownProtocolFails(t *testing.T) {
 func TestClassifyOperation_unsupportedProtocolFails(t *testing.T) {
 	t.Parallel()
 	model := &ServiceModel{Protocol: Protocol(99), Operations: map[string]Operation{}}
-	_, err := ClassifyOperation(model, newClassifyReq(t, http.MethodGet, "https://example/"), ParsedHost{})
+	_, err := ClassifyOperation(model, newClassifyView(t, http.MethodGet, "https://example/"), ParsedHost{})
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp", err)
 	}
@@ -339,9 +317,9 @@ func TestClassifyQuery_postURLActionRejected_reportedAttack(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	// URL says a benign op; body says another. AWS executes the body — deny.
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/?Action=ListUsers")
-	req.Body = io.NopCloser(strings.NewReader("Action=CreateUser&Version=2010-05-08"))
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/?Action=ListUsers")
+	v.Body = "Action=CreateUser&Version=2010-05-08"
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want ErrClassifierUnknownOp (URL Action on POST must deny)", err)
 	}
 }
@@ -349,9 +327,9 @@ func TestClassifyQuery_postURLActionRejected_reportedAttack(t *testing.T) {
 func TestClassifyQuery_postURLActionRejected_evenWhenAgreeing(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/?Action=ListUsers")
-	req.Body = io.NopCloser(strings.NewReader("Action=ListUsers"))
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/?Action=ListUsers")
+	v.Body = "Action=ListUsers"
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (strict: any URL Action on POST denies)", err)
 	}
 }
@@ -360,9 +338,9 @@ func TestClassifyQuery_postEmptyURLActionRejected(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	// "?Action=" — present but empty; still a smuggling tell on a POST.
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/?Action=")
-	req.Body = io.NopCloser(strings.NewReader("Action=ListUsers"))
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/?Action=")
+	v.Body = "Action=ListUsers"
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (empty URL Action present on POST)", err)
 	}
 }
@@ -370,9 +348,9 @@ func TestClassifyQuery_postEmptyURLActionRejected(t *testing.T) {
 func TestClassifyQuery_postDuplicateBodyAction(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	req.Body = io.NopCloser(strings.NewReader("Action=ListUsers&Action=CreateUser"))
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	v.Body = "Action=ListUsers&Action=CreateUser"
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (duplicate Action in body)", err)
 	}
 }
@@ -381,8 +359,8 @@ func TestClassifyQuery_postNilBody(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	// POST, no URL Action, nil body → distinct nil-body branch.
-	req := newClassifyReq(t, http.MethodPost, "https://iam.amazonaws.com/")
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (POST nil body)", err)
 	}
 }
@@ -390,8 +368,8 @@ func TestClassifyQuery_postNilBody(t *testing.T) {
 func TestClassifyQuery_getDuplicateURLAction(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers&Action=CreateUser")
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=ListUsers&Action=CreateUser")
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (duplicate Action in URL)", err)
 	}
 }
@@ -402,8 +380,8 @@ func TestClassifyQuery_emptyActionValueDenied(t *testing.T) {
 	// "?Action=" — Action present but empty value → deny. Reaches singleAction's
 	// empty-Action arm via the GET/URL path (on a POST the URL-Action guard would
 	// intercept it first), so this is the case that covers that branch.
-	req := newClassifyReq(t, http.MethodGet, "https://iam.amazonaws.com/?Action=")
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodGet, "https://iam.amazonaws.com/?Action=")
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (empty Action value)", err)
 	}
 }
@@ -412,12 +390,12 @@ func TestClassifyQuery_lowercaseMethodClassifies(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
 	// Model-supplied lowercase "post"/"get" must still classify, not fall to deny.
-	post := newClassifyReq(t, "post", "https://iam.amazonaws.com/")
-	post.Body = io.NopCloser(strings.NewReader("Action=ListUsers"))
+	post := newClassifyView(t, "post", "https://iam.amazonaws.com/")
+	post.Body = "Action=ListUsers"
 	if op, err := classifyQuery(model, post); err != nil || op != "ListUsers" {
 		t.Errorf("lowercase post: op=%q err=%v, want ListUsers", op, err)
 	}
-	get := newClassifyReq(t, "get", "https://iam.amazonaws.com/?Action=ListUsers")
+	get := newClassifyView(t, "get", "https://iam.amazonaws.com/?Action=ListUsers")
 	if op, err := classifyQuery(model, get); err != nil || op != "ListUsers" {
 		t.Errorf("lowercase get: op=%q err=%v, want ListUsers", op, err)
 	}
@@ -426,8 +404,8 @@ func TestClassifyQuery_lowercaseMethodClassifies(t *testing.T) {
 func TestClassifyQuery_unsupportedMethod(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	req := newClassifyReq(t, http.MethodDelete, "https://iam.amazonaws.com/?Action=ListUsers")
-	if _, err := classifyQuery(model, req); !errors.Is(err, ErrClassifierUnknownOp) {
+	v := newClassifyView(t, http.MethodDelete, "https://iam.amazonaws.com/?Action=ListUsers")
+	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Errorf("err = %v, want deny (method not used by query protocol)", err)
 	}
 }

--- a/internal/auth/aws/classifier_proto_internal_test.go
+++ b/internal/auth/aws/classifier_proto_internal_test.go
@@ -355,13 +355,13 @@ func TestClassifyQuery_postDuplicateBodyAction(t *testing.T) {
 	}
 }
 
-func TestClassifyQuery_postNilBody(t *testing.T) {
+func TestClassifyQuery_postEmptyBody(t *testing.T) {
 	t.Parallel()
 	model := iamMinModel()
-	// POST, no URL Action, nil body → distinct nil-body branch.
+	// POST, no URL Action, empty body string -> distinct empty-body branch.
 	v := newClassifyView(t, http.MethodPost, "https://iam.amazonaws.com/")
 	if _, err := classifyQuery(model, v); !errors.Is(err, ErrClassifierUnknownOp) {
-		t.Errorf("err = %v, want deny (POST nil body)", err)
+		t.Errorf("err = %v, want deny (POST empty body)", err)
 	}
 }
 

--- a/internal/auth/aws/provider.go
+++ b/internal/auth/aws/provider.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // ModelResolver resolves a host endpoint prefix to every modeled service that
@@ -59,7 +60,7 @@ type argsShape struct {
 // matched but contributes no required action. Multiple matches occur only for
 // prefix collisions (e.g. email→ses/sesv2). Fail closed on any unresolved
 // candidate.
-func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *Provider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	var args argsShape
 	if err := json.Unmarshal(rawArgs, &args); err != nil {
 		return fmt.Errorf("aws_hardening: parse aws_auth: %w", err)
@@ -67,7 +68,7 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 	if args.AWSAuth == nil {
 		return errors.New("aws_hardening: aws_auth is required")
 	}
-	parsed, err := ParseHost(strings.ToLower(req.URL.Hostname()))
+	parsed, err := ParseHost(v.Hostname)
 	if err != nil {
 		return err
 	}
@@ -82,7 +83,7 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 		if !strings.EqualFold(model.EndpointPrefix, parsed.Service) {
 			continue // defensive: index/parse drift.
 		}
-		op, opErr := ClassifyOperation(model, req, parsed)
+		op, opErr := ClassifyOperation(model, v, parsed)
 		if opErr != nil {
 			// Every classifier error means this candidate does not serve the
 			// operation (ClassifyOperation only ever wraps ErrClassifierUnknownOp),

--- a/internal/auth/aws/provider_internal_test.go
+++ b/internal/auth/aws/provider_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"slices"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 func TestProvider_AuthorizeAction_happyPath(t *testing.T) {
@@ -14,9 +16,9 @@ func TestProvider_AuthorizeAction_happyPath(t *testing.T) {
 		allowed:              map[string]bool{"s3:ListBuckets": true},
 		smithyEndpointPrefix: "",
 	})
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	if err := p.AuthorizeAction(t.Context(), req, raw); err != nil {
+	if err := p.AuthorizeAction(t.Context(), v, raw); err != nil {
 		t.Fatalf("AuthorizeAction: %v", err)
 	}
 }
@@ -32,9 +34,9 @@ func TestProvider_AuthorizeAction_permissionlessAllowed(t *testing.T) {
 		evaluator: &fakeEvaluator{allowed: map[string]bool{}, err: nil},
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	if err := p.AuthorizeAction(t.Context(), req, raw); err != nil {
+	if err := p.AuthorizeAction(t.Context(), v, raw); err != nil {
 		t.Fatalf("AuthorizeAction (permissionless must allow): %v", err)
 	}
 }
@@ -42,9 +44,9 @@ func TestProvider_AuthorizeAction_permissionlessAllowed(t *testing.T) {
 func TestProvider_AuthorizeAction_deniedAction(t *testing.T) {
 	t.Parallel()
 	p := newTestProvider(t, providerTestSetup{allowed: map[string]bool{}, smithyEndpointPrefix: ""})
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if !errors.Is(err, ErrPolicyDenied) {
 		t.Errorf("err = %v, want ErrPolicyDenied", err)
 	}
@@ -59,9 +61,9 @@ func TestProvider_AuthorizeAction_endpointPrefixMismatchSkips(t *testing.T) {
 		allowed:              map[string]bool{"s3:ListBuckets": true},
 		smithyEndpointPrefix: "NOT-s3",
 	})
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("err = %v, want ErrActionUnresolved (mismatched candidate skipped)", err)
 	}
@@ -70,8 +72,8 @@ func TestProvider_AuthorizeAction_endpointPrefixMismatchSkips(t *testing.T) {
 func TestProvider_AuthorizeAction_malformedJSON(t *testing.T) {
 	t.Parallel()
 	p := newTestProvider(t, providerTestSetup{allowed: nil, smithyEndpointPrefix: ""})
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
-	err := p.AuthorizeAction(t.Context(), req, []byte(`{bad`))
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	err := p.AuthorizeAction(t.Context(), v, []byte(`{bad`))
 	if err == nil {
 		t.Errorf("expected JSON parse error")
 	}
@@ -80,8 +82,8 @@ func TestProvider_AuthorizeAction_malformedJSON(t *testing.T) {
 func TestProvider_AuthorizeAction_missingAWSAuth(t *testing.T) {
 	t.Parallel()
 	p := newTestProvider(t, providerTestSetup{allowed: nil, smithyEndpointPrefix: ""})
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
-	err := p.AuthorizeAction(t.Context(), req, []byte(`{}`))
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	err := p.AuthorizeAction(t.Context(), v, []byte(`{}`))
 	if err == nil {
 		t.Errorf("expected missing aws_auth error")
 	}
@@ -90,9 +92,9 @@ func TestProvider_AuthorizeAction_missingAWSAuth(t *testing.T) {
 func TestProvider_AuthorizeAction_unrecognizedHost(t *testing.T) {
 	t.Parallel()
 	p := newTestProvider(t, providerTestSetup{allowed: nil, smithyEndpointPrefix: ""})
-	req := mustProviderReq(t, http.MethodGet, "https://attacker.com/")
+	v := mustProviderView(t, http.MethodGet, "https://attacker.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if !errors.Is(err, ErrHostPattern) {
 		t.Errorf("err = %v, want ErrHostPattern", err)
 	}
@@ -106,9 +108,9 @@ func TestProvider_AuthorizeAction_modelResolveFails(t *testing.T) {
 		evaluator: &fakeEvaluator{allowed: nil, err: nil},
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if err == nil {
 		t.Errorf("expected archive error")
 	}
@@ -126,9 +128,9 @@ func TestProvider_AuthorizeAction_classifierUnknownOpSkips(t *testing.T) {
 		evaluator: &fakeEvaluator{allowed: map[string]bool{"s3:ListBuckets": true}, err: nil},
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodPost, "https://s3.us-east-1.amazonaws.com/foo")
+	v := mustProviderView(t, http.MethodPost, "https://s3.us-east-1.amazonaws.com/foo")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("err = %v, want ErrActionUnresolved (unknown-op candidate skipped)", err)
 	}
@@ -142,9 +144,9 @@ func TestProvider_AuthorizeAction_evaluatorFails(t *testing.T) {
 		evaluator: &fakeEvaluator{allowed: nil, err: errors.New("throttled")},
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	err := p.AuthorizeAction(t.Context(), req, raw)
+	err := p.AuthorizeAction(t.Context(), v, raw)
 	if err == nil {
 		t.Errorf("expected evaluator error")
 	}
@@ -158,9 +160,9 @@ func TestProvider_AuthorizeAction_unresolvedDenies(t *testing.T) {
 		evaluator: &fakeEvaluator{allowed: nil, err: nil},
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://s3.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-	if err := p.AuthorizeAction(t.Context(), req, raw); !errors.Is(err, ErrActionUnresolved) {
+	if err := p.AuthorizeAction(t.Context(), v, raw); !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("err = %v, want ErrActionUnresolved", err)
 	}
 }
@@ -186,9 +188,9 @@ func TestProvider_AuthorizeAction_collisionUnion(t *testing.T) {
 		evaluator: ev,
 		policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 	}
-	req := mustProviderReq(t, http.MethodGet, "https://email.us-east-1.amazonaws.com/")
+	v := mustProviderView(t, http.MethodGet, "https://email.us-east-1.amazonaws.com/")
 	raw := []byte(`{"aws_auth":{"service":"email","region":"us-east-1"}}`)
-	if err := p.AuthorizeAction(t.Context(), req, raw); err != nil {
+	if err := p.AuthorizeAction(t.Context(), v, raw); err != nil {
 		t.Fatalf("AuthorizeAction: %v", err)
 	}
 	want := []string{"ses:ListBuckets", "sesv2:ListBuckets"}
@@ -246,9 +248,9 @@ func TestProvider_AuthorizeAction_virtualHostedClassifiesObjectOps(t *testing.T)
 				evaluator: ev,
 				policyARN: "arn:aws:iam::aws:policy/SecurityAudit",
 			}
-			req := mustProviderReq(t, http.MethodGet, c.url)
+			v := mustProviderView(t, http.MethodGet, c.url)
 			raw := []byte(`{"aws_auth":{"service":"s3","region":"us-east-1"}}`)
-			if err := p.AuthorizeAction(t.Context(), req, raw); err != nil {
+			if err := p.AuthorizeAction(t.Context(), v, raw); err != nil {
 				t.Fatalf("AuthorizeAction: %v", err)
 			}
 			if !slices.Equal(ev.got, c.want) {
@@ -473,11 +475,11 @@ func (e *capturingEvaluator) AllowedAll(_ context.Context, actions []string) (bo
 	return e.allow, nil
 }
 
-func mustProviderReq(t *testing.T, method, raw string) *http.Request {
+func mustProviderView(t *testing.T, method, raw string) authreq.View {
 	t.Helper()
 	req, err := http.NewRequestWithContext(t.Context(), method, raw, nil)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	return req
+	return authreq.NewView(req, "")
 }

--- a/internal/auth/azure.go
+++ b/internal/auth/azure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	azurehardening "github.com/cynative/cynative/internal/auth/azure"
 )
 
@@ -105,14 +106,14 @@ func (p *azureProvider) AuthorizesHost(ctx context.Context, host string, rawArgs
 
 // AuthorizeAction implements auth.ActionAuthorizer, delegating to the composed
 // Layer 1 + Layer 2 provider after lazy init.
-func (p *azureProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *azureProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	if err := p.ensureReady(ctx); err != nil {
 		return err
 	}
 	if p.hardeningAction == nil {
 		return errors.New("azure_hardening: action authorizer not initialized")
 	}
-	return p.hardeningAction.AuthorizeAction(ctx, req, rawArgs)
+	return p.hardeningAction.AuthorizeAction(ctx, v, rawArgs)
 }
 
 // InjectAuth rejects a model-supplied SAS credential (the generic credential

--- a/internal/auth/azure/classifier.go
+++ b/internal/auth/azure/classifier.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // Action is the derived RBAC Action. Full is the canonical
@@ -53,20 +55,20 @@ var pollSegments = map[string]bool{"operations": true, "operationstatuses": true
 // resource names.
 const typeNameStride = 2
 
-// DeriveAction resolves req to exactly one candidate RBAC Action, deny-on-ambiguity.
-// Pure modulo the injected Catalog port. The service is never read from the claim —
+// DeriveAction resolves v to exactly one candidate RBAC Action, deny-on-ambiguity.
+// Pure modulo the injected Catalog port. The service is never read from the claim -
 // the namespace comes from the URL path (the last /providers/ segment).
-func DeriveAction(ctx context.Context, req *http.Request, cat Catalog) (Action, error) {
-	method := strings.ToUpper(req.Method)
-	segs := splitPath(req.URL.Path)
+func DeriveAction(ctx context.Context, v authreq.View, cat Catalog) (Action, error) {
+	method := strings.ToUpper(v.Method)
+	segs := splitPath(v.Path)
 
 	// Reject any non-canonical path segment before classification: both the
 	// provider-less template alignment and the poll even/odd parity rely on
-	// segment positions, and req.URL.Path reaches us verbatim (no upstream
+	// segment positions, and the decoded path reaches us verbatim (no upstream
 	// path.Clean), so an empty, ".", or ".." segment, or a percent-encoded
 	// slash (%2F), could otherwise skew parity or diverge decoded/wire form.
-	if nonCanonicalPath(req.URL.EscapedPath(), segs) {
-		return Action{}, fmt.Errorf("%w: non-canonical path %q", ErrActionUnresolved, req.URL.EscapedPath())
+	if nonCanonicalPath(v.EscapedPath, segs) {
+		return Action{}, fmt.Errorf("%w: non-canonical path %q", ErrActionUnresolved, v.EscapedPath)
 	}
 
 	namespace, rest, ok := resolveNamespace(segs)

--- a/internal/auth/azure/classifier_internal_test.go
+++ b/internal/auth/azure/classifier_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // classifierFakeCatalog is a hand-written Catalog fake for the pure classifier tests.
@@ -72,13 +74,13 @@ func classifierCatalog() classifierFakeCatalog {
 	}
 }
 
-func creq(t *testing.T, method, rawurl string) *http.Request {
+func deriveView(t *testing.T, method, rawurl string) authreq.View {
 	t.Helper()
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
-	return &http.Request{Method: method, URL: u, Header: http.Header{}}
+	return authreq.NewView(&http.Request{Method: method, URL: u, Header: http.Header{}}, "")
 }
 
 func TestDeriveAction(t *testing.T) {
@@ -87,13 +89,13 @@ func TestDeriveAction(t *testing.T) {
 	cat := classifierCatalog()
 	tests := []struct {
 		name     string
-		req      *http.Request
+		v        authreq.View
 		wantFull string
 		wantErr  error
 	}{
 		{
 			name: "GET get → read",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm?api-version=2023-03-01",
@@ -102,7 +104,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "GET list → read (shared with get)",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines",
@@ -111,7 +113,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "PUT → write",
-			req: creq(
+			v: deriveView(
 				t,
 				"PUT",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
@@ -120,7 +122,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "PATCH → write",
-			req: creq(
+			v: deriveView(
 				t,
 				"PATCH",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
@@ -129,7 +131,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "DELETE → delete",
-			req: creq(
+			v: deriveView(
 				t,
 				"DELETE",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
@@ -138,7 +140,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "POST instance action → action",
-			req: creq(
+			v: deriveView(
 				t,
 				"POST",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm/runCommand",
@@ -147,7 +149,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "Storage listKeys POST → /action (NOT /read), isDataAction irrelevant",
-			req: creq(
+			v: deriveView(
 				t,
 				"POST",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/a/listKeys",
@@ -156,12 +158,12 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name:     "ResourceGraph POST-read → resources/read (allow-list)",
-			req:      creq(t, "POST", "https://management.azure.com/providers/Microsoft.ResourceGraph/resources"),
+			v:        deriveView(t, "POST", "https://management.azure.com/providers/Microsoft.ResourceGraph/resources"),
 			wantFull: "Microsoft.ResourceGraph/resources/read",
 		},
 		{
 			name: "nested /providers/ namespace shift → last /providers/ wins",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/w/providers/Microsoft.SecurityInsights/incidents/i",
@@ -170,12 +172,12 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name:     "provider-less subscriptions root → Microsoft.Resources read",
-			req:      creq(t, "GET", "https://management.azure.com/subscriptions"),
+			v:        deriveView(t, "GET", "https://management.azure.com/subscriptions"),
 			wantFull: "Microsoft.Resources/subscriptions/read",
 		},
 		{
 			name: "GET async poll shape → scope-level read",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/locations/eastus/operations/op123",
@@ -184,7 +186,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "Cosmos readonlykeys POST dual → ambiguity DENY",
-			req: creq(
+			v: deriveView(
 				t,
 				"POST",
 				"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.DocumentDB/databaseAccounts/a/readonlykeys",
@@ -193,7 +195,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "unknown resource type → unresolved",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/widgets/w",
@@ -202,7 +204,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "GET unregistered segment trailing a known type → unresolved",
-			req: creq(
+			v: deriveView(
 				t,
 				"GET",
 				"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines/vm/bogus/x",
@@ -211,7 +213,7 @@ func TestDeriveAction(t *testing.T) {
 		},
 		{
 			name: "POST two unregistered trailing segments → unresolved",
-			req: creq(
+			v: deriveView(
 				t,
 				"POST",
 				"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines/vm/bogus/b/doThing",
@@ -224,7 +226,7 @@ func TestDeriveAction(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := DeriveAction(context.Background(), tc.req, cat)
+			got, err := DeriveAction(context.Background(), tc.v, cat)
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {
 					t.Fatalf("DeriveAction err = %v, want %v", err, tc.wantErr)
@@ -248,7 +250,7 @@ func TestDeriveActionRunCommandVsRunCommands(t *testing.T) {
 
 	cat := classifierCatalog()
 
-	action, err := DeriveAction(context.Background(), creq(
+	action, err := DeriveAction(context.Background(), deriveView(
 		t,
 		"POST",
 		"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm/runCommand",
@@ -257,7 +259,7 @@ func TestDeriveActionRunCommandVsRunCommands(t *testing.T) {
 		t.Fatalf("runCommand action = %q err=%v", action.Full, err)
 	}
 
-	child, err := DeriveAction(context.Background(), creq(
+	child, err := DeriveAction(context.Background(), deriveView(
 		t,
 		"GET",
 		"https://management.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm/runCommands/rc",
@@ -275,7 +277,7 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	ctx := context.Background()
 
 	// providerLessAction: POST on a provider-less path → ErrActionUnresolved (line 82).
-	_, err := DeriveAction(ctx, creq(t, "POST", "https://management.azure.com/subscriptions"), cat)
+	_, err := DeriveAction(ctx, deriveView(t, "POST", "https://management.azure.com/subscriptions"), cat)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("provider-less POST: want ErrActionUnresolved, got %v", err)
 	}
@@ -283,13 +285,13 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	// providerLessAction: bare /managementGroups is NOT a real ARM route (real
 	// route is provider-ful /providers/Microsoft.Management/managementGroups), so
 	// it now fails closed. Do NOT re-add a managementgroups branch.
-	_, mgErr := DeriveAction(ctx, creq(t, "GET", "https://management.azure.com/managementGroups"), cat)
+	_, mgErr := DeriveAction(ctx, deriveView(t, "GET", "https://management.azure.com/managementGroups"), cat)
 	if !errors.Is(mgErr, ErrActionUnresolved) {
 		t.Errorf("bare managementGroups: want ErrActionUnresolved, got %v", mgErr)
 	}
 
 	// providerLessAction: unknown root → ErrActionUnresolved (line 91).
-	_, err = DeriveAction(ctx, creq(t, "GET", "https://management.azure.com/unknown"), cat)
+	_, err = DeriveAction(ctx, deriveView(t, "GET", "https://management.azure.com/unknown"), cat)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("provider-less unknown root: want ErrActionUnresolved, got %v", err)
 	}
@@ -302,7 +304,7 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	}
 	// Use a catalog that injects an error via a wrapper that implements Catalog.
 	catErr := errFetchCatalog{}
-	_, err = DeriveAction(ctx, creq(t, "GET",
+	_, err = DeriveAction(ctx, deriveView(t, "GET",
 		"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines/vm"), catErr)
 	if !errors.Is(err, ErrCatalogUnavailable) {
 		t.Errorf("ResourceTypes fetch error: want ErrCatalogUnavailable, got %v", err)
@@ -310,7 +312,7 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	_ = errCat // used above to document intent; errFetchCatalog is the real injector.
 
 	// verbAction unsupported method (line 168).
-	_, err = DeriveAction(ctx, creq(t, "HEAD",
+	_, err = DeriveAction(ctx, deriveView(t, "HEAD",
 		"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines/vm"), cat)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("HEAD method: want ErrActionUnresolved, got %v", err)
@@ -319,7 +321,7 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	// postAction catalog lookup error (line 177): ResourceTypes must succeed (so
 	// resolveResourceType finds the type) but LookupOperation fails.
 	catLookupErr := lookupErrCatalog{}
-	_, err = DeriveAction(ctx, creq(
+	_, err = DeriveAction(ctx, deriveView(
 		t,
 		"POST",
 		"https://management.azure.com/subscriptions/s/providers/Microsoft.Storage/storageAccounts/a/listKeys",
@@ -329,7 +331,7 @@ func TestDeriveActionCoverageGaps(t *testing.T) {
 	}
 
 	// splitPath empty path (line 211): provider-less root with empty path → segs nil → len==0.
-	_, err = DeriveAction(ctx, creq(t, "GET", "https://management.azure.com/"), cat)
+	_, err = DeriveAction(ctx, deriveView(t, "GET", "https://management.azure.com/"), cat)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("empty path: want ErrActionUnresolved, got %v", err)
 	}
@@ -374,7 +376,7 @@ func TestDeriveAction_emptySegmentRejected(t *testing.T) {
 	for _, u := range cases {
 		t.Run(u, func(t *testing.T) {
 			t.Parallel()
-			if _, err := DeriveAction(ctx, creq(t, "GET", u), cat); !errors.Is(err, ErrActionUnresolved) {
+			if _, err := DeriveAction(ctx, deriveView(t, "GET", u), cat); !errors.Is(err, ErrActionUnresolved) {
 				t.Errorf("empty segment %q: want ErrActionUnresolved, got %v", u, err)
 			}
 		})
@@ -399,7 +401,7 @@ func TestDeriveAction_nonCanonicalPathRejected(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := DeriveAction(ctx, creq(t, "GET", c.url), cat); !errors.Is(err, ErrActionUnresolved) {
+			if _, err := DeriveAction(ctx, deriveView(t, "GET", c.url), cat); !errors.Is(err, ErrActionUnresolved) {
 				t.Errorf("%s (%s): want ErrActionUnresolved, got %v", c.name, c.url, err)
 			}
 		})
@@ -456,7 +458,7 @@ func TestProviderLessAction_routeTable(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
 			t.Parallel()
-			got, err := DeriveAction(ctx, creq(t, "GET", c.url), cat)
+			got, err := DeriveAction(ctx, deriveView(t, "GET", c.url), cat)
 			if err != nil || got.Full != c.wantFull {
 				t.Errorf("derive %s: got %q err=%v, want %q", c.url, got.Full, err, c.wantFull)
 			}
@@ -480,7 +482,7 @@ func TestProviderLessAction_failsClosed(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := DeriveAction(ctx, creq(t, c.method, c.url), cat); !errors.Is(err, ErrActionUnresolved) {
+			if _, err := DeriveAction(ctx, deriveView(t, c.method, c.url), cat); !errors.Is(err, ErrActionUnresolved) {
 				t.Errorf("%s: want ErrActionUnresolved, got %v", c.name, err)
 			}
 		})
@@ -565,7 +567,7 @@ func TestPollAction_positionalShapes(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := DeriveAction(ctx, creq(t, "GET", c.url), cat)
+			got, err := DeriveAction(ctx, deriveView(t, "GET", c.url), cat)
 			if c.wantErr {
 				if !errors.Is(err, ErrActionUnresolved) {
 					t.Errorf("%s: want ErrActionUnresolved, got %q err=%v", c.name, got.Full, err)
@@ -587,7 +589,7 @@ func TestPollAction_bareMarkerAtInstancePositionFallsThrough(t *testing.T) {
 	// and not the namespace root → must fall through to resolveResourceType. The
 	// catalog has no virtualMachines/operations type, so it fails closed.
 	u := "https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines/vm/operations"
-	if _, err := DeriveAction(ctx, creq(t, "GET", u), cat); !errors.Is(err, ErrActionUnresolved) {
+	if _, err := DeriveAction(ctx, deriveView(t, "GET", u), cat); !errors.Is(err, ErrActionUnresolved) {
 		t.Errorf("bare marker at instance position: want ErrActionUnresolved (not a poll), got %v", err)
 	}
 }
@@ -618,7 +620,7 @@ func TestProviderLessAction_emittedActionsValidateAgainstCatalog(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
 			t.Parallel()
-			a, err := DeriveAction(ctx, creq(t, "GET", c.url), cat)
+			a, err := DeriveAction(ctx, deriveView(t, "GET", c.url), cat)
 			if err != nil || a.Full != c.wantFull {
 				t.Fatalf("derive %s: got %q err=%v, want %q", c.url, a.Full, err, c.wantFull)
 			}

--- a/internal/auth/azure/provider.go
+++ b/internal/auth/azure/provider.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // Provider is the composed pure Layer-2 provider that internal/auth/azure.go
@@ -41,7 +42,7 @@ type azureArgsShape struct {
 // The service is derived from the URL path (the last /providers/ namespace);
 // azure_auth.service is only verified against it, never used as a source.
 // Fails closed on any unresolved step.
-func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *Provider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	var args azureArgsShape
 	if err := json.Unmarshal(rawArgs, &args); err != nil {
 		return fmt.Errorf("azure_hardening: parse azure_auth: %w", err)
@@ -51,7 +52,7 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 	}
 
 	// Layer 2: structural action derivation (service from URL path only).
-	action, err := DeriveAction(ctx, req, p.catalog)
+	action, err := DeriveAction(ctx, v, p.catalog)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/azure/provider_internal_test.go
+++ b/internal/auth/azure/provider_internal_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // providerFakeCatalog wires both ResourceTypes (for derivation) and
@@ -90,13 +92,13 @@ func azArgs(t *testing.T, service string) json.RawMessage {
 	return b
 }
 
-func areq(t *testing.T, method, rawurl string) *http.Request {
+func providerView(t *testing.T, method, rawurl string) authreq.View {
 	t.Helper()
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		t.Fatalf("url: %v", err)
 	}
-	return (&http.Request{Method: method, URL: u, Header: http.Header{}}).WithContext(context.Background())
+	return authreq.NewView(&http.Request{Method: method, URL: u, Header: http.Header{}}, "")
 }
 
 func TestProviderAuthorizeAction(t *testing.T) {
@@ -149,7 +151,7 @@ func TestProviderAuthorizeAction(t *testing.T) {
 			t.Parallel()
 
 			p := buildProvider(t)
-			err := p.AuthorizeAction(context.Background(), areq(t, tc.method, tc.url), azArgs(t, tc.service))
+			err := p.AuthorizeAction(context.Background(), providerView(t, tc.method, tc.url), azArgs(t, tc.service))
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {
 					t.Fatalf("AuthorizeAction err = %v, want %v", err, tc.wantErr)
@@ -167,9 +169,15 @@ func TestProviderMissingAzureAuth(t *testing.T) {
 	t.Parallel()
 
 	p := buildProvider(t)
-	if err := p.AuthorizeAction(context.Background(),
-		areq(t, "GET", "https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines"),
-		json.RawMessage(`{}`)); err == nil {
+	if err := p.AuthorizeAction(
+		context.Background(),
+		providerView(
+			t,
+			"GET",
+			"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines",
+		),
+		json.RawMessage(`{}`),
+	); err == nil {
 		t.Fatal("missing azure_auth must error")
 	}
 }
@@ -178,9 +186,15 @@ func TestProviderInvalidJSON(t *testing.T) {
 	t.Parallel()
 
 	p := buildProvider(t)
-	err := p.AuthorizeAction(context.Background(),
-		areq(t, "GET", "https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines"),
-		json.RawMessage(`not-json`))
+	err := p.AuthorizeAction(
+		context.Background(),
+		providerView(
+			t,
+			"GET",
+			"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines",
+		),
+		json.RawMessage(`not-json`),
+	)
 	if err == nil {
 		t.Fatal("invalid JSON must error")
 	}
@@ -205,9 +219,15 @@ func TestProviderValidateActionError(t *testing.T) {
 	eval := NewRoleEvaluator(RolePermissions{Actions: []string{"*/read"}})
 	p := NewProvider(cat, eval, "Reader")
 
-	err := p.AuthorizeAction(context.Background(),
-		areq(t, "GET", "https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines"),
-		azArgs(t, "Microsoft.Compute"))
+	err := p.AuthorizeAction(
+		context.Background(),
+		providerView(
+			t,
+			"GET",
+			"https://management.azure.com/subscriptions/s/providers/Microsoft.Compute/virtualMachines",
+		),
+		azArgs(t, "Microsoft.Compute"),
+	)
 	if !errors.Is(err, ErrActionUnresolved) {
 		t.Fatalf("expected ErrActionUnresolved, got %v", err)
 	}

--- a/internal/auth/azure_internal_test.go
+++ b/internal/auth/azure_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	azurehardening "github.com/cynative/cynative/internal/auth/azure"
 )
 
@@ -79,7 +80,7 @@ type fakeAzureAction struct {
 	retErr error
 }
 
-func (f *fakeAzureAction) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+func (f *fakeAzureAction) AuthorizeAction(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 	f.called = true
 	return f.retErr
 }
@@ -193,9 +194,8 @@ func TestAzureAuthorizeAction_Delegates(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAzureAction{} //nolint:exhaustruct // retErr nil.
 	p := newTestAzureProvider(fakeAzureCred{token: "tok"}, fake)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://management.azure.com/subscriptions", nil)
-	if err := p.AuthorizeAction(context.Background(), req,
+	v := actionView(t, http.MethodGet, "https://management.azure.com/subscriptions")
+	if err := p.AuthorizeAction(context.Background(), v,
 		json.RawMessage(`{"azure_auth":{"service":"Microsoft.Resources"}}`)); err != nil {
 		t.Fatalf("AuthorizeAction = %v", err)
 	}
@@ -207,8 +207,8 @@ func TestAzureAuthorizeAction_Delegates(t *testing.T) {
 func TestAzureAuthorizeAction_LazyError(t *testing.T) {
 	t.Parallel()
 	p := newTestAzureProviderLazyErr("init-failed")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://management.azure.com/x", nil)
-	if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+	v := actionView(t, http.MethodGet, "https://management.azure.com/x")
+	if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 		t.Error("AuthorizeAction should error on lazy failure")
 	}
 }
@@ -219,8 +219,8 @@ func TestAzureAuthorizeAction_NilHardening(t *testing.T) {
 		catalog: fakeAzureCatalog{},
 	}
 	p.doLazyResolve = func(_ context.Context) error { return nil } // leaves hardeningAction nil.
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://management.azure.com/x", nil)
-	if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+	v := actionView(t, http.MethodGet, "https://management.azure.com/x")
+	if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 		t.Error("AuthorizeAction should error when hardeningAction is nil")
 	}
 }
@@ -258,8 +258,12 @@ func TestAzureInjectAuth_UsesResolvedScope(t *testing.T) {
 	var p *azureProvider
 	p = newAzureProvider(fakeAzureCatalog{}, "https://management.usgovcloudapi.net/.default",
 		func(_ context.Context) error { p.scopedCredential = cred; return nil })
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://management.usgovcloudapi.net/x", nil)
+	req, _ := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://management.usgovcloudapi.net/x",
+		nil,
+	)
 	if err := p.InjectAuth(req, json.RawMessage(`{}`)); err != nil {
 		t.Fatalf("InjectAuth = %v", err)
 	}
@@ -289,8 +293,12 @@ func TestAzureInjectAuth_TokenError(t *testing.T) {
 func TestAzureInjectAuth_RejectsModelSAS(t *testing.T) {
 	t.Parallel()
 	p := newTestAzureProvider(fakeAzureCred{token: "scoped-token"}, &fakeAzureAction{})
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://management.azure.com/x?sig=abc&sv=2021", nil)
+	req, _ := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://management.azure.com/x?sig=abc&sv=2021",
+		nil,
+	)
 	err := p.InjectAuth(req, json.RawMessage(`{}`))
 	if !errors.Is(err, azurehardening.ErrModelSuppliedCredential) {
 		t.Errorf("InjectAuth SAS = %v, want ErrModelSuppliedCredential", err)

--- a/internal/auth/eks.go
+++ b/internal/auth/eks.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 const eksProviderName = "eks"
@@ -156,13 +158,13 @@ func (p *eksProvider) resolveCluster(ctx context.Context, args *EKSAuthArgs) (cl
 // AuthorizeAction enforces the read-only ClusterRole posture for EKS Kubernetes API
 // requests via the shared k8sGate. It implements the optional
 // auth.ActionAuthorizer interface.
-func (p *eksProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *eksProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	args, err := parseEKSArgs(rawArgs)
 	if err != nil {
 		return err
 	}
 
-	return p.authorizeAction(ctx, req, args)
+	return p.authorizeAction(ctx, v, args)
 }
 
 func (p *eksProvider) CACertData(ctx context.Context, rawArgs json.RawMessage) (string, error) {

--- a/internal/auth/gcp.go
+++ b/internal/auth/gcp.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	gcphardening "github.com/cynative/cynative/internal/auth/gcp"
 )
 
@@ -111,14 +112,14 @@ func (p *gcpProvider) AuthorizesHost(ctx context.Context, host string, rawArgs j
 
 // AuthorizeAction implements auth.ActionAuthorizer, delegating to the composed
 // Layer 2 provider after lazy init.
-func (p *gcpProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *gcpProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	if err := p.ensureReady(ctx); err != nil {
 		return err
 	}
 	if p.hardeningAction == nil {
 		return errors.New("gcp_hardening: action authorizer not initialized")
 	}
-	return p.hardeningAction.AuthorizeAction(ctx, req, rawArgs)
+	return p.hardeningAction.AuthorizeAction(ctx, v, rawArgs)
 }
 
 // InjectAuth attaches the raw ADC bearer token. Read-only and host gating are

--- a/internal/auth/gcp/catalog_internal_test.go
+++ b/internal/auth/gcp/catalog_internal_test.go
@@ -360,7 +360,7 @@ func TestAssembleCatalogMultiVersionSameID(t *testing.T) {
 		"https://cloudresourcemanager.googleapis.com/v1/projects",
 		"https://cloudresourcemanager.googleapis.com/v3/projects",
 	} {
-		got, cerr := Classify(idx, req(t, "GET", path))
+		got, cerr := Classify(idx, classifyView(t, "GET", path))
 		if cerr != nil || got != "cloudresourcemanager.projects.list" {
 			t.Errorf("Classify(%s) = %q err=%v, want cloudresourcemanager.projects.list", path, got, cerr)
 		}

--- a/internal/auth/gcp/classifier.go
+++ b/internal/auth/gcp/classifier.go
@@ -3,16 +3,17 @@ package gcp
 import (
 	"fmt"
 	"maps"
-	"net/http"
 	"slices"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
-// Classify resolves req to exactly one Discovery method id from idx, or returns
+// Classify resolves v to exactly one Discovery method id from idx, or returns
 // ErrClassifierUnknownOp on zero or multiple survivors. Deterministic. Pure.
-func Classify(idx MethodIndex, req *http.Request) (string, error) {
-	method := strings.ToUpper(req.Method)
-	path := strings.Trim(req.URL.Path, "/")
+func Classify(idx MethodIndex, v authreq.View) (string, error) {
+	method := strings.ToUpper(v.Method)
+	path := strings.Trim(v.Path, "/")
 
 	keys := slices.Sorted(maps.Keys(idx)) // deterministic iteration.
 
@@ -41,14 +42,14 @@ func Classify(idx MethodIndex, req *http.Request) (string, error) {
 	case 1:
 		return survivors[0], nil
 	case 0:
-		return "", fmt.Errorf("%w: no method matches %s %s", ErrClassifierUnknownOp, method, req.URL.Path)
+		return "", fmt.Errorf("%w: no method matches %s %s", ErrClassifierUnknownOp, method, v.Path)
 	default:
 		return "", fmt.Errorf(
 			"%w: %d methods match %s %s (ambiguous)",
 			ErrClassifierUnknownOp,
 			len(survivors),
 			method,
-			req.URL.Path,
+			v.Path,
 		)
 	}
 }

--- a/internal/auth/gcp/classifier_internal_test.go
+++ b/internal/auth/gcp/classifier_internal_test.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
-func req(t *testing.T, method, rawurl string) *http.Request {
+func classifyView(t *testing.T, method, rawurl string) authreq.View {
 	t.Helper()
 
 	u, err := url.Parse(rawurl)
@@ -15,7 +17,7 @@ func req(t *testing.T, method, rawurl string) *http.Request {
 		t.Fatalf("parse url: %v", err)
 	}
 
-	return &http.Request{Method: method, URL: u, Header: http.Header{}}
+	return authreq.NewView(&http.Request{Method: method, URL: u, Header: http.Header{}}, "")
 }
 
 func computeIndex() MethodIndex {
@@ -83,56 +85,60 @@ func TestClassify(t *testing.T) {
 	tests := []struct {
 		name    string
 		idx     MethodIndex
-		req     *http.Request
+		v       authreq.View
 		want    string
 		wantErr bool
 	}{
 		{
 			name: "list",
 			idx:  computeIndex(),
-			req:  req(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+			v:    classifyView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 			want: "compute.instances.list",
 		},
 		{
 			name: "insert same template POST",
 			idx:  computeIndex(),
-			req:  req(t, "POST", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+			v:    classifyView(t, "POST", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 			want: "compute.instances.insert",
 		},
 		{
 			name: "get vs delete by method GET",
 			idx:  computeIndex(),
-			req:  req(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
+			v:    classifyView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
 			want: "compute.instances.get",
 		},
 		{
 			name: "delete",
 			idx:  computeIndex(),
-			req:  req(t, "DELETE", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
+			v:    classifyView(t, "DELETE", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
 			want: "compute.instances.delete",
 		},
 		{
 			name: "literal verb start",
 			idx:  computeIndex(),
-			req:  req(t, "POST", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i/start"),
+			v: classifyView(
+				t,
+				"POST",
+				"https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i/start",
+			),
 			want: "compute.instances.start",
 		},
 		{
 			name: "storage list fallback",
 			idx:  storageIndex(),
-			req:  req(t, "GET", "https://storage.googleapis.com/storage/v1/b"),
+			v:    classifyView(t, "GET", "https://storage.googleapis.com/storage/v1/b"),
 			want: "storage.buckets.list",
 		},
 		{
 			name: "media upload",
 			idx:  storageIndex(),
-			req:  req(t, "POST", "https://storage.googleapis.com/upload/storage/v1/b/mybucket/o"),
+			v:    classifyView(t, "POST", "https://storage.googleapis.com/upload/storage/v1/b/mybucket/o"),
 			want: "storage.objects.insert",
 		},
 		{
 			name:    "zero match fails",
 			idx:     computeIndex(),
-			req:     req(t, "GET", "https://compute.googleapis.com/compute/v1/nope"),
+			v:       classifyView(t, "GET", "https://compute.googleapis.com/compute/v1/nope"),
 			wantErr: true,
 		},
 	}
@@ -141,7 +147,7 @@ func TestClassify(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := Classify(tc.idx, tc.req)
+			got, err := Classify(tc.idx, tc.v)
 			if tc.wantErr {
 				if !errors.Is(err, ErrClassifierUnknownOp) {
 					t.Fatalf("Classify err = %v, want ErrClassifierUnknownOp", err)
@@ -165,7 +171,7 @@ func TestClassifyColonVerb(t *testing.T) {
 	t.Parallel()
 
 	idx := storageIndex()
-	got, err := Classify(idx, req(t, "GET", "https://storage.googleapis.com/storage/v1/b/mybucket/iam"))
+	got, err := Classify(idx, classifyView(t, "GET", "https://storage.googleapis.com/storage/v1/b/mybucket/iam"))
 	if err != nil || got != "storage.buckets.getIamPolicy" {
 		t.Fatalf("getIamPolicy classify = %q err=%v", got, err)
 	}
@@ -180,7 +186,7 @@ func TestClassifyAmbiguousFailClosed(t *testing.T) {
 		"svc.bar.get": {ID: "svc.bar.get", HTTPMethod: "GET", FlatPath: "v1/projects/{project}/foo/{foo}"},
 	}
 
-	_, err := Classify(ambiguous, req(t, "GET", "https://example.googleapis.com/v1/projects/p/foo/f"))
+	_, err := Classify(ambiguous, classifyView(t, "GET", "https://example.googleapis.com/v1/projects/p/foo/f"))
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Fatalf("ambiguous match must return ErrClassifierUnknownOp, got %v", err)
 	}
@@ -196,7 +202,7 @@ func TestClassifyLiteralMismatch(t *testing.T) {
 	// the literal "v1" segment will not match "v2", so no survivor → fail closed.
 	_, err := Classify(
 		computeIndex(),
-		req(t, "GET", "https://compute.googleapis.com/compute/v2/projects/p/zones/z/instances"),
+		classifyView(t, "GET", "https://compute.googleapis.com/compute/v2/projects/p/zones/z/instances"),
 	)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Fatalf("literal mismatch must return ErrClassifierUnknownOp, got %v", err)
@@ -225,19 +231,28 @@ func TestClassifyColonVerbCustom(t *testing.T) {
 	}
 
 	// Placeholder-base colon-verb: verb matches, base is placeholder → match.
-	got, err := Classify(idx, req(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:setIamPolicy"))
+	got, err := Classify(
+		idx,
+		classifyView(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:setIamPolicy"),
+	)
 	if err != nil || got != "svc.res.setIamPolicy" {
 		t.Fatalf("placeholder colon-verb: got %q err=%v", got, err)
 	}
 
 	// Mismatched colon-verb: request has :getIamPolicy but only :setIamPolicy exists → fail closed.
-	_, err = Classify(idx, req(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:getIamPolicy"))
+	_, err = Classify(
+		idx,
+		classifyView(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:getIamPolicy"),
+	)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Fatalf("mismatched colon-verb must return ErrClassifierUnknownOp, got %v", err)
 	}
 
 	// Literal-base colon-verb: template literal "myRes" matches request literal exactly.
-	got, err = Classify(idx, req(t, "POST", "https://example.googleapis.com/v1/globalResources/myRes:testPermissions"))
+	got, err = Classify(
+		idx,
+		classifyView(t, "POST", "https://example.googleapis.com/v1/globalResources/myRes:testPermissions"),
+	)
 	if err != nil || got != "svc.globalRes.testPermissions" {
 		t.Fatalf("literal colon-verb: got %q err=%v", got, err)
 	}
@@ -257,7 +272,10 @@ func TestClassifyRealFlatPathShape(t *testing.T) {
 			ServicePath: "compute/v1/",
 		},
 	}
-	got, err := Classify(idx, req(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"))
+	got, err := Classify(
+		idx,
+		classifyView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+	)
 	if err != nil || got != "compute.instances.list" {
 		t.Fatalf("real-shape classify: got=%q err=%v, want compute.instances.list", got, err)
 	}
@@ -273,12 +291,12 @@ func TestClassifySplitSegmentsEmpty(t *testing.T) {
 		"svc.root.get": {ID: "svc.root.get", HTTPMethod: "GET", FlatPath: ""},
 	}
 	// A request to the root "/" path (trimmed → "") must match.
-	got, err := Classify(idx, req(t, "GET", "https://example.googleapis.com/"))
+	got, err := Classify(idx, classifyView(t, "GET", "https://example.googleapis.com/"))
 	if err != nil || got != "svc.root.get" {
 		t.Fatalf("empty flatPath root match: got %q err=%v", got, err)
 	}
 	// A request with any non-empty path must not match.
-	_, err = Classify(idx, req(t, "GET", "https://example.googleapis.com/v1/something"))
+	_, err = Classify(idx, classifyView(t, "GET", "https://example.googleapis.com/v1/something"))
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Fatalf("non-empty path vs empty template must fail closed, got %v", err)
 	}
@@ -299,7 +317,10 @@ func TestClassifyBarePlaceholderRejectsCustomVerb(t *testing.T) {
 		},
 	}
 
-	_, err := Classify(idx, req(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:customVerb"))
+	_, err := Classify(
+		idx,
+		classifyView(t, "POST", "https://example.googleapis.com/v1/projects/p/resources/r:customVerb"),
+	)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
 		t.Fatalf("custom-verb request must not match a bare-placeholder template, got %v", err)
 	}

--- a/internal/auth/gcp/provider.go
+++ b/internal/auth/gcp/provider.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // Provider is the composed pure Layer-2 provider that internal/auth/gcp.go
@@ -48,7 +49,7 @@ type gcpArgsShape struct {
 // For www.googleapis.com, the service is resolved from the PATH (via
 // resolveService) and then verified against the gcp_auth.service claim here —
 // because Layer 3 (AuthorizesHost) cannot do that check without the path.
-func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *Provider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	var args gcpArgsShape
 	if err := json.Unmarshal(rawArgs, &args); err != nil {
 		return fmt.Errorf("gcp_hardening: parse gcp_auth: %w", err)
@@ -58,10 +59,9 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 		return errors.New("gcp_hardening: gcp_auth.service is required")
 	}
 
-	host := strings.ToLower(req.URL.Hostname())
-	isWWW := host == wwwGoogleapisHost
+	isWWW := v.Hostname == wwwGoogleapisHost
 
-	service, err := p.resolveService(ctx, req)
+	service, err := p.resolveService(ctx, v)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 		return err
 	}
 
-	methodID, err := Classify(idx, req)
+	methodID, err := Classify(idx, v)
 	if err != nil {
 		return err
 	}
@@ -100,22 +100,20 @@ func (p *Provider) AuthorizeAction(ctx context.Context, req *http.Request, rawAr
 
 // resolveService derives the service from the request HOST only, handling the
 // www.googleapis.com compound case by falling back to path-based resolution.
-func (p *Provider) resolveService(ctx context.Context, req *http.Request) (string, error) {
-	host := strings.ToLower(req.URL.Hostname())
-
-	parsed, err := ParseHost(host)
+func (p *Provider) resolveService(ctx context.Context, v authreq.View) (string, error) {
+	parsed, err := ParseHost(v.Hostname)
 	if err != nil {
 		return "", err
 	}
 
 	if parsed.Service == wwwCompoundSentinel {
-		svc, ok := p.catalog.ResolveWWWService(ctx, req.URL.Path)
+		svc, ok := p.catalog.ResolveWWWService(ctx, v.Path)
 		if !ok {
-			return "", fmt.Errorf("%w: %q (www path service not in catalog)", ErrHostPattern, req.URL.Path)
+			return "", fmt.Errorf("%w: %q (www path service not in catalog)", ErrHostPattern, v.Path)
 		}
 
 		return svc, nil
 	}
 
-	return p.catalog.ResolveService(ctx, parsed, host)
+	return p.catalog.ResolveService(ctx, parsed, v.Hostname)
 }

--- a/internal/auth/gcp/provider_internal_test.go
+++ b/internal/auth/gcp/provider_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // buildProvider builds a Provider wired with a catalog that carries the full
@@ -53,7 +55,7 @@ func gcpArgs(t *testing.T, svc string) json.RawMessage {
 	return b
 }
 
-func httpReq(t *testing.T, method, rawurl string) *http.Request {
+func providerView(t *testing.T, method, rawurl string) authreq.View {
 	t.Helper()
 
 	u, err := url.Parse(rawurl)
@@ -61,7 +63,7 @@ func httpReq(t *testing.T, method, rawurl string) *http.Request {
 		t.Fatalf("url: %v", err)
 	}
 
-	return (&http.Request{Method: method, URL: u, Header: http.Header{}}).WithContext(context.Background())
+	return authreq.NewView(&http.Request{Method: method, URL: u, Header: http.Header{}}, "")
 }
 
 func TestProviderAuthorizeActionAllowRead(t *testing.T) {
@@ -71,7 +73,7 @@ func TestProviderAuthorizeActionAllowRead(t *testing.T) {
 
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		gcpArgs(t, "compute"),
 	); err != nil {
 		t.Fatalf("allowed read errored: %v", err)
@@ -86,7 +88,7 @@ func TestProviderAuthorizeActionDenyWrite(t *testing.T) {
 	// DELETE is a write — PermissionResolver returns SourceNone → ErrPermissionUnresolved.
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "DELETE", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
+		providerView(t, "DELETE", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances/i"),
 		gcpArgs(t, "compute"),
 	)
 	if !errors.Is(err, ErrPermissionUnresolved) && !errors.Is(err, ErrPermissionDenied) {
@@ -102,7 +104,7 @@ func TestProviderAuthorizeActionMissingGCPAuth(t *testing.T) {
 	// {} has no gcp_auth key → nil struct → explicit error (A15).
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		json.RawMessage(`{}`),
 	); err == nil {
 		t.Fatal("missing gcp_auth should error")
@@ -117,7 +119,7 @@ func TestProviderAuthorizeActionUnknownHost(t *testing.T) {
 	// madeupservice is not in the catalog → fail closed.
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://madeupservice.googleapis.com/x"),
+		providerView(t, "GET", "https://madeupservice.googleapis.com/x"),
 		gcpArgs(t, "madeupservice"),
 	); err == nil {
 		t.Fatal("unknown host should fail closed")
@@ -146,7 +148,7 @@ func TestProviderAuthorizeActionPermissionDenied(t *testing.T) {
 
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		gcpArgs(t, "compute"),
 	)
 	if !errors.Is(err, ErrPermissionDenied) {
@@ -164,7 +166,7 @@ func TestProviderAuthorizeActionWWWPath(t *testing.T) {
 	// oauth2.tokeninfo is permissionless → should succeed.
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
+		providerView(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
 		gcpArgs(t, "oauth2"),
 	); err != nil {
 		t.Fatalf("www-path oauth2 tokeninfo should succeed, got %v", err)
@@ -182,7 +184,7 @@ func TestProviderAuthorizeActionWWWClaimMismatch(t *testing.T) {
 	// Path resolves to "oauth2" (servicePath oauth2/v2/) but claim says "storage".
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
+		providerView(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
 		gcpArgs(t, "storage"),
 	)
 	if !errors.Is(err, ErrHostClaimMismatch) {
@@ -198,7 +200,7 @@ func TestProviderAuthorizeActionWWWPathUnknown(t *testing.T) {
 	// www.googleapis.com path does not match any servicePath → fail closed.
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://www.googleapis.com/notaservice/v9/x"),
+		providerView(t, "GET", "https://www.googleapis.com/notaservice/v9/x"),
 		gcpArgs(t, "notaservice"),
 	); err == nil {
 		t.Fatal("unknown www path should fail closed")
@@ -212,7 +214,7 @@ func TestProviderAuthorizeActionBadJSON(t *testing.T) {
 
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		json.RawMessage(`not json`),
 	); err == nil {
 		t.Fatal("bad JSON should error")
@@ -233,7 +235,7 @@ func TestProviderAuthorizeActionNonCatalogWWW(t *testing.T) {
 
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
+		providerView(t, "GET", "https://www.googleapis.com/oauth2/v2/tokeninfo"),
 		gcpArgs(t, "oauth2"),
 	); !errors.Is(err, ErrHostPattern) {
 		t.Fatalf("non-catalog www should return ErrHostPattern, got %v", err)
@@ -248,7 +250,7 @@ func TestProviderAuthorizeActionBadHost(t *testing.T) {
 	// localhost is rejected by ParseHost (SSRF guard) → line 84 error branch.
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://localhost/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://localhost/compute/v1/projects/p/zones/z/instances"),
 		gcpArgs(t, "compute"),
 	); err == nil {
 		t.Fatal("localhost host should fail closed")
@@ -284,7 +286,7 @@ func TestProviderAuthorizeActionMethodIndexError(t *testing.T) {
 
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		gcpArgs(t, "compute"),
 	)
 	if err == nil {
@@ -314,7 +316,7 @@ func TestProviderAuthorizeActionClassifyError(t *testing.T) {
 
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
+		providerView(t, "GET", "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"),
 		gcpArgs(t, "compute"),
 	)
 	if !errors.Is(err, ErrClassifierUnknownOp) {
@@ -439,7 +441,7 @@ func TestProviderAuthorizeActionCRMProjectsListV1Allowed(t *testing.T) {
 	} {
 		if aerr := p.AuthorizeAction(
 			context.Background(),
-			httpReq(t, "GET", path),
+			providerView(t, "GET", path),
 			gcpArgs(t, "cloudresourcemanager"),
 		); aerr != nil {
 			t.Errorf("AuthorizeAction(%s) under a granting role should be authorized, got %v", path, aerr)
@@ -459,7 +461,7 @@ func TestProviderAuthorizeActionCRMProjectsListAllowed(t *testing.T) {
 	})
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
+		providerView(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
 		gcpArgs(t, "cloudresourcemanager"),
 	); err != nil {
 		t.Fatalf("projects.list under a granting role should be authorized, got %v", err)
@@ -480,7 +482,7 @@ func TestProviderAuthorizeActionCRMProjectsListRequiresGet(t *testing.T) {
 	p := buildCRMProvider(t, map[string]bool{"resourcemanager.projects.list": true}) // .list but NOT .get.
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
+		providerView(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
 		gcpArgs(t, "cloudresourcemanager"),
 	)
 	if !errors.Is(err, ErrPermissionDenied) {
@@ -496,7 +498,7 @@ func TestProviderAuthorizeActionCRMProjectsListDenied(t *testing.T) {
 	p := buildCRMProvider(t, map[string]bool{})
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
+		providerView(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects"),
 		gcpArgs(t, "cloudresourcemanager"),
 	)
 	if !errors.Is(err, ErrPermissionDenied) {
@@ -511,7 +513,7 @@ func TestProviderAuthorizeActionCRMProjectsSearchAllowed(t *testing.T) {
 	p := buildCRMProvider(t, map[string]bool{"resourcemanager.projects.get": true})
 	if err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects:search"),
+		providerView(t, "GET", "https://cloudresourcemanager.googleapis.com/v3/projects:search"),
 		gcpArgs(t, "cloudresourcemanager"),
 	); err != nil {
 		t.Fatalf("projects.search under a granting role should be authorized, got %v", err)
@@ -533,7 +535,7 @@ func TestProviderAuthorizeActionCRMHierarchySearchDenied(t *testing.T) {
 	} {
 		err := p.AuthorizeAction(
 			context.Background(),
-			httpReq(t, "GET", path),
+			providerView(t, "GET", path),
 			gcpArgs(t, "cloudresourcemanager"),
 		)
 		if !errors.Is(err, ErrPermissionDenied) {
@@ -632,7 +634,7 @@ func TestProviderAuthorizeActionContainerReadsAllowed(t *testing.T) {
 	} {
 		if err := p.AuthorizeAction(
 			context.Background(),
-			httpReq(t, "GET", path),
+			providerView(t, "GET", path),
 			gcpArgs(t, "container"),
 		); err != nil {
 			t.Errorf("AuthorizeAction(%s) under roles/viewer grants should be authorized, got %v", path, err)
@@ -650,7 +652,7 @@ func TestProviderAuthorizeActionContainerNodePoolsNeedsClusterGet(t *testing.T) 
 	p := buildContainerProvider(t, map[string]bool{"container.clusters.list": true}) // .list but NOT .get.
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(
+		providerView(
 			t,
 			"GET",
 			"https://container.googleapis.com/v1/projects/p/locations/us-central1-a/clusters/c/nodePools",
@@ -701,7 +703,7 @@ func TestProviderAuthorizeActionContainerMappingsAreDistinct(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			p := buildContainerProvider(t, map[string]bool{tc.granted: true})
-			err := p.AuthorizeAction(context.Background(), httpReq(t, "GET", tc.url), gcpArgs(t, "container"))
+			err := p.AuthorizeAction(context.Background(), providerView(t, "GET", tc.url), gcpArgs(t, "container"))
 			if !errors.Is(err, ErrPermissionDenied) {
 				t.Fatalf("%s: want ErrPermissionDenied, got %v", tc.name, err)
 			}
@@ -718,7 +720,7 @@ func TestProviderAuthorizeActionContainerReadDenied(t *testing.T) {
 	p := buildContainerProvider(t, map[string]bool{})
 	err := p.AuthorizeAction(
 		context.Background(),
-		httpReq(t, "GET", "https://container.googleapis.com/v1/projects/p/locations/us-central1-a/clusters/c"),
+		providerView(t, "GET", "https://container.googleapis.com/v1/projects/p/locations/us-central1-a/clusters/c"),
 		gcpArgs(t, "container"),
 	)
 	if !errors.Is(err, ErrPermissionDenied) {

--- a/internal/auth/gcp_internal_test.go
+++ b/internal/auth/gcp_internal_test.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	gcphardening "github.com/cynative/cynative/internal/auth/gcp"
 )
 
@@ -257,7 +258,7 @@ type fakeHardeningProvider struct {
 	retErr error
 }
 
-func (f *fakeHardeningProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+func (f *fakeHardeningProvider) AuthorizeAction(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 	f.called = true
 	return f.retErr
 }
@@ -275,10 +276,10 @@ func TestGCPAuthorizeAction_Delegates(t *testing.T) {
 		return nil
 	}
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://compute.googleapis.com/", nil)
+	v := actionView(t, http.MethodGet, "https://compute.googleapis.com/")
 	if err := p.AuthorizeAction(
 		context.Background(),
-		req,
+		v,
 		json.RawMessage(`{"gcp_auth":{"service":"compute"}}`),
 	); err != nil {
 		t.Fatalf("AuthorizeAction = %v", err)
@@ -292,8 +293,8 @@ func TestGCPAuthorizeAction_LazyError(t *testing.T) {
 	t.Parallel()
 	p := newTestGCPProviderLazyErr("init-failed")
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://compute.googleapis.com/", nil)
-	if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+	v := actionView(t, http.MethodGet, "https://compute.googleapis.com/")
+	if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 		t.Error("AuthorizeAction should error when lazy init fails")
 	}
 }
@@ -310,8 +311,8 @@ func TestGCPAuthorizeAction_NilHardening(t *testing.T) {
 		return nil
 	}
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://compute.googleapis.com/", nil)
-	if err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{}`)); err == nil {
+	v := actionView(t, http.MethodGet, "https://compute.googleapis.com/")
+	if err := p.AuthorizeAction(context.Background(), v, json.RawMessage(`{}`)); err == nil {
 		t.Error("AuthorizeAction should error when hardeningAction is nil")
 	}
 }

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -286,12 +286,12 @@ func githubDialAllowed(ip netip.Addr) bool {
 // AuditResponse compares GitHub's authoritative required-permission header against
 // our classified level and logs a one-line drift warning when read may have been
 // insufficient. Advisory only; never blocks or consumes the body.
-func (p *githubProvider) AuditResponse(req *http.Request, header http.Header) {
+func (p *githubProvider) AuditResponse(v authreq.AuditView, header http.Header) {
 	accepted := header.Get("X-Accepted-Github-Permissions")
 	if accepted == "" {
 		return
 	}
-	level, err := githubhardening.RequiredLevel(req.Method, req.URL.EscapedPath())
+	level, err := githubhardening.RequiredLevel(v.Method, v.EscapedPath)
 	if err != nil {
 		return
 	}

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
-	"strings"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/auth/exposure"
 	githubhardening "github.com/cynative/cynative/internal/auth/github"
 	"github.com/cynative/cynative/internal/cache"
@@ -99,16 +99,13 @@ func (p *githubProvider) AuthorizesHost(_ context.Context, host string, _ json.R
 	return host == "api.github.com" || isGithubDownloadHost(host), nil
 }
 
-// effectiveDownloadHost returns the download host the request targets, or "" when
-// it is not a download host. The URL host is the only authority: the transport
-// rejects a model-supplied Host header, so the host classified here is always the
-// host dialed and authorized. url.Hostname already strips the port and any IPv6
-// brackets; the lower-casing is still required because net/url preserves host
-// case and AuthorizeAction receives the raw request.
-func effectiveDownloadHost(req *http.Request) string {
-	authority := strings.ToLower(req.URL.Hostname())
-	if isGithubDownloadHost(authority) {
-		return authority
+// effectiveDownloadHost returns hostname when it is one of GitHub's download
+// hosts, else "". The view lower-cases the hostname at projection and the
+// transport rejects a model-supplied authority, so the host classified here is
+// always the host dialed and authorized.
+func effectiveDownloadHost(hostname string) string {
+	if isGithubDownloadHost(hostname) {
+		return hostname
 	}
 	return ""
 }
@@ -118,17 +115,17 @@ func effectiveDownloadHost(req *http.Request) string {
 // table-independent; api.github.com requests are classified against the live table
 // and allowed iff the configured ceiling permits the required level. A missing
 // table fails closed (category table not ready). Runs before InjectAuth.
-func (p *githubProvider) AuthorizeAction(ctx context.Context, req *http.Request, _ json.RawMessage) error {
-	if githubhardening.IsGraphQLEndpoint(req.URL.EscapedPath()) {
-		return fmt.Errorf("%w: %s %s", githubhardening.ErrGraphQLUnsupported, req.Method, req.URL.EscapedPath())
+func (p *githubProvider) AuthorizeAction(ctx context.Context, v authreq.View, _ json.RawMessage) error {
+	if githubhardening.IsGraphQLEndpoint(v.EscapedPath) {
+		return fmt.Errorf("%w: %s %s", githubhardening.ErrGraphQLUnsupported, v.Method, v.EscapedPath)
 	}
 
-	if host := effectiveDownloadHost(req); host != "" {
-		if req.Method == http.MethodGet || req.Method == http.MethodHead {
+	if host := effectiveDownloadHost(v.Hostname); host != "" {
+		if v.Method == http.MethodGet || v.Method == http.MethodHead {
 			return nil
 		}
 		return fmt.Errorf("%w: %s %s to %s (download hosts are GET/HEAD-only)",
-			githubhardening.ErrExposureExceeded, req.Method, req.URL.Path, host)
+			githubhardening.ErrExposureExceeded, v.Method, v.Path, host)
 	}
 
 	table := p.tables.Get(ctx)
@@ -144,7 +141,7 @@ func (p *githubProvider) AuthorizeAction(ctx context.Context, req *http.Request,
 
 	// Use EscapedPath so a branch name like feature%2Ffoo stays as one segment and
 	// matches its template (decoded "/" would split into extra segments → no match).
-	access, err := githubhardening.ClassifyRequest(table, req.Method, req.URL.EscapedPath())
+	access, err := githubhardening.ClassifyRequest(table, v.Method, v.EscapedPath)
 	if err != nil {
 		return err
 	}
@@ -152,7 +149,7 @@ func (p *githubProvider) AuthorizeAction(ctx context.Context, req *http.Request,
 	ceiling := githubhardening.Resolve(p.exposure, access.Route.Category, access.Route.Subcategory)
 	if !exposure.Allows(ceiling, access.Level) {
 		return fmt.Errorf("%w: %s %s needs %s on %q (ceiling %s)",
-			githubhardening.ErrExposureExceeded, req.Method, req.URL.EscapedPath(),
+			githubhardening.ErrExposureExceeded, v.Method, v.EscapedPath,
 			exposure.LevelName(access.Level), access.Route.Category, exposure.LevelName(ceiling))
 	}
 	return nil

--- a/internal/auth/github_provider_internal_test.go
+++ b/internal/auth/github_provider_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/auth/exposure"
 	githubhardening "github.com/cynative/cynative/internal/auth/github"
 	"github.com/cynative/cynative/internal/cache"
@@ -41,7 +42,8 @@ func testGithubProvider(
 func okFetch(context.Context) ([]byte, error) { return []byte(provFixtureOpenAPI), nil }
 
 // getReq builds a GET request for the paths that still need a live request
-// (InjectAuth, AuditResponse); the action gate takes a view instead.
+// (InjectAuth, and AuditResponse's view projection); the action gate takes a
+// view instead.
 func getReq(t *testing.T, rawurl string) *http.Request {
 	t.Helper()
 	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawurl, nil)
@@ -160,7 +162,7 @@ func TestGithubProvider_AuditResponse_nilErrOut(t *testing.T) {
 	p.errOut = nil // nil writer — out() must substitute io.Discard, no panic.
 	h := http.Header{}
 	h.Set("X-Accepted-Github-Permissions", "issues=write") // GET classified read but GitHub wants write → drift.
-	p.AuditResponse(getReq(t, "https://api.github.com/repos/o/r/issues/1"), h)
+	p.AuditResponse(authreq.NewAuditView(getReq(t, "https://api.github.com/repos/o/r/issues/1")), h)
 }
 
 func TestGithubProvider_downloadHostGetOnly(t *testing.T) {
@@ -278,7 +280,7 @@ func TestGithubProvider_AuditResponse_drift(t *testing.T) {
 	p, buf := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	h := http.Header{}
 	h.Set("X-Accepted-Github-Permissions", "issues=write") // GET classified read but GitHub wants write.
-	p.AuditResponse(getReq(t, "https://api.github.com/repos/o/r/issues/1"), h)
+	p.AuditResponse(authreq.NewAuditView(getReq(t, "https://api.github.com/repos/o/r/issues/1")), h)
 	if !strings.Contains(buf.String(), "github_hardening") {
 		t.Errorf("expected drift warning, got %q", buf.String())
 	}
@@ -289,13 +291,13 @@ func TestGithubProvider_AuditResponse_noop(t *testing.T) {
 
 	p, buf := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	// No header → nothing logged.
-	p.AuditResponse(getReq(t, "https://api.github.com/user"), http.Header{})
+	p.AuditResponse(authreq.NewAuditView(getReq(t, "https://api.github.com/user")), http.Header{})
 	// Unrecognized method → RequiredLevel errors → nothing logged.
 	bad := getReq(t, "https://api.github.com/user")
 	bad.Method = "WAT"
 	withHdr := http.Header{}
 	withHdr.Set("X-Accepted-Github-Permissions", "issues=write")
-	p.AuditResponse(bad, withHdr)
+	p.AuditResponse(authreq.NewAuditView(bad), withHdr)
 	if buf.Len() != 0 {
 		t.Errorf("expected no audit output, got %q", buf.String())
 	}
@@ -315,17 +317,17 @@ func (plainProvider) AuthorizesHost(context.Context, string, json.RawMessage) (b
 func TestAuditResponse_dispatcher(t *testing.T) {
 	t.Parallel()
 
-	r := getReq(t, "https://api.github.com/repos/o/r/issues/1")
+	v := authreq.NewAuditView(getReq(t, "https://api.github.com/repos/o/r/issues/1"))
 	// Unknown provider name → silent no-op (find returns an error).
-	AuditResponse("nonexistent", r, http.Header{}, nil)
+	AuditResponse("nonexistent", v, http.Header{}, nil)
 	// Found but not a ResponseAuditor → silent no-op (assertion fails).
-	AuditResponse("plain", r, http.Header{}, []Provider{plainProvider{}})
+	AuditResponse("plain", v, http.Header{}, []Provider{plainProvider{}})
 
 	// Found AND a ResponseAuditor → the audit runs (drift warning emitted).
 	gh, buf := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	h := http.Header{}
 	h.Set("X-Accepted-Github-Permissions", "issues=write")
-	AuditResponse("github", r, h, []Provider{gh})
+	AuditResponse("github", v, h, []Provider{gh})
 	if !strings.Contains(buf.String(), "github_hardening") {
 		t.Errorf("dispatcher must run the auditor, got %q", buf.String())
 	}

--- a/internal/auth/github_provider_internal_test.go
+++ b/internal/auth/github_provider_internal_test.go
@@ -255,7 +255,7 @@ func TestGithubProvider_AuthorizeAction_escapedPath(t *testing.T) {
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	// A URL with %2F in the branch segment: GET /repos/o/r/branches/feature%2Ffoo/protection.
 	// The view's Path decodes to "/repos/o/r/branches/feature/foo/protection" (too many
-	// segments), but its EscapedPath preserves "%2F" as one segment — matching the template.
+	// segments), but its EscapedPath preserves "%2F" as one segment, matching the template.
 	v := actionView(t, "GET", "https://api.github.com/repos/o/r/branches/feature%2Ffoo/protection")
 	if err := p.AuthorizeAction(context.Background(), v, nil); err != nil {
 		t.Fatalf("AuthorizeAction with %%2F branch = %v, want nil (read allowed)", err)

--- a/internal/auth/github_provider_internal_test.go
+++ b/internal/auth/github_provider_internal_test.go
@@ -40,9 +40,11 @@ func testGithubProvider(
 
 func okFetch(context.Context) ([]byte, error) { return []byte(provFixtureOpenAPI), nil }
 
-func req(t *testing.T, method, rawurl string) *http.Request {
+// getReq builds a GET request for the paths that still need a live request
+// (InjectAuth, AuditResponse); the action gate takes a view instead.
+func getReq(t *testing.T, rawurl string) *http.Request {
 	t.Helper()
-	r, err := http.NewRequestWithContext(context.Background(), method, rawurl, nil)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawurl, nil)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
@@ -80,7 +82,7 @@ func TestGithubProvider_AuthorizeAction(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			p, _ := testGithubProvider(t, c.exposure, okFetch)
-			err := p.AuthorizeAction(context.Background(), req(t, c.method, c.url), nil)
+			err := p.AuthorizeAction(context.Background(), actionView(t, c.method, c.url), nil)
 			if c.wantErr == nil && err != nil {
 				t.Fatalf("AuthorizeAction = %v, want nil", err)
 			}
@@ -100,7 +102,7 @@ func TestGithubProvider_AuthorizeAction_unknownKeyFatal(t *testing.T) {
 		exposure.Exposure{"default": exposure.LevelWrite, "issuez": exposure.LevelNone},
 	)
 	p, _ := testGithubProvider(t, exp, okFetch)
-	err := p.AuthorizeAction(context.Background(), req(t, "GET", "https://api.github.com/user"), nil)
+	err := p.AuthorizeAction(context.Background(), actionView(t, "GET", "https://api.github.com/user"), nil)
 	if !errors.Is(err, githubhardening.ErrUnknownKey) {
 		t.Fatalf("AuthorizeAction = %v, want ErrUnknownKey", err)
 	}
@@ -112,10 +114,7 @@ func TestGithubAuthorizeAction_DeniesGraphQL(t *testing.T) {
 		t.Run(method, func(t *testing.T) {
 			t.Parallel()
 			p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
-			req, _ := http.NewRequestWithContext(
-				context.Background(), method, "https://api.github.com/graphql", nil,
-			)
-			err := p.AuthorizeAction(context.Background(), req, nil)
+			err := p.AuthorizeAction(context.Background(), actionView(t, method, "https://api.github.com/graphql"), nil)
 			if !errors.Is(err, githubhardening.ErrGraphQLUnsupported) {
 				t.Fatalf("AuthorizeAction(%s /graphql) err = %v, want ErrGraphQLUnsupported", method, err)
 			}
@@ -131,10 +130,11 @@ func TestGithubAuthorizeAction_DeniesGraphQL(t *testing.T) {
 func TestGithubAuthorizeAction_EncodedGraphQLFailsClosed(t *testing.T) {
 	t.Parallel()
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
-	req, _ := http.NewRequestWithContext(
-		context.Background(), http.MethodPost, "https://api.github.com/%67raphql", nil,
+	err := p.AuthorizeAction(
+		context.Background(),
+		actionView(t, http.MethodPost, "https://api.github.com/%67raphql"),
+		nil,
 	)
-	err := p.AuthorizeAction(context.Background(), req, nil)
 	if !errors.Is(err, githubhardening.ErrUnclassifiable) {
 		t.Fatalf("AuthorizeAction(POST /%%67raphql) err = %v, want ErrUnclassifiable (fail-closed)", err)
 	}
@@ -145,7 +145,7 @@ func TestGithubProvider_notReadyWhenNoTable(t *testing.T) {
 
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(),
 		func(context.Context) ([]byte, error) { return nil, errors.New("offline") })
-	err := p.AuthorizeAction(context.Background(), req(t, "GET", "https://api.github.com/user"), nil)
+	err := p.AuthorizeAction(context.Background(), actionView(t, "GET", "https://api.github.com/user"), nil)
 	if !errors.Is(err, githubhardening.ErrTableNotReady) {
 		t.Fatalf("AuthorizeAction = %v, want ErrTableNotReady", err)
 	}
@@ -160,7 +160,7 @@ func TestGithubProvider_AuditResponse_nilErrOut(t *testing.T) {
 	p.errOut = nil // nil writer — out() must substitute io.Discard, no panic.
 	h := http.Header{}
 	h.Set("X-Accepted-Github-Permissions", "issues=write") // GET classified read but GitHub wants write → drift.
-	p.AuditResponse(req(t, "GET", "https://api.github.com/repos/o/r/issues/1"), h)
+	p.AuditResponse(getReq(t, "https://api.github.com/repos/o/r/issues/1"), h)
 }
 
 func TestGithubProvider_downloadHostGetOnly(t *testing.T) {
@@ -168,19 +168,19 @@ func TestGithubProvider_downloadHostGetOnly(t *testing.T) {
 
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	if err := p.AuthorizeAction(
-		context.Background(), req(t, "GET", "https://codeload.github.com/o/r/tarball/main"), nil,
+		context.Background(), actionView(t, "GET", "https://codeload.github.com/o/r/tarball/main"), nil,
 	); err != nil {
 		t.Errorf("download GET = %v, want nil", err)
 	}
-	// net/url preserves host case, so effectiveDownloadHost must lower-case the
-	// hostname before matching it against the download-host set.
+	// The view lower-cases the hostname at projection, so a mixed-case authority
+	// still matches the download-host set.
 	if err := p.AuthorizeAction(
-		context.Background(), req(t, "GET", "https://CODELOAD.GitHub.com/o/r/tarball/main"), nil,
+		context.Background(), actionView(t, "GET", "https://CODELOAD.GitHub.com/o/r/tarball/main"), nil,
 	); err != nil {
 		t.Errorf("download GET (upper-case host) = %v, want nil", err)
 	}
 	if err := p.AuthorizeAction(
-		context.Background(), req(t, "POST", "https://codeload.github.com/o/r/x"), nil,
+		context.Background(), actionView(t, "POST", "https://codeload.github.com/o/r/x"), nil,
 	); !errors.Is(err, githubhardening.ErrExposureExceeded) {
 		t.Errorf("download POST = %v, want ErrExposureExceeded", err)
 	}
@@ -196,7 +196,7 @@ func TestGithubAuthorizeAction_GraphQLDeniedOnDownloadHost(t *testing.T) {
 
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	err := p.AuthorizeAction(
-		context.Background(), req(t, "GET", "https://codeload.github.com/graphql"), nil,
+		context.Background(), actionView(t, "GET", "https://codeload.github.com/graphql"), nil,
 	)
 	if !errors.Is(err, githubhardening.ErrGraphQLUnsupported) {
 		t.Fatalf("AuthorizeAction(GET codeload /graphql) err = %v, want ErrGraphQLUnsupported", err)
@@ -228,7 +228,7 @@ func TestGithubProvider_InjectAuth_stripsAPIVersion(t *testing.T) {
 	t.Parallel()
 
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
-	r := req(t, "GET", "https://api.github.com/user")
+	r := getReq(t, "https://api.github.com/user")
 	r.Header.Set("X-Github-Api-Version", "1999-01-01") // model-supplied — must be removed.
 	if err := p.InjectAuth(r, nil); err != nil {
 		t.Fatalf("InjectAuth: %v", err)
@@ -252,10 +252,10 @@ func TestGithubProvider_AuthorizeAction_escapedPath(t *testing.T) {
 
 	p, _ := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	// A URL with %2F in the branch segment: GET /repos/o/r/branches/feature%2Ffoo/protection.
-	// req.URL.Path decodes to "/repos/o/r/branches/feature/foo/protection" (too many segments),
-	// but req.URL.EscapedPath() preserves "%2F" as one segment — matching the template.
-	r := req(t, "GET", "https://api.github.com/repos/o/r/branches/feature%2Ffoo/protection")
-	if err := p.AuthorizeAction(context.Background(), r, nil); err != nil {
+	// The view's Path decodes to "/repos/o/r/branches/feature/foo/protection" (too many
+	// segments), but its EscapedPath preserves "%2F" as one segment — matching the template.
+	v := actionView(t, "GET", "https://api.github.com/repos/o/r/branches/feature%2Ffoo/protection")
+	if err := p.AuthorizeAction(context.Background(), v, nil); err != nil {
 		t.Fatalf("AuthorizeAction with %%2F branch = %v, want nil (read allowed)", err)
 	}
 }
@@ -278,7 +278,7 @@ func TestGithubProvider_AuditResponse_drift(t *testing.T) {
 	p, buf := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	h := http.Header{}
 	h.Set("X-Accepted-Github-Permissions", "issues=write") // GET classified read but GitHub wants write.
-	p.AuditResponse(req(t, "GET", "https://api.github.com/repos/o/r/issues/1"), h)
+	p.AuditResponse(getReq(t, "https://api.github.com/repos/o/r/issues/1"), h)
 	if !strings.Contains(buf.String(), "github_hardening") {
 		t.Errorf("expected drift warning, got %q", buf.String())
 	}
@@ -289,9 +289,9 @@ func TestGithubProvider_AuditResponse_noop(t *testing.T) {
 
 	p, buf := testGithubProvider(t, githubhardening.BaselineExposure(), okFetch)
 	// No header → nothing logged.
-	p.AuditResponse(req(t, "GET", "https://api.github.com/user"), http.Header{})
+	p.AuditResponse(getReq(t, "https://api.github.com/user"), http.Header{})
 	// Unrecognized method → RequiredLevel errors → nothing logged.
-	bad := req(t, "GET", "https://api.github.com/user")
+	bad := getReq(t, "https://api.github.com/user")
 	bad.Method = "WAT"
 	withHdr := http.Header{}
 	withHdr.Set("X-Accepted-Github-Permissions", "issues=write")
@@ -315,7 +315,7 @@ func (plainProvider) AuthorizesHost(context.Context, string, json.RawMessage) (b
 func TestAuditResponse_dispatcher(t *testing.T) {
 	t.Parallel()
 
-	r := req(t, "GET", "https://api.github.com/repos/o/r/issues/1")
+	r := getReq(t, "https://api.github.com/repos/o/r/issues/1")
 	// Unknown provider name → silent no-op (find returns an error).
 	AuditResponse("nonexistent", r, http.Header{}, nil)
 	// Found but not a ResponseAuditor → silent no-op (assertion fails).

--- a/internal/auth/gitlab.go
+++ b/internal/auth/gitlab.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/auth/exposure"
 	gitlabclass "github.com/cynative/cynative/internal/auth/gitlab"
 	"github.com/cynative/cynative/internal/cache"
@@ -198,13 +199,25 @@ func (p *gitlabProvider) expectedPort() string {
 // hostname, so without this gate a model could target a different TLS port on the
 // pinned host or IP and have the injected Bearer token attached under an unpinned
 // port.
-func (p *gitlabProvider) authorizeRequestPort(req *http.Request) error {
+func (p *gitlabProvider) authorizeRequestPort(v authreq.View) error {
 	want := p.expectedPort()
-	if got := portOfAuthority(req.URL.Host); got != want {
+	if got := defaultedPort(v.Port); got != want {
 		return fmt.Errorf("%w: request port %s does not match configured GitLab port %s (provider gitlab)",
 			ErrHostNotAuthorized, got, want)
 	}
 	return nil
+}
+
+// defaultedPort returns port, or "443" (the https default) when empty. The view
+// reports an absent port as "", and [net/http] normalizes an explicit-but-empty
+// port to the same thing before any gate runs, so "" here means "no port given"
+// exactly as portOfAuthority's error branch did.
+func defaultedPort(port string) string {
+	if port == "" {
+		return "443"
+	}
+
+	return port
 }
 
 // Description returns a human-readable description of the provider's posture. It
@@ -271,11 +284,11 @@ var errGitLabSudoBlocked = errors.New(
 // "Sudo" header — admin-token impersonation, blocked regardless of exposure),
 // or the "token" query parameter that GitLab's pipeline-trigger endpoints
 // authenticate with (a smuggled credential alongside the injected Bearer).
-func rejectGitLabSmuggledControls(req *http.Request) error {
-	// Parse RawQuery explicitly and fail closed on error: req.URL.Query() silently
-	// drops pairs on a ";"-separated query that GitLab/Rack still honors, which
-	// would hide a smuggled sudo/token parameter.
-	params, err := url.ParseQuery(req.URL.RawQuery)
+func rejectGitLabSmuggledControls(v authreq.View) error {
+	// Parse RawQuery explicitly and fail closed on error: a lenient parse
+	// silently drops pairs on a ";"-separated query that GitLab/Rack still
+	// honors, which would hide a smuggled sudo/token parameter.
+	params, err := url.ParseQuery(v.RawQuery)
 	if err != nil {
 		return fmt.Errorf("%w: unparseable URL query (provider gitlab): %w", ErrModelSuppliedCredential, err)
 	}
@@ -287,7 +300,7 @@ func rejectGitLabSmuggledControls(req *http.Request) error {
 			return fmt.Errorf("%w: token query parameter present (provider gitlab)", ErrModelSuppliedCredential)
 		}
 	}
-	for key := range req.Header {
+	for key := range v.Header {
 		if strings.EqualFold(key, "Sudo") {
 			return fmt.Errorf("%w (Sudo header)", errGitLabSudoBlocked)
 		}
@@ -418,25 +431,17 @@ func bodyMultipartHasCredential(body string) bool {
 // permits that level. A request that cannot be classified (any
 // non-/api/v4 path fails closed here), a missing table, an unknown configured key,
 // or an exceeded ceiling all fail closed. Runs before InjectAuth.
-func (p *gitlabProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
-	if err := rejectGitLabSmuggledControls(req); err != nil {
+func (p *gitlabProvider) AuthorizeAction(ctx context.Context, v authreq.View, _ json.RawMessage) error {
+	if err := rejectGitLabSmuggledControls(v); err != nil {
 		return err
 	}
-	if err := p.authorizeRequestPort(req); err != nil {
+	if err := p.authorizeRequestPort(v); err != nil {
 		return err
 	}
-	if gitlabclass.IsGraphQLEndpoint(req.URL.EscapedPath()) {
-		return fmt.Errorf("%w: %s", gitlabclass.ErrGraphQLUnsupported, req.URL.EscapedPath())
+	if gitlabclass.IsGraphQLEndpoint(v.EscapedPath) {
+		return fmt.Errorf("%w: %s", gitlabclass.ErrGraphQLUnsupported, v.EscapedPath)
 	}
-	var parsed struct {
-		Body string `json:"body"`
-	}
-	if len(rawArgs) > 0 {
-		if err := json.Unmarshal(rawArgs, &parsed); err != nil {
-			return fmt.Errorf("failed to parse http_request args for classification: %w", err)
-		}
-	}
-	if err := rejectGitLabBodyCredential(parsed.Body); err != nil {
+	if err := rejectGitLabBodyCredential(v.Body); err != nil {
 		return err
 	}
 
@@ -450,15 +455,15 @@ func (p *gitlabProvider) AuthorizeAction(ctx context.Context, req *http.Request,
 		return err
 	}
 
-	// Classify on the ESCAPED path: req.URL.Path is percent-decoded, so a write to
-	// a repository-files path whose encoded segment decodes to end with a
+	// Classify on the ESCAPED path: the decoded path is percent-decoded, so a
+	// write to a repository-files path whose encoded segment decodes to end with a
 	// read-only endpoint (e.g. .../files/x%2Fapi%2Fv4%2Fmarkdown) would otherwise
-	// forge the read suffix; EscapedPath keeps %2F encoded so only real endpoints
-	// match. The variables→ci-variables override lives at distill-time (over the
-	// trusted spec template), so a "variables" value in a path PARAMETER does not
-	// inherit the sensitive ceiling here.
-	escaped := req.URL.EscapedPath()
-	access, cerr := gitlabclass.ClassifyRequest(table, req.Method, escaped)
+	// forge the read suffix; the escaped path keeps %2F encoded so only real
+	// endpoints match. The variables→ci-variables override lives at distill-time
+	// (over the trusted spec template), so a "variables" value in a path PARAMETER
+	// does not inherit the sensitive ceiling here.
+	escaped := v.EscapedPath
+	access, cerr := gitlabclass.ClassifyRequest(table, v.Method, escaped)
 	if cerr != nil {
 		return cerr
 	}
@@ -466,7 +471,7 @@ func (p *gitlabProvider) AuthorizeAction(ctx context.Context, req *http.Request,
 	ceiling := gitlabclass.Resolve(p.exposure, category)
 	if !exposure.Allows(ceiling, access.Level) {
 		return fmt.Errorf("%w: %s %s needs %s on %q (ceiling %s)",
-			gitlabclass.ErrExposureExceeded, req.Method, escaped,
+			gitlabclass.ErrExposureExceeded, v.Method, escaped,
 			exposure.LevelName(access.Level), category, exposure.LevelName(ceiling))
 	}
 	return nil

--- a/internal/auth/gitlab_internal_test.go
+++ b/internal/auth/gitlab_internal_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/netip"
@@ -170,8 +169,8 @@ func TestGitLabProvider_AuthorizeAction_Exposure(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			p := newTestGitLabExposure(t, "gitlab.com", c.exposure, okGitLabFetch)
-			req, _ := http.NewRequestWithContext(context.Background(), c.method, c.url, nil)
-			err := p.AuthorizeAction(context.Background(), req, nil)
+			v := actionView(t, c.method, c.url)
+			err := p.AuthorizeAction(context.Background(), v, nil)
 			if c.wantErr == nil && err != nil {
 				t.Fatalf("AuthorizeAction = %v, want nil", err)
 			}
@@ -219,16 +218,14 @@ func TestAuthorizeAction_VariablesParamValueNoBypass(t *testing.T) {
 
 	// (a) The file literally named "variables" must NOT inherit the ci-variables
 	// write ceiling: its true category is repository-files under default:read.
-	putReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPut,
-		"https://gitlab.com/api/v4/projects/1/repository/files/variables", nil)
-	if err := p.AuthorizeAction(context.Background(), putReq, nil); !errors.Is(err, gitlabclass.ErrExposureExceeded) {
+	v := actionView(t, http.MethodPut, "https://gitlab.com/api/v4/projects/1/repository/files/variables")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrExposureExceeded) {
 		t.Fatalf("PUT repository-files/variables must be denied with ErrExposureExceeded (no bypass), got %v", err)
 	}
 
 	// (b) A real CI-variable write is allowed under ci-variables:write.
-	postReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://gitlab.com/api/v4/projects/1/variables", nil)
-	if err := p.AuthorizeAction(context.Background(), postReq, nil); err != nil {
+	postView := actionView(t, http.MethodPost, "https://gitlab.com/api/v4/projects/1/variables")
+	if err := p.AuthorizeAction(context.Background(), postView, nil); err != nil {
 		t.Fatalf("POST projects/1/variables (real ci-variable write) must be allowed, got %v", err)
 	}
 }
@@ -239,9 +236,8 @@ func TestAuthorizeAction_VariablesParamValueNoBypass(t *testing.T) {
 func TestAuthorizeAction_NilTableDenies(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLabExposure(t, "gitlab.com", gitlabclass.BaselineExposure(), errGitLabFetch)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/api/v4/projects", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); !errors.Is(err, gitlabclass.ErrTableNotReady) {
+	v := actionView(t, http.MethodGet, "https://gitlab.com/api/v4/projects")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrTableNotReady) {
 		t.Fatalf("nil table must deny with ErrTableNotReady, got %v", err)
 	}
 }
@@ -256,9 +252,8 @@ func TestGitLabProvider_AuthorizeAction_UnknownKeyFatal(t *testing.T) {
 		exposure.Exposure{"default": exposure.LevelWrite, "projectz": exposure.LevelNone},
 	)
 	p := newTestGitLabExposure(t, "gitlab.com", exp, okGitLabFetch)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/api/v4/projects", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); !errors.Is(err, gitlabclass.ErrUnknownKey) {
+	v := actionView(t, http.MethodGet, "https://gitlab.com/api/v4/projects")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrUnknownKey) {
 		t.Fatalf("AuthorizeAction = %v, want ErrUnknownKey", err)
 	}
 }
@@ -301,14 +296,13 @@ func TestGitLabProvider_CACertData(t *testing.T) {
 }
 
 // TestGitLabProvider_AuthorizeAction_GraphQLDenied guards that a POST to
-// /api/graphql is denied regardless of the rawArgs body.
+// /api/graphql is denied regardless of the request body.
 func TestGitLabProvider_AuthorizeAction_GraphQLDenied(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	args, _ := json.Marshal(map[string]string{"body": `{"query":"mutation { x }"}`})
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://gitlab.com/api/graphql", strings.NewReader(""))
-	if err := p.AuthorizeAction(context.Background(), req, args); !errors.Is(err, gitlabclass.ErrGraphQLUnsupported) {
+	v := actionView(t, http.MethodPost, "https://gitlab.com/api/graphql")
+	v.Body = `{"query":"mutation { x }"}`
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrGraphQLUnsupported) {
 		t.Fatalf("graphql request must be denied with ErrGraphQLUnsupported, got %v", err)
 	}
 }
@@ -380,9 +374,8 @@ func TestGitLabProvider_AuthorizesAddr_PinMiss(t *testing.T) {
 func TestGitLabProvider_AuthorizeAction_EncodedSlashNoMarkdownBypass(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://gitlab.com/api/v4/projects/1/repository/files/x%2Fapi%2Fv4%2Fmarkdown", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); err == nil {
+	v := actionView(t, http.MethodPost, "https://gitlab.com/api/v4/projects/1/repository/files/x%2Fapi%2Fv4%2Fmarkdown")
+	if err := p.AuthorizeAction(context.Background(), v, nil); err == nil {
 		t.Fatal("encoded-slash write must be blocked, not classified as the markdown read")
 	}
 }
@@ -392,9 +385,8 @@ func TestGitLabProvider_AuthorizeAction_EncodedSlashNoMarkdownBypass(t *testing.
 func TestGitLabProvider_AuthorizeAction_GraphQLGetDenied(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/api/graphql?query=mutation%20%7B%20x%20%7D", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); !errors.Is(err, gitlabclass.ErrGraphQLUnsupported) {
+	v := actionView(t, http.MethodGet, "https://gitlab.com/api/graphql?query=mutation%20%7B%20x%20%7D")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrGraphQLUnsupported) {
 		t.Fatalf("graphql GET must be denied with ErrGraphQLUnsupported, got %v", err)
 	}
 }
@@ -422,11 +414,11 @@ func TestRejectGitLabSmuggledControls(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, c.url, nil)
+			v := actionView(t, http.MethodGet, c.url)
 			if c.sudoHdr != "" {
-				req.Header.Set("Sudo", c.sudoHdr)
+				v.Header.Set("Sudo", c.sudoHdr)
 			}
-			err := rejectGitLabSmuggledControls(req)
+			err := rejectGitLabSmuggledControls(v)
 			if c.want == nil {
 				if err != nil {
 					t.Fatalf("%q: unexpected err %v", c.name, err)
@@ -446,24 +438,9 @@ func TestRejectGitLabSmuggledControls(t *testing.T) {
 func TestGitLabProvider_AuthorizeAction_SudoRejected(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/api/v4/projects?sudo=alice", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); !errors.Is(err, errGitLabSudoBlocked) {
+	v := actionView(t, http.MethodGet, "https://gitlab.com/api/v4/projects?sudo=alice")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, errGitLabSudoBlocked) {
 		t.Fatalf("sudo must be rejected, got %v", err)
-	}
-}
-
-// TestGitLabProvider_AuthorizeAction_BadRawArgs exercises the [json.Unmarshal]
-// error branch in AuthorizeAction (invalid JSON in rawArgs).
-func TestGitLabProvider_AuthorizeAction_BadRawArgs(t *testing.T) {
-	t.Parallel()
-	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/api/v4/projects", nil)
-	// Pass invalid JSON as rawArgs to trigger the unmarshal error branch.
-	err := p.AuthorizeAction(context.Background(), req, json.RawMessage(`{bad json`))
-	if err == nil {
-		t.Fatal("invalid rawArgs must return error")
 	}
 }
 
@@ -473,9 +450,8 @@ func TestGitLabProvider_AuthorizeAction_UnclassifiableMethod(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
 	// FROBNICATE is not a recognized HTTP method; classifier returns ErrUnclassifiable.
-	req, _ := http.NewRequestWithContext(context.Background(), "FROBNICATE",
-		"https://gitlab.com/api/v4/projects", nil)
-	err := p.AuthorizeAction(context.Background(), req, nil)
+	v := actionView(t, "FROBNICATE", "https://gitlab.com/api/v4/projects")
+	err := p.AuthorizeAction(context.Background(), v, nil)
 	if err == nil {
 		t.Fatal("unclassifiable method must return error")
 	}
@@ -559,8 +535,8 @@ func TestGitLabProvider_AuthorizeAction_PortEnforcement(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			p := newTestGitLab(t, c.host)
-			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, c.url, nil)
-			err := p.AuthorizeAction(context.Background(), req, nil)
+			v := actionView(t, http.MethodGet, c.url)
+			err := p.AuthorizeAction(context.Background(), v, nil)
 			if c.blocked {
 				if !errors.Is(err, ErrHostNotAuthorized) {
 					t.Fatalf("%q: want ErrHostNotAuthorized, got %v", c.name, err)
@@ -580,10 +556,9 @@ func TestGitLabProvider_AuthorizeAction_PortEnforcement(t *testing.T) {
 func TestGitLabProvider_AuthorizeAction_BodyTriggerToken(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://gitlab.com/api/v4/projects/1/trigger/pipeline", nil)
-	rawArgs := json.RawMessage(`{"body":"token=secret&ref=main"}`)
-	err := p.AuthorizeAction(context.Background(), req, rawArgs)
+	v := actionView(t, http.MethodPost, "https://gitlab.com/api/v4/projects/1/trigger/pipeline")
+	v.Body = "token=secret&ref=main"
+	err := p.AuthorizeAction(context.Background(), v, nil)
 	if !errors.Is(err, ErrModelSuppliedCredential) {
 		t.Fatalf("body trigger token must be rejected, got %v", err)
 	}
@@ -646,10 +621,8 @@ func TestGitLabProvider_CurrentToken_Error(t *testing.T) {
 func TestGitlabAuthorizeAction_DeniesGraphQL(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLab(t, "gitlab.com")
-	req, _ := http.NewRequestWithContext(
-		context.Background(), http.MethodPost, "https://gitlab.com/api/graphql", nil,
-	)
-	err := p.AuthorizeAction(context.Background(), req, nil)
+	v := actionView(t, http.MethodPost, "https://gitlab.com/api/graphql")
+	err := p.AuthorizeAction(context.Background(), v, nil)
 	if !errors.Is(err, gitlabclass.ErrGraphQLUnsupported) {
 		t.Fatalf("AuthorizeAction(/api/graphql) err = %v, want ErrGraphQLUnsupported", err)
 	}
@@ -686,9 +659,8 @@ func TestGitLabProvider_InjectAuth_TokenSourceError(t *testing.T) {
 func TestAuthorizeAction_NonAPIPath_FailsClosed(t *testing.T) {
 	t.Parallel()
 	p := newTestGitLabExposure(t, "gitlab.com", gitlabclass.BaselineExposure(), okGitLabFetch)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"https://gitlab.com/-/jobs/artifacts/x", nil)
-	if err := p.AuthorizeAction(context.Background(), req, nil); !errors.Is(err, gitlabclass.ErrUnclassifiable) {
+	v := actionView(t, http.MethodGet, "https://gitlab.com/-/jobs/artifacts/x")
+	if err := p.AuthorizeAction(context.Background(), v, nil); !errors.Is(err, gitlabclass.ErrUnclassifiable) {
 		t.Fatalf("AuthorizeAction(/-/jobs/artifacts/x) = %v, want ErrUnclassifiable", err)
 	}
 }

--- a/internal/auth/gke.go
+++ b/internal/auth/gke.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/oauth2"
 	container "google.golang.org/api/container/v1"
 	"google.golang.org/api/option"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 const gkeProviderName = "gke"
@@ -154,13 +156,13 @@ func (p *gkeProvider) resolveCluster(ctx context.Context, args *GKEAuthArgs) (cl
 // AuthorizeAction enforces the read-only ClusterRole posture for GKE Kubernetes API
 // requests via the shared k8sGate. It implements the optional
 // auth.ActionAuthorizer interface.
-func (p *gkeProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *gkeProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	args, err := parseGKEArgs(rawArgs)
 	if err != nil {
 		return err
 	}
 
-	return p.authorizeAction(ctx, req, args)
+	return p.authorizeAction(ctx, v, args)
 }
 
 func (p *gkeProvider) CACertData(ctx context.Context, rawArgs json.RawMessage) (string, error) {

--- a/internal/auth/k8sgate.go
+++ b/internal/auth/k8sgate.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/netip"
+	"net/url"
 
+	"github.com/cynative/cynative/internal/auth/authreq"
 	k8sauthz "github.com/cynative/cynative/internal/auth/k8s"
 )
 
@@ -38,7 +39,7 @@ type k8sGate[A any] struct {
 // Kubernetes API request: it validates the args, resolves (and caches) the
 // cluster's configured ClusterRole policy, classifies the request, and authorizes
 // it — failing closed on any resolution error and naming the cluster_role on denial.
-func (g *k8sGate[A]) authorizeAction(ctx context.Context, req *http.Request, args *A) error {
+func (g *k8sGate[A]) authorizeAction(ctx context.Context, v authreq.View, args *A) error {
 	if err := g.validate(args); err != nil {
 		return err
 	}
@@ -51,7 +52,11 @@ func (g *k8sGate[A]) authorizeAction(ctx context.Context, req *http.Request, arg
 		return fmt.Errorf("k8s_hardening: cannot resolve clusterrole %q policy: %w", g.clusterRole, err)
 	}
 
-	ri := k8sauthz.Classify(req.Method, req.URL.Path, req.URL.Query())
+	// Lenient parse, matching kube-apiserver's own r.URL.Query(): the server is
+	// itself Go, so a pair Go drops is a pair the server drops.
+	query, _ := url.ParseQuery(v.RawQuery)
+
+	ri := k8sauthz.Classify(v.Method, v.Path, query)
 
 	if authErr := k8sauthz.Authorize(ri, vp); authErr != nil {
 		return fmt.Errorf("cluster_role=%q: %w", g.clusterRole, authErr)

--- a/internal/auth/k8sgate_internal_test.go
+++ b/internal/auth/k8sgate_internal_test.go
@@ -56,8 +56,8 @@ func TestK8sGate_authorizeAction(t *testing.T) {
 
 			return nil, nil //nolint:nilnil // unreachable after t.Fatal; stub never runs.
 		}}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		if err := g.authorizeAction(context.Background(), req, args); err == nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		if err := g.authorizeAction(context.Background(), v, args); err == nil {
 			t.Fatal("validate failure must error")
 		}
 	})
@@ -69,8 +69,8 @@ func TestK8sGate_authorizeAction(t *testing.T) {
 		args := &gateTestArgs{key: "k", fetch: func() (*k8sauthz.ViewPolicy, error) {
 			return nil, errors.New("boom")
 		}}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		err := g.authorizeAction(context.Background(), req, args)
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		err := g.authorizeAction(context.Background(), v, args)
 		if err == nil || !strings.Contains(err.Error(), `k8s_hardening: cannot resolve clusterrole "view" policy`) {
 			t.Fatalf("want wrapped resolve error, got %v", err)
 		}
@@ -85,8 +85,8 @@ func TestK8sGate_authorizeAction(t *testing.T) {
 				"%w: reading clusterrole %q returned k8s API 401 Unauthorized", ErrClusterAccessDenied, "view",
 			)
 		}}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/pods", nil)
-		err := g.authorizeAction(context.Background(), req, args)
+		v := actionView(t, http.MethodGet, "https://example/api/v1/pods")
+		err := g.authorizeAction(context.Background(), v, args)
 		if !errors.Is(err, ErrClusterAccessDenied) {
 			t.Fatalf("want ErrClusterAccessDenied surfaced, got %v", err)
 		}
@@ -102,8 +102,8 @@ func TestK8sGate_authorizeAction(t *testing.T) {
 		args := &gateTestArgs{key: "k", fetch: func() (*k8sauthz.ViewPolicy, error) {
 			return viewPolicyAllowingPods(), nil
 		}}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/pods", nil)
-		if err := g.authorizeAction(context.Background(), req, args); err != nil {
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/pods")
+		if err := g.authorizeAction(context.Background(), v, args); err != nil {
 			t.Fatalf("list pods should be allowed: %v", err)
 		}
 	})
@@ -115,8 +115,8 @@ func TestK8sGate_authorizeAction(t *testing.T) {
 		args := &gateTestArgs{key: "k", fetch: func() (*k8sauthz.ViewPolicy, error) {
 			return viewPolicyAllowingPods(), nil
 		}}
-		req, _ := http.NewRequest(http.MethodGet, "https://example/api/v1/namespaces/d/secrets", nil)
-		err := g.authorizeAction(context.Background(), req, args)
+		v := actionView(t, http.MethodGet, "https://example/api/v1/namespaces/d/secrets")
+		err := g.authorizeAction(context.Background(), v, args)
 		if !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("list secrets should be ErrForbidden, got %v", err)
 		}

--- a/internal/auth/kubernetes.go
+++ b/internal/auth/kubernetes.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // kubernetesProviderName is the connector id the model selects via auth_provider.
@@ -479,11 +481,11 @@ func (p *kubernetesProvider) probeAndSeedView(ctx context.Context) error {
 }
 
 // AuthorizeAction enforces the read-only ClusterRole posture via the shared k8sGate.
-func (p *kubernetesProvider) AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error {
+func (p *kubernetesProvider) AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error {
 	args, err := parseKubernetesArgs(rawArgs)
 	if err != nil {
 		return err
 	}
 
-	return p.authorizeAction(ctx, req, args)
+	return p.authorizeAction(ctx, v, args)
 }

--- a/internal/auth/kubernetes_internal_test.go
+++ b/internal/auth/kubernetes_internal_test.go
@@ -813,8 +813,8 @@ func TestKubernetesProvider_AuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://h/api/v1/namespaces/d/pods", nil)
-		if err := p.AuthorizeAction(ctx, req, nil); err != nil {
+		v := actionView(t, http.MethodGet, "https://h/api/v1/namespaces/d/pods")
+		if err := p.AuthorizeAction(ctx, v, nil); err != nil {
 			t.Fatalf("list pods should be allowed: %v", err)
 		}
 	})
@@ -823,8 +823,8 @@ func TestKubernetesProvider_AuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://h/api/v1/nodes", nil)
-		if err := p.AuthorizeAction(ctx, req, nil); !errors.Is(err, k8sauthz.ErrForbidden) {
+		v := actionView(t, http.MethodGet, "https://h/api/v1/nodes")
+		if err := p.AuthorizeAction(ctx, v, nil); !errors.Is(err, k8sauthz.ErrForbidden) {
 			t.Fatalf("get nodes should be ErrForbidden, got %v", err)
 		}
 	})
@@ -836,8 +836,8 @@ func TestKubernetesProvider_AuthorizeAction(t *testing.T) {
 		p.fetchView = func(context.Context, *KubernetesAuthArgs) (*k8sauthz.ViewPolicy, error) {
 			return nil, errors.New("boom")
 		}
-		req, _ := http.NewRequest(http.MethodGet, "https://h/api/v1/pods", nil)
-		if err := p.AuthorizeAction(ctx, req, nil); err == nil {
+		v := actionView(t, http.MethodGet, "https://h/api/v1/pods")
+		if err := p.AuthorizeAction(ctx, v, nil); err == nil {
 			t.Fatal("fetch error must deny (fail closed)")
 		}
 	})
@@ -846,8 +846,8 @@ func TestKubernetesProvider_AuthorizeAction(t *testing.T) {
 		t.Parallel()
 
 		p := newProv()
-		req, _ := http.NewRequest(http.MethodGet, "https://h/api/v1/pods", nil)
-		if err := p.AuthorizeAction(ctx, req, json.RawMessage(`{`)); err == nil {
+		v := actionView(t, http.MethodGet, "https://h/api/v1/pods")
+		if err := p.AuthorizeAction(ctx, v, json.RawMessage(`{`)); err == nil {
 			t.Fatal("malformed args must error")
 		}
 	})

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"golang.org/x/oauth2"
+
+	"github.com/cynative/cynative/internal/auth/authreq"
 )
 
 // Provider defines an extensible interface for injecting API credentials securely.
@@ -254,9 +256,11 @@ func GetServerNameData(
 
 // ActionAuthorizer is optionally implemented by providers that perform per-request
 // action-level authorization beyond host gating. transport.do calls it via
-// AuthorizeAction after AuthorizeHost and before InjectAuth.
+// AuthorizeAction after AuthorizeHost and before InjectAuth. It receives a
+// narrowed, read-only view rather than the live request, so a gate cannot alter
+// what it is judging; InjectAuth keeps the request itself.
 type ActionAuthorizer interface {
-	AuthorizeAction(ctx context.Context, req *http.Request, rawArgs json.RawMessage) error
+	AuthorizeAction(ctx context.Context, v authreq.View, rawArgs json.RawMessage) error
 }
 
 // AuthorizeAction dispatches to the named provider's ActionAuthorizer if it
@@ -264,7 +268,7 @@ type ActionAuthorizer interface {
 func AuthorizeAction(
 	ctx context.Context,
 	name string,
-	req *http.Request,
+	v authreq.View,
 	providers []Provider,
 	rawArgs json.RawMessage,
 ) error {
@@ -274,7 +278,7 @@ func AuthorizeAction(
 	}
 
 	if ap, ok := p.(ActionAuthorizer); ok {
-		if authErr := ap.AuthorizeAction(ctx, req, rawArgs); authErr != nil {
+		if authErr := ap.AuthorizeAction(ctx, v, rawArgs); authErr != nil {
 			return fmt.Errorf("auth: authorize action for provider %s: %w", name, authErr)
 		}
 	}

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -291,19 +291,19 @@ func AuthorizeAction(
 // X-Accepted-GitHub-Permissions header against the classified access level). It
 // must not block and must not consume the body.
 type ResponseAuditor interface {
-	AuditResponse(req *http.Request, header http.Header)
+	AuditResponse(v authreq.AuditView, header http.Header)
 }
 
 // AuditResponse dispatches a post-response audit to the named provider when it
 // implements ResponseAuditor. It is best-effort: unknown provider or no
 // capability is a silent no-op (auditing never affects the response).
-func AuditResponse(name string, req *http.Request, header http.Header, providers []Provider) {
+func AuditResponse(name string, v authreq.AuditView, header http.Header, providers []Provider) {
 	p, err := find(providers, name)
 	if err != nil {
 		return
 	}
 	if ra, ok := p.(ResponseAuditor); ok {
-		ra.AuditResponse(req, header)
+		ra.AuditResponse(v, header)
 	}
 }
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -270,7 +270,7 @@ func (c *Client) do(
 	// Post-response, advisory: lets a provider compare the response against its
 	// classification (e.g. GitHub's X-Accepted-GitHub-Permissions). No-op for
 	// providers without the capability; never blocks, never consumes the body.
-	auth.AuditResponse(args.AuthProvider, req, resp.Header, providers)
+	auth.AuditResponse(args.AuthProvider, authreq.NewAuditView(req), resp.Header, providers)
 
 	return resp, args.MaxResponseBodySize, cleanup, nil
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cynative/cynative/internal/auth"
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/redact"
 )
 
@@ -194,7 +195,6 @@ func (c *Client) do(
 	}
 
 	reqBody, viewBody := bodyForRequest(args.Body)
-	_ = viewBody // Consumed by the request view in the next change.
 
 	req, err := http.NewRequestWithContext(ctx, args.Method, args.URL, reqBody)
 	if err != nil {
@@ -231,11 +231,13 @@ func (c *Client) do(
 	// so it is computed once here.
 	rawArgs := json.RawMessage(arguments)
 
+	v := authreq.NewView(req, viewBody)
+
 	if hostErr := auth.AuthorizeHost(ctx, args.AuthProvider, req.URL.Hostname(), providers, rawArgs); hostErr != nil {
 		return nil, 0, noop, hostErr
 	}
 
-	if actionErr := auth.AuthorizeAction(ctx, args.AuthProvider, req, providers, rawArgs); actionErr != nil {
+	if actionErr := auth.AuthorizeAction(ctx, args.AuthProvider, v, providers, rawArgs); actionErr != nil {
 		return nil, 0, noop, actionErr
 	}
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -144,6 +144,21 @@ type Response struct {
 	Truncated  bool                `json:"truncated"`
 }
 
+// bodyForRequest derives the two representations of a request body from one
+// value: the reader net/http sends, and the string the authorization gates
+// judge. Both come from here so no edit can change one and miss the other.
+//
+// An empty body yields a nil reader rather than an empty [strings.Reader],
+// preserving what the code this replaced did: net/http leaves the request body
+// nil, and the SigV4 payload hash takes its empty-payload path.
+func bodyForRequest(body string) (io.Reader, string) {
+	if body == "" {
+		return nil, ""
+	}
+
+	return strings.NewReader(body), body
+}
+
 // do parses arguments, clamps limits, builds and sends the HTTP request, and
 // returns the live [*http.Response], the clamped max-bytes limit, and a cleanup
 // func that releases the per-request transport's idle connections. cleanup is
@@ -178,10 +193,8 @@ func (c *Client) do(
 		return nil, 0, noop, fmt.Errorf("auth_provider is required (available: %s)", providerNames(providers))
 	}
 
-	var reqBody io.Reader
-	if args.Body != "" {
-		reqBody = strings.NewReader(args.Body)
-	}
+	reqBody, viewBody := bodyForRequest(args.Body)
+	_ = viewBody // Consumed by the request view in the next change.
 
 	req, err := http.NewRequestWithContext(ctx, args.Method, args.URL, reqBody)
 	if err != nil {

--- a/internal/transport/transport_internal_test.go
+++ b/internal/transport/transport_internal_test.go
@@ -32,6 +32,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cynative/cynative/internal/auth"
+	"github.com/cynative/cynative/internal/auth/authreq"
 	"github.com/cynative/cynative/internal/auth/authtest"
 	"github.com/cynative/cynative/internal/redact"
 )
@@ -1668,7 +1669,7 @@ func (p *orderingProvider) AuthorizesHost(_ context.Context, _ string, _ json.Ra
 	return true, nil
 }
 
-func (p *orderingProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+func (p *orderingProvider) AuthorizeAction(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 	*p.calls = append(*p.calls, "action")
 
 	return nil
@@ -1783,7 +1784,7 @@ func (p *denyingActionProvider) AuthorizesHost(_ context.Context, _ string, _ js
 	return true, nil
 }
 
-func (p *denyingActionProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+func (p *denyingActionProvider) AuthorizeAction(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 	*p.calls = append(*p.calls, "action")
 
 	return errors.New("action denied")
@@ -1828,7 +1829,7 @@ func (p *spyProvider) AuthorizesHost(_ context.Context, _ string, _ json.RawMess
 	return true, nil
 }
 
-func (p *spyProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+func (p *spyProvider) AuthorizeAction(_ context.Context, _ authreq.View, _ json.RawMessage) error {
 	*p.called = true
 
 	return nil
@@ -1836,6 +1837,68 @@ func (p *spyProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json
 
 func (p *spyProvider) InjectAuth(_ *http.Request, _ json.RawMessage) error {
 	return nil
+}
+
+// bodySpyProvider is a LoopbackProvider that also records the body its action
+// gate was handed, so a test can compare what the gate judged against what the
+// server received.
+type bodySpyProvider struct {
+	*authtest.LoopbackProvider
+
+	seen *string
+}
+
+func (p *bodySpyProvider) AuthorizeAction(_ context.Context, v authreq.View, _ json.RawMessage) error {
+	*p.seen = v.Body
+
+	return nil
+}
+
+// TestDoGateAndWireSeeTheSameBody pins the body's two representations to one
+// origin: the view the gate judges and the payload the server receives must be
+// the same bytes.
+func TestDoGateAndWireSeeTheSameBody(t *testing.T) {
+	t.Parallel()
+
+	const sentinel = `{"sentinel":"a1b2c3"}`
+
+	var gotByGate string
+
+	onWire := make(chan string, 1)
+
+	srv, providers := newTLSTestServer(t, func(_ http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		onWire <- string(raw)
+	})
+
+	loopback, ok := providers[0].(*authtest.LoopbackProvider)
+	if !ok {
+		t.Fatalf("expected LoopbackProvider, got %T", providers[0])
+	}
+
+	loopback.ProviderName = "spy"
+	spy := []auth.Provider{&bodySpyProvider{LoopbackProvider: loopback, seen: &gotByGate}}
+
+	c := NewClient()
+	args := fmt.Sprintf(`{"method":"POST","url":%q,"body":%q,"auth_provider":"spy"}`,
+		srv.URL+"/v1/things", sentinel)
+
+	resp, _, cleanup, err := c.do(t.Context(), args, spy)
+	defer cleanup()
+
+	if err != nil {
+		t.Fatalf("do() error = %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if gotByGate != sentinel {
+		t.Errorf("gate saw body %q, want %q", gotByGate, sentinel)
+	}
+
+	if gotOnWire := <-onWire; gotOnWire != sentinel {
+		t.Errorf("wire carried body %q, want %q", gotOnWire, sentinel)
+	}
 }
 
 // TestDoRejectsNonHTTPSBeforeAuthorization pins the ordering the request view
@@ -1873,7 +1936,12 @@ func TestDoRejectsMalformedArgsBeforeAuthorization(t *testing.T) {
 
 	c := NewClient()
 
-	if _, _, _, err := c.do(t.Context(), `{"method":"GET",`, providers); err == nil {
+	// The literal carries a valid auth_provider and https url ahead of the syntax
+	// error, so the rejection can only come from the parse and not from a later
+	// missing-field or scheme check.
+	const malformed = `{"auth_provider":"gitlab","url":"https://gitlab.com/api/v4/user","method":"GET",`
+
+	if _, _, _, err := c.do(t.Context(), malformed, providers); err == nil {
 		t.Fatal("do() error = nil, want a JSON parse failure")
 	}
 

--- a/internal/transport/transport_internal_test.go
+++ b/internal/transport/transport_internal_test.go
@@ -2319,7 +2319,7 @@ type auditProvider struct {
 	audited bool
 }
 
-func (a *auditProvider) AuditResponse(_ *http.Request, _ http.Header) { a.audited = true }
+func (a *auditProvider) AuditResponse(_ authreq.AuditView, _ http.Header) { a.audited = true }
 
 func TestExecute_invokesResponseAuditor(t *testing.T) {
 	t.Parallel()

--- a/internal/transport/transport_internal_test.go
+++ b/internal/transport/transport_internal_test.go
@@ -1764,6 +1764,83 @@ func (p *denyingActionProvider) AuthorizesAddr(
 	return true, nil
 }
 
+// spyProvider is a minimal auth.Provider + auth.ActionAuthorizer fake that
+// records whether AuthorizeAction ran, for tests that must prove a gate never
+// reaches authorization at all (as opposed to orderingProvider/
+// denyingActionProvider above, which prove the order among the gates that do
+// run).
+type spyProvider struct {
+	name   string
+	called *bool
+}
+
+// newSpyProvider returns a Provider named name whose AuthorizeAction sets
+// *called = true.
+func newSpyProvider(name string, called *bool) auth.Provider {
+	return &spyProvider{name: name, called: called}
+}
+
+func (p *spyProvider) Name() string        { return p.name }
+func (p *spyProvider) Description() string { return "records whether AuthorizeAction ran" }
+
+func (p *spyProvider) AuthorizesHost(_ context.Context, _ string, _ json.RawMessage) (bool, error) {
+	return true, nil
+}
+
+func (p *spyProvider) AuthorizeAction(_ context.Context, _ *http.Request, _ json.RawMessage) error {
+	*p.called = true
+
+	return nil
+}
+
+func (p *spyProvider) InjectAuth(_ *http.Request, _ json.RawMessage) error {
+	return nil
+}
+
+// TestDoRejectsNonHTTPSBeforeAuthorization pins the ordering the request view
+// depends on: the view carries no scheme, so gates that assume https rely on
+// the transport having already refused anything else.
+func TestDoRejectsNonHTTPSBeforeAuthorization(t *testing.T) {
+	t.Parallel()
+
+	var gateCalled bool
+
+	providers := []auth.Provider{newSpyProvider("gitlab", &gateCalled)}
+
+	c := NewClient()
+	args := `{"method":"GET","url":"http://example.com/api/v4/user","auth_provider":"gitlab"}`
+
+	if _, _, _, err := c.do(t.Context(), args, providers); err == nil {
+		t.Fatal("do() error = nil, want a scheme rejection")
+	}
+
+	if gateCalled {
+		t.Error("authorization ran on a non-https URL; the scheme check must come first")
+	}
+}
+
+// TestDoRejectsMalformedArgsBeforeAuthorization replaces the deleted
+// TestGitLabProvider_AuthorizeAction_BadRawArgs. That test covered an unmarshal
+// branch inside a gate; the property it stood in for is that malformed
+// http_request JSON never reaches a gate at all, which is asserted here.
+func TestDoRejectsMalformedArgsBeforeAuthorization(t *testing.T) {
+	t.Parallel()
+
+	var gateCalled bool
+
+	providers := []auth.Provider{newSpyProvider("gitlab", &gateCalled)}
+
+	c := NewClient()
+
+	if _, _, _, err := c.do(t.Context(), `{"method":"GET",`, providers); err == nil {
+		t.Fatal("do() error = nil, want a JSON parse failure")
+	}
+
+	if gateCalled {
+		t.Error("authorization ran on unparseable arguments")
+	}
+}
+
 func TestRequestArgs_ParsesGCPAuth(t *testing.T) {
 	t.Parallel()
 
@@ -2158,5 +2235,59 @@ func TestExecute_invokesResponseAuditor(t *testing.T) {
 
 	if !ap.audited {
 		t.Error("ResponseAuditor.AuditResponse was not invoked after a successful response")
+	}
+}
+
+// TestRequestConstructionNormalizesEmptyPort pins the net/http behavior the
+// GitLab port check relies on: an authority with an explicit-but-empty port is
+// normalized before any gate sees it, so the view's Port is "" for it exactly
+// as for an absent port, and both mean the https default.
+func TestRequestConstructionNormalizesEmptyPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawURL   string
+		wantHost string
+		wantPort string
+	}{
+		{name: "absent port", rawURL: "https://example.com/p", wantHost: "example.com", wantPort: ""},
+		{name: "empty port is trimmed", rawURL: "https://example.com:/p", wantHost: "example.com", wantPort: ""},
+		{
+			name:     "real port survives",
+			rawURL:   "https://example.com:8080/p",
+			wantHost: "example.com:8080",
+			wantPort: "8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.rawURL, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			if got := req.URL.Host; got != tt.wantHost {
+				t.Errorf("req.URL.Host = %q, want %q", got, tt.wantHost)
+			}
+
+			if got := req.URL.Port(); got != tt.wantPort {
+				t.Errorf("req.URL.Port() = %q, want %q", got, tt.wantPort)
+			}
+		})
+	}
+}
+
+// TestRequestConstructionRejectsMalformedPort pins that a non-numeric port
+// never reaches a gate, as it does not today.
+func TestRequestConstructionRejectsMalformedPort(t *testing.T) {
+	t.Parallel()
+
+	_, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com:abc/p", nil)
+	if err == nil {
+		t.Fatal("new request error = nil, want a parse failure on a malformed port")
 	}
 }

--- a/internal/transport/transport_internal_test.go
+++ b/internal/transport/transport_internal_test.go
@@ -241,6 +241,47 @@ func TestExecute_PostWithBody(t *testing.T) {
 	}
 }
 
+func TestBodyForRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         string
+		wantNil    bool
+		wantString string
+	}{
+		{name: "empty body yields a nil reader", in: "", wantNil: true, wantString: ""},
+		{name: "non-empty body yields both representations", in: `{"a":1}`, wantNil: false, wantString: `{"a":1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader, s := bodyForRequest(tt.in)
+
+			if (reader == nil) != tt.wantNil {
+				t.Errorf("reader nil = %v, want %v", reader == nil, tt.wantNil)
+			}
+
+			if s != tt.wantString {
+				t.Errorf("string = %q, want %q", s, tt.wantString)
+			}
+
+			if reader != nil {
+				got, err := io.ReadAll(reader)
+				if err != nil {
+					t.Fatalf("read: %v", err)
+				}
+
+				if string(got) != tt.wantString {
+					t.Errorf("reader contents = %q, want %q", got, tt.wantString)
+				}
+			}
+		})
+	}
+}
+
 func TestExecute_QueryParams(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #248.

## What & why

`AuthorizeAction` received the whole mutable `*http.Request`, so each connector
decided for itself which part of it was authoritative. That divergence is what
#243 (GCP service-claim bypass) and #247 (GitHub exposure-ceiling bypass) both
were. #246 removed the specific divergence and pinned its absence with a linter.
A linter is the right tool for "nobody may touch this field"; it is not the
right tool for "this gate cannot see anything it should not". That is a type
problem, and this is the type.

The read-only gates now take an immutable value view. `InjectAuth` keeps the
real request, since it mutates headers and AWS SigV4 signs during it.

- `ActionAuthorizer.AuthorizeAction` takes `authreq.View` (method, hostname,
  port, decoded path, escaped path, raw query, a cloned header, body string).
- `ResponseAuditor.AuditResponse` takes the smaller `authreq.AuditView` (method
  and escaped path only), built after injection so the audit still observes the
  request as sent.
- Both live in the new stdlib-only leaf `internal/auth/authreq`, because
  `internal/auth` imports its own aws/gcp/azure subpackages and a type declared
  in `internal/auth` would be an import cycle.

Two pieces of machinery existed only because the gates were handed a live
request, and both are deleted:

- AWS `classifyQueryBody` read the body during classification and rewound it so
  the SigV4 signer still saw the payload. That was a read-only gate mutating the
  request it was judging. The body now arrives as a string; `getPayloadHash` in
  `InjectAuth` is the sole remaining reader.
- GitLab re-parsed the body out of the separate `http_request` rawArgs JSON,
  because consuming `req.Body` would have broken the wire send. It authorized
  bytes from a different source than the ones sent. That re-parse, its unmarshal
  error branch, and the coverage-only test guarding it are gone.

## Shape notes

- `Hostname` and `Port` are separate and both derived only from the URL. There
  is deliberately no `Host` field: a single one would reintroduce the overloaded
  authority vocabulary behind #243 and #247.
- Both `Path` and `EscapedPath` are carried, because Azure compares them to
  reject a percent-encoded slash. Carrying one would silently disable that.
- `RawQuery` is carried unparsed with no `Query()` helper. GitLab parses
  fail-closed because Rack honors `;` as a separator and Go does not, while the
  Kubernetes and AWS gates match their Go upstreams' lenient parse. Those are
  correctly different, and one shared helper would impose a single policy on
  servers that disagree.
- The header is cloned, so a gate cannot reach the wire request through it.
  Cloning preserves key spelling, which GitLab's raw-key `Sudo` scan needs.

## What this does not close

`rawArgs` is still the full tool-call JSON passed to all six gate methods, so it
remains a second full-fidelity view of the request. Nothing in production reads
request content from it after this change (GitLab's body read was the last one),
but the narrowing is enforced by the request type only, not by everything a gate
receives. Narrowing `rawArgs` is follow-up work, not bundled here.

## Behavior

No intended behavior changes beyond the two deletions. The one candidate,
GitLab's port comparison, is equivalent: `http.NewRequestWithContext` calls
`removeEmptyPort`, so `https://host:/p` reaches the gate as `host` and both the
old `portOfAuthority(req.URL.Host)` and the new `defaultedPort(v.Port)` compute
`443`. A test pins that normalization.

## Tests

New pins: authority conflict (a request whose wire authority disagrees with its
URL, asserting the view takes the URL), header isolation, non-canonical header
key preservation, hostname normalization, body dual-observation (an authorizer
spy and the server must see the same sentinel, since a server-side assertion
alone proves wire integrity but not what the gate judged), scheme-before-auth
ordering, malformed-args-before-auth ordering, and port normalization.

Removed: the AWS body-restore assertion and its `failingReader` (they pinned a
rewind and an error branch that no longer exist), and
`TestGitLabProvider_AuthorizeAction_BadRawArgs` (its branch is deleted; the
property moved to a transport boundary test asserting malformed JSON never
reaches a gate).

Verified live against real GCP, AWS and GitHub: an authorized GCP read, a GCP
write denied client-side, an AWS SigV4 POST with a form body returning 200
(exercising the classify-then-sign path end to end), and a GitHub
secret-scanning request denied by the exposure ceiling.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed
