### PR TITLE
fix: drop the redundant version stanza from the Homebrew Formula

### DIFF
--- a/.github/workflows/channel-smoke.yaml
+++ b/.github/workflows/channel-smoke.yaml
@@ -108,11 +108,15 @@ jobs:
             rm -rf /tmp/tap-probe
             if git clone --quiet --depth 1 \
                 https://github.com/cynative/homebrew-tap /tmp/tap-probe 2>/tmp/poll-err; then
-              if grep -Fq "version \"${VERSION}\"" /tmp/tap-probe/Formula/cynative.rb 2>/dev/null; then
+              # The formula carries no `version` stanza — `brew audit --strict`
+              # rejects one that restates the version scanned from the url — so
+              # the release tag in the download urls is what marks the served
+              # version. The trailing slash keeps 1.9.1 from matching v1.9.10.
+              if grep -Fq "/releases/download/v${VERSION}/" /tmp/tap-probe/Formula/cynative.rb 2>/dev/null; then
                 echo "tap serves ${VERSION} (attempt ${attempt})"
                 exit 0
               fi
-              last="tap cloned but formula version != ${VERSION}"
+              last="tap cloned but formula does not serve ${VERSION}"
             else
               last="$(tr -d '\n' < /tmp/poll-err)"
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1154,7 +1154,15 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   can never fail `publish` and skip the post-publish channel jobs (cynative#140). Publish is
   additionally gated on `scripts/release/audit-formula.sh`
   (offline `brew audit --strict` of the rendered formula in a throwaway tap, in the `release`
-  job); any pre-publish failure leaves the draft intact. Publish requires
+  job); any pre-publish failure leaves the draft intact. The rendered Formula deliberately
+  carries **no `version` stanza**, so the release tag in each of the four download urls is the
+  only version source: `audit --strict` rejects a `version` that merely restates what brew
+  scans out of the url, which is what broke the v1.9.0 release once Homebrew started preferring
+  the release tag over the asset filename (before that it read `x86_64` as version "86.64", so
+  the two never collided). That leaves the rendered version at the mercy of Homebrew's url
+  parsing, so `audit-formula.sh` pins it: every url must scan to exactly the release version,
+  checked for all four arches rather than only the runner's, since brew evaluates an arch block
+  only on its own platform. Publish requires
   `result == 'success'` from every gate job (not `!= 'failure'`), so a cancelled gate blocks the
   publish; that is also why `connector-e2e.yaml` scopes `cancel-in-progress` to `workflow_dispatch`
   runs and gives the gate path its own run-id concurrency group (a called workflow's concurrency

--- a/scripts/release/audit-formula.sh
+++ b/scripts/release/audit-formula.sh
@@ -35,9 +35,28 @@ brew untap cynative/audit >/dev/null 2>&1 || true
 brew tap-new --no-git cynative/audit >/dev/null
 trap 'brew untap cynative/audit >/dev/null 2>&1 || true' EXIT
 
+formula="$(brew --repository cynative/audit)/Formula/cynative.rb"
 "${here}/render-formula.sh" "${version}" \
   "${sha_darwin_arm}" "${sha_darwin_intel}" "${sha_linux_arm}" "${sha_linux_intel}" \
-  > "$(brew --repository cynative/audit)/Formula/cynative.rb"
+  > "${formula}"
+
+# The formula carries no `version` stanza (audit --strict rejects one that
+# restates the version scanned from the URL), so the version brew reports is
+# whatever its URL parser makes of the tag. Pin that per url: a parser change
+# would otherwise ship a formula labeled with a version nobody chose, and
+# `brew upgrade` compares exactly that label. Every url is checked, not just
+# the runner's, since the arch blocks are only evaluated on their own platform.
+# ARGV, not env: brew sanitizes non-HOMEBREW_ variables out of `brew ruby`.
+brew ruby -e '
+  expected, path = ARGV
+  urls = File.read(path).scan(/^\s*url "([^"]+)"$/).flatten
+  abort "expected 4 urls in the formula, found #{urls.length}" unless urls.length == 4
+  urls.each do |url|
+    scanned = Version.detect(url).to_s
+    next if scanned == expected
+    abort "brew scans version #{scanned.inspect} from #{url}, expected #{expected.inspect}"
+  end
+' -- "${version}" "${formula}"
 
 brew audit --strict cynative/audit/cynative
 echo "formula audit OK (${version})"

--- a/scripts/release/render-formula.sh
+++ b/scripts/release/render-formula.sh
@@ -3,6 +3,11 @@
 # Pure and arg-driven (the Homebrew twin of render-scoop.sh), so it is unit-testable offline.
 # Usage: render-formula.sh <version-without-v> <sha_darwin_arm64> <sha_darwin_x86_64> <sha_linux_arm64> <sha_linux_x86_64>
 # Note: ${...} are bash (filled now); #{...} are Ruby (evaluated by brew at install).
+#
+# There is deliberately no `version` stanza: `brew audit --strict` rejects one
+# that merely restates the version brew scans out of the download URL, so the
+# tag in each url is the single source. That makes the rendered version depend
+# on Homebrew's URL parsing, which audit-formula.sh pins per url before publish.
 set -euo pipefail
 version="$1"
 sha_darwin_arm="$2"; sha_darwin_intel="$3"
@@ -18,7 +23,6 @@ cat <<EOF
 class Cynative < Formula
   desc "Agentic security research across your code, cloud, and runtime (read-only)"
   homepage "https://github.com/cynative/cynative"
-  version "${version}"
   license "Apache-2.0"
 
   on_macos do
@@ -29,24 +33,24 @@ class Cynative < Formula
     depends_on macos: :monterey
 
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Darwin_arm64.tar.gz"
       sha256 "${sha_darwin_arm}"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Darwin_x86_64.tar.gz"
       sha256 "${sha_darwin_intel}"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Linux_arm64.tar.gz"
       sha256 "${sha_linux_arm}"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Linux_x86_64.tar.gz"
       sha256 "${sha_linux_intel}"
     end
   end

--- a/test/render-formula.unit.test.sh
+++ b/test/render-formula.unit.test.sh
@@ -26,7 +26,6 @@ desc='Agentic security research across your code, cloud, and runtime (read-only)
 if (
 	out=$("$render" 1.5.1 "$sha_a" "$sha_b" "$sha_c" "$sha_d") || exit 1
 	printf '%s' "$out" | grep -q 'class Cynative < Formula' || exit 1
-	printf '%s' "$out" | grep -Fq "version \"1.5.1\"" || exit 1
 	printf '%s' "$out" | grep -Fq "desc \"$desc\"" || exit 1
 	printf '%s' "$out" | grep -Fq 'homepage "https://github.com/cynative/cynative"' || exit 1
 	printf '%s' "$out" | grep -Fq 'license "Apache-2.0"' || exit 1
@@ -40,10 +39,23 @@ if (
 	printf '%s' "$out" | grep -Fq "sha256 \"$sha_c\"" || exit 1
 	printf '%s' "$out" | grep -Fq "sha256 \"$sha_d\"" || exit 1
 	printf '%s' "$out" | grep -Fq 'bin.install "cynative"' || exit 1
-	# Ruby interpolation for brew-time version, not the shell-filled one in urls.
-	printf '%s' "$out" | grep -Fq 'v#{version}/' || exit 1
 	exit 0
-); then pass "render-formula renders version/arches/urls/hashes/meta and :monterey floor"; else fail "render-formula happy path"; fi
+); then pass "render-formula renders arches/urls/hashes/meta and the :monterey floor"; else fail "render-formula happy path"; fi
+
+# ---- no version stanza; the tag in every url is the sole version source ------
+# `brew audit --strict` rejects a `version` that restates what it scans from the
+# URL (Homebrew/brew#23336 made it scan the release tag rather than misreading
+# `x86_64`), so re-adding the stanza breaks the release gate. All four urls must
+# carry the literal tag: brew evaluates each arch block only on its own
+# platform, and a Ruby-interpolated `v#{version}` would resolve to nothing once
+# the stanza is gone.
+if (
+	out=$("$render" 1.5.1 "$sha_a" "$sha_b" "$sha_c" "$sha_d") || exit 1
+	! printf '%s' "$out" | grep -Eq '^[[:space:]]*version ' || exit 1
+	! printf '%s' "$out" | grep -Fq '#{version}' || exit 1
+	[ "$(printf '%s\n' "$out" | grep -Fc '/releases/download/v1.5.1/')" -eq 4 ] || exit 1
+	exit 0
+); then pass "render-formula omits the version stanza and pins the tag in all four urls"; else fail "render-formula version sourcing"; fi
 
 # ---- byte-for-byte golden ----------------------------------------------------
 golden="$here/testdata/homebrew-cynative.golden.rb"

--- a/test/testdata/homebrew-cynative.golden.rb
+++ b/test/testdata/homebrew-cynative.golden.rb
@@ -1,7 +1,6 @@
 class Cynative < Formula
   desc "Agentic security research across your code, cloud, and runtime (read-only)"
   homepage "https://github.com/cynative/cynative"
-  version "1.5.1"
   license "Apache-2.0"
 
   on_macos do
@@ -12,24 +11,24 @@ class Cynative < Formula
     depends_on macos: :monterey
 
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Darwin_arm64.tar.gz"
       sha256 "5c712baad9179d576da1f8cff632b840b4b03495fd565a79fea8fe1a2b8b6be1"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Darwin_x86_64.tar.gz"
       sha256 "1321513cd9c9a8bd117c0ec1986845daf9face1ccdc35441b2b1910e50ce7be8"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Linux_arm64.tar.gz"
       sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Linux_x86_64.tar.gz"
       sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     end
   end


### PR DESCRIPTION
The v1.9.0 release failed at the pre-publish formula audit ([run 31714619507](https://github.com/cynative/cynative/actions/runs/31714619507)):

```
cynative/audit/cynative
  * Stable: `version 1.9.0` is redundant with version scanned from URL
Error: 1 problem in 1 formula detected.
```

Nothing changed on our side; the renderer has not been touched since v1.8.0 shipped green through the same step. [Homebrew/brew#23336](https://github.com/Homebrew/brew/issues/23336) taught the URL parser to prefer a GitHub release tag over a version guessed from the asset filename. Before that, `Version.detect` read `cynative_Linux_x86_64.tar.gz` as version `86.64`, so the scanned version never equalled the declared one and the redundancy check stayed quiet. The audit only runs on the release path, so it surfaced at release time rather than on a PR.

Verified locally against brew 6.0.17, which reproduces the CI failure exactly, and against the 3-week-old brew that still passed.

## What changed

- **`render-formula.sh`**: drop the `version` stanza and put the literal tag in each of the four urls, which is how binary formulas over GitHub release assets are normally written. `brew info` on the rendered formula reports the intended version.
- **`audit-formula.sh`**: pin the version brew scans, per url. Removing the stanza leaves the rendered version at the mercy of Homebrew's URL parsing, and this failure is exactly that parsing changing under us. Every url must now scan to exactly the release version before publish, checked for all four arches rather than only the runner's, since brew evaluates an arch block only on its own platform.

The pin matters because nothing downstream would catch a drift: `brew upgrade` compares that label, and the post-publish Homebrew smoke asserts the binary's own `--version` output, not the formula's. A future parser change now fails the release instead of publishing a formula labeled with a version nobody chose.

- **`render-formula.unit.test.sh`** + golden: assert the stanza is gone, no `#{version}` survives, and all four urls carry the literal tag. Both regressions (re-adding the stanza, restoring `v#{version}` in a url) were mutation-tested and fail the suite.

## Release recovery

This does not unstick v1.9.0 by itself: the release job builds from release-please's SHA, which predates this commit, so a re-trigger would fail identically. Recovery is to fix forward — delete the stale v1.9.0 draft and let release-please cut 1.9.1 from a SHA that contains this fix.

`make check-go` and `make check-scripts` pass locally.