### PR TITLE
fix: keep the Homebrew version stanza, skip the audit rule instead

### DIFF
--- a/.github/workflows/channel-smoke.yaml
+++ b/.github/workflows/channel-smoke.yaml
@@ -108,15 +108,11 @@ jobs:
             rm -rf /tmp/tap-probe
             if git clone --quiet --depth 1 \
                 https://github.com/cynative/homebrew-tap /tmp/tap-probe 2>/tmp/poll-err; then
-              # The formula carries no `version` stanza — `brew audit --strict`
-              # rejects one that restates the version scanned from the url — so
-              # the release tag in the download urls is what marks the served
-              # version. The trailing slash keeps 1.9.1 from matching v1.9.10.
-              if grep -Fq "/releases/download/v${VERSION}/" /tmp/tap-probe/Formula/cynative.rb 2>/dev/null; then
+              if grep -Fq "version \"${VERSION}\"" /tmp/tap-probe/Formula/cynative.rb 2>/dev/null; then
                 echo "tap serves ${VERSION} (attempt ${attempt})"
                 exit 0
               fi
-              last="tap cloned but formula does not serve ${VERSION}"
+              last="tap cloned but formula version != ${VERSION}"
             else
               last="$(tr -d '\n' < /tmp/poll-err)"
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1154,15 +1154,19 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   can never fail `publish` and skip the post-publish channel jobs (cynative#140). Publish is
   additionally gated on `scripts/release/audit-formula.sh`
   (offline `brew audit --strict` of the rendered formula in a throwaway tap, in the `release`
-  job); any pre-publish failure leaves the draft intact. The rendered Formula deliberately
-  carries **no `version` stanza**, so the release tag in each of the four download urls is the
-  only version source: `audit --strict` rejects a `version` that merely restates what brew
-  scans out of the url, which is what broke the v1.9.0 release once Homebrew started preferring
-  the release tag over the asset filename (before that it read `x86_64` as version "86.64", so
-  the two never collided). That leaves the rendered version at the mercy of Homebrew's url
-  parsing, so `audit-formula.sh` pins it: every url must scan to exactly the release version,
-  checked for all four arches rather than only the runner's, since brew evaluates an arch block
-  only on its own platform. Publish requires
+  job); any pre-publish failure leaves the draft intact. That audit runs
+  **`--except=version`**, and the Formula's `version` stanza is load-bearing: `audit --strict`
+  calls a version redundant when it matches the one brew scans out of the download url, which
+  is what broke the v1.9.0 release once Homebrew started preferring the release tag over the
+  asset filename (before that it read `x86_64` as version "86.64", so the two never collided).
+  Dropping the stanza is the wrong answer and was tried and reverted: Homebrew's url parsing has
+  misread our asset names on every build tested (`x86_64` → "86.64" before
+  [Homebrew/brew#23336](https://github.com/Homebrew/brew/issues/23336), `arm64` → "64" after
+  it), and it is the **user's** brew that resolves the formula, so a misparse ships as the
+  installed version and as what `brew upgrade` compares. `--except` takes audit method names, so
+  it disables exactly `ResourceAuditor#audit_version`; its only other service here is catching a
+  missing version, which `audit-formula.sh` replaces with a direct assertion that
+  `brew info` reports exactly the release version. Publish requires
   `result == 'success'` from every gate job (not `!= 'failure'`), so a cancelled gate blocks the
   publish; that is also why `connector-e2e.yaml` scopes `cancel-in-progress` to `workflow_dispatch`
   runs and gives the gate path its own run-id concurrency group (a called workflow's concurrency

--- a/scripts/release/audit-formula.sh
+++ b/scripts/release/audit-formula.sh
@@ -27,6 +27,7 @@ if ! command -v brew >/dev/null 2>&1 && [ -x /home/linuxbrew/.linuxbrew/bin/brew
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 command -v brew >/dev/null 2>&1 || { echo "::error::brew not found" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "::error::jq not found" >&2; exit 1; }
 
 # Throwaway local tap. --no-git because tap-new otherwise makes a git commit,
 # which fails wherever no git identity is configured (CI runners, dev hosts).
@@ -40,23 +41,30 @@ formula="$(brew --repository cynative/audit)/Formula/cynative.rb"
   "${sha_darwin_arm}" "${sha_darwin_intel}" "${sha_linux_arm}" "${sha_linux_intel}" \
   > "${formula}"
 
-# The formula carries no `version` stanza (audit --strict rejects one that
-# restates the version scanned from the URL), so the version brew reports is
-# whatever its URL parser makes of the tag. Pin that per url: a parser change
-# would otherwise ship a formula labeled with a version nobody chose, and
-# `brew upgrade` compares exactly that label. Every url is checked, not just
-# the runner's, since the arch blocks are only evaluated on their own platform.
-# ARGV, not env: brew sanitizes non-HOMEBREW_ variables out of `brew ruby`.
-brew ruby -e '
-  expected, path = ARGV
-  urls = File.read(path).scan(/^\s*url "([^"]+)"$/).flatten
-  abort "expected 4 urls in the formula, found #{urls.length}" unless urls.length == 4
-  urls.each do |url|
-    scanned = Version.detect(url).to_s
-    next if scanned == expected
-    abort "brew scans version #{scanned.inspect} from #{url}, expected #{expected.inspect}"
-  end
-' -- "${version}" "${formula}"
+# --except=version, and the formula KEEPS its `version` stanza. `brew audit
+# --strict` calls a version that matches the one it scans out of the download
+# url redundant, and fails the release over it; the obvious answer, dropping the
+# stanza, is wrong. Homebrew's url parsing is not a dependable version source
+# for our asset names, and it is the USER's brew that resolves the formula, not
+# CI's:
+#   * before Homebrew/brew#23336, `cynative_Linux_x86_64.tar.gz` scanned as
+#     version "86.64" (which is why this audit passed silently until v1.9.0)
+#   * the ubuntu-latest brew that carries that fix still scans
+#     `cynative_Darwin_arm64.tar.gz` as version "64" (observed live on the
+#     v1.9.1 release run)
+# so a stanza-less formula installs under a version nobody chose on whichever
+# arch the user's brew happens to misparse, and `brew upgrade` compares exactly
+# that label. An explicit version is the only spelling that means the same thing
+# on every brew. --except takes audit METHOD names, so this turns off exactly
+# one, ResourceAuditor#audit_version, and nothing else.
+brew audit --strict --except=version cynative/audit/cynative
 
-brew audit --strict cynative/audit/cynative
+# That method's only other service here is catching a missing or empty version
+# (its remaining arm is core/bottle-only), so assert the version directly rather
+# than lose the check: this is what the formula will report to `brew install`.
+resolved="$(brew info --json=v2 cynative/audit/cynative | jq -r '.formulae[0].versions.stable')"
+if [ "${resolved}" != "${version}" ]; then
+  echo "::error::formula reports version '${resolved}', expected '${version}'" >&2
+  exit 1
+fi
 echo "formula audit OK (${version})"

--- a/scripts/release/render-formula.sh
+++ b/scripts/release/render-formula.sh
@@ -3,11 +3,6 @@
 # Pure and arg-driven (the Homebrew twin of render-scoop.sh), so it is unit-testable offline.
 # Usage: render-formula.sh <version-without-v> <sha_darwin_arm64> <sha_darwin_x86_64> <sha_linux_arm64> <sha_linux_x86_64>
 # Note: ${...} are bash (filled now); #{...} are Ruby (evaluated by brew at install).
-#
-# There is deliberately no `version` stanza: `brew audit --strict` rejects one
-# that merely restates the version brew scans out of the download URL, so the
-# tag in each url is the single source. That makes the rendered version depend
-# on Homebrew's URL parsing, which audit-formula.sh pins per url before publish.
 set -euo pipefail
 version="$1"
 sha_darwin_arm="$2"; sha_darwin_intel="$3"
@@ -23,6 +18,7 @@ cat <<EOF
 class Cynative < Formula
   desc "Agentic security research across your code, cloud, and runtime (read-only)"
   homepage "https://github.com/cynative/cynative"
+  version "${version}"
   license "Apache-2.0"
 
   on_macos do
@@ -33,24 +29,24 @@ class Cynative < Formula
     depends_on macos: :monterey
 
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Darwin_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_arm64.tar.gz"
       sha256 "${sha_darwin_arm}"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Darwin_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_x86_64.tar.gz"
       sha256 "${sha_darwin_intel}"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Linux_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_arm64.tar.gz"
       sha256 "${sha_linux_arm}"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v${version}/cynative_Linux_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_x86_64.tar.gz"
       sha256 "${sha_linux_intel}"
     end
   end

--- a/test/render-formula.unit.test.sh
+++ b/test/render-formula.unit.test.sh
@@ -26,6 +26,7 @@ desc='Agentic security research across your code, cloud, and runtime (read-only)
 if (
 	out=$("$render" 1.5.1 "$sha_a" "$sha_b" "$sha_c" "$sha_d") || exit 1
 	printf '%s' "$out" | grep -q 'class Cynative < Formula' || exit 1
+	printf '%s' "$out" | grep -Fq "version \"1.5.1\"" || exit 1
 	printf '%s' "$out" | grep -Fq "desc \"$desc\"" || exit 1
 	printf '%s' "$out" | grep -Fq 'homepage "https://github.com/cynative/cynative"' || exit 1
 	printf '%s' "$out" | grep -Fq 'license "Apache-2.0"' || exit 1
@@ -39,23 +40,26 @@ if (
 	printf '%s' "$out" | grep -Fq "sha256 \"$sha_c\"" || exit 1
 	printf '%s' "$out" | grep -Fq "sha256 \"$sha_d\"" || exit 1
 	printf '%s' "$out" | grep -Fq 'bin.install "cynative"' || exit 1
+	# Ruby interpolation for brew-time version, not the shell-filled one in urls.
+	printf '%s' "$out" | grep -Fq 'v#{version}/' || exit 1
 	exit 0
-); then pass "render-formula renders arches/urls/hashes/meta and the :monterey floor"; else fail "render-formula happy path"; fi
+); then pass "render-formula renders version/arches/urls/hashes/meta and :monterey floor"; else fail "render-formula happy path"; fi
 
-# ---- no version stanza; the tag in every url is the sole version source ------
-# `brew audit --strict` rejects a `version` that restates what it scans from the
-# URL (Homebrew/brew#23336 made it scan the release tag rather than misreading
-# `x86_64`), so re-adding the stanza breaks the release gate. All four urls must
-# carry the literal tag: brew evaluates each arch block only on its own
-# platform, and a Ruby-interpolated `v#{version}` would resolve to nothing once
-# the stanza is gone.
+# ---- the version stanza is load-bearing; do not "fix" the audit by removing it
+# `brew audit --strict` calls the stanza redundant with the version it scans
+# from the url, and audit-formula.sh answers that with --except=version rather
+# than by dropping it. Dropping it hands the version to Homebrew's url parsing,
+# which has misread our asset names on every brew build tested: "86.64" from
+# x86_64 before Homebrew/brew#23336, "64" from arm64 after it. The user's brew
+# resolves the formula, so a misparse ships as the installed version.
 if (
-	out=$("$render" 1.5.1 "$sha_a" "$sha_b" "$sha_c" "$sha_d") || exit 1
-	! printf '%s' "$out" | grep -Eq '^[[:space:]]*version ' || exit 1
-	! printf '%s' "$out" | grep -Fq '#{version}' || exit 1
-	[ "$(printf '%s\n' "$out" | grep -Fc '/releases/download/v1.5.1/')" -eq 4 ] || exit 1
+	out=$("$render" 9.9.9 "$sha_a" "$sha_b" "$sha_c" "$sha_d") || exit 1
+	printf '%s' "$out" | grep -Eq '^[[:space:]]*version "9\.9\.9"$' || exit 1
+	# The urls interpolate that stanza rather than restating the version, so the
+	# tag can never drift from it.
+	[ "$(printf '%s\n' "$out" | grep -Fc '/download/v#{version}/')" -eq 4 ] || exit 1
 	exit 0
-); then pass "render-formula omits the version stanza and pins the tag in all four urls"; else fail "render-formula version sourcing"; fi
+); then pass "render-formula keeps the version stanza and interpolates it into all four urls"; else fail "render-formula version stanza"; fi
 
 # ---- byte-for-byte golden ----------------------------------------------------
 golden="$here/testdata/homebrew-cynative.golden.rb"

--- a/test/testdata/homebrew-cynative.golden.rb
+++ b/test/testdata/homebrew-cynative.golden.rb
@@ -1,6 +1,7 @@
 class Cynative < Formula
   desc "Agentic security research across your code, cloud, and runtime (read-only)"
   homepage "https://github.com/cynative/cynative"
+  version "1.5.1"
   license "Apache-2.0"
 
   on_macos do
@@ -11,24 +12,24 @@ class Cynative < Formula
     depends_on macos: :monterey
 
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Darwin_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_arm64.tar.gz"
       sha256 "5c712baad9179d576da1f8cff632b840b4b03495fd565a79fea8fe1a2b8b6be1"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Darwin_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Darwin_x86_64.tar.gz"
       sha256 "1321513cd9c9a8bd117c0ec1986845daf9face1ccdc35441b2b1910e50ce7be8"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Linux_arm64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_arm64.tar.gz"
       sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     end
 
     on_intel do
-      url "https://github.com/cynative/cynative/releases/download/v1.5.1/cynative_Linux_x86_64.tar.gz"
+      url "https://github.com/cynative/cynative/releases/download/v#{version}/cynative_Linux_x86_64.tar.gz"
       sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     end
   end


### PR DESCRIPTION
Corrects #257. That PR dropped the Formula's `version` stanza to satisfy `brew audit --strict`; the v1.9.1 release run ([31739479972](https://github.com/cynative/cynative/actions/runs/31739479972)) shows why that was wrong — caught pre-publish by the per-url pin #257 added alongside it:

```
brew scans version "64" from https://github.com/cynative/cynative/releases/download/v1.9.1/cynative_Darwin_arm64.tar.gz, expected "1.9.1"
```

Homebrew's url parsing has misread our asset names on **every** build tested:

| brew build | `cynative_Linux_x86_64.tar.gz` | `cynative_Darwin_arm64.tar.gz` |
|---|---|---|
| before [Homebrew/brew#23336](https://github.com/Homebrew/brew/issues/23336) | `86.64` | — |
| ubuntu-latest, with that fix | `1.9.1` | `64` |
| 6.0.17 (local) | `1.9.1` | `1.9.1` |

A stanza-less formula installs under a version nobody chose on whichever arch the user's brew misparses. Decisively: **the user's brew resolves the formula, not CI's**, so no gate in this repo can make that safe — and that label is what `brew upgrade` compares, so a misparse silently strands users on the version they already have. macOS arm64 is the primary Homebrew audience, which is the arch that misparses on the runner's own brew.

## What changed

- **`render-formula.sh`**, **golden**, and the **channel-smoke tap probe** are restored byte-for-byte to what shipped through v1.8.0: the `version` stanza and its `v#{version}` urls, and the probe that greps for that stanza.
- **`audit-formula.sh`** answers the audit with `--except=version`. That flag takes audit *method* names, so it disables exactly `ResourceAuditor#audit_version` and nothing else (verified against the Homebrew source — it is the only `def audit_version`). The method's only other service here is catching a missing or empty version, its remaining arm being core/bottle-only, so the script now asserts directly that `brew info --json=v2` reports the release version. Negative-tested: a renderer emitting `0.0.1` for a 1.9.1 release fails the gate.
- **`render-formula.unit.test.sh`** pins the stanza in the opposite direction, with the reasoning inline, so the next person to hit this audit failure finds the answer rather than repeating the experiment. Mutation-tested: removing the stanza fails three cases.

Verified against brew 6.0.17: `audit-formula.sh` exits 0 and reports the intended version. `make check-go` and `make check-scripts` pass.

## Release state

The v1.9.1 draft is intact and unpublished; nothing was released. Once this lands, the release needs a fresh run rather than a re-run of the failed one — I'll drive that.