### PR TITLE
fix: recover from empty model turns instead of ending the run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,17 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     minus the hand-triaged `nonChatProviders` exclusions (providers whose Bifrost impl cannot
     chat, rejected by `config.ValidateLLM`). `CanonicalEnvKeyLookup` backs the single-env-var
     fallback.
+  - Response text is read from **both** content shapes (`textBlocks` in `convert.go`).
+    Bifrost carries assistant prose in either `ContentStr` or `ContentBlocks` and providers
+    disagree on which: Anthropic joins every text part into `ContentStr`, while Gemini emits
+    one block per response part and collapses to `ContentStr` **only when there is exactly
+    one**. Reading `ContentStr` alone therefore silently dropped the whole answer of any
+    multi-part Gemini reply, which reached the agent loop as an empty turn and ended the run
+    (#271). A provider that splits content is covered by this. The **other** carriers
+    Bifrost already has today are not read: `ChatAssistantMessage.Refusal`/`.Reasoning` and
+    the `refusal` content-block type. An OpenAI-style refusal therefore still reaches the
+    loop as a blank turn and is retried and reported as an empty response rather than shown
+    to the operator — tracked separately, alongside surfacing `FinishReason`.
   - Env references resolve through the injected `LookupEnv`, never the process environment:
     `ResolveEnvVar` turns `env.X` strings into Bifrost `SecretVar`s, `ProviderEnvKeys` enumerates
     the dotted key paths that `CYNATIVE_LLM_*` vars map onto, and `ValidateEnvVars` verifies
@@ -382,8 +393,16 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   against a fake `schema.ChatModel` (no framework runner, no checkpoint store, no
   interrupt/resume). `Agent.run` (`loop.go`) calls `model.Generate`, renders the assistant turn,
   and returns its text when there are no tool calls; otherwise it dispatches each tool call,
-  appends a `ToolMessage` per result, and loops (terminating after `maxIter` iterations with an
-  empty answer). Tool failures and unknown-tool names come back as tool-result content, never a
+  appends a `ToolMessage` per result, and loops. A turn carrying **neither** text nor a tool
+  call is not an answer: `acceptTurn` retries it with `emptyTurnDirective` and ends the run
+  with `errNoAnswer` after `maxConsecutiveEmpty` (3) in a row, while exhausting `maxIter` ends
+  it with `errIterationLimit`. The two are distinct sentinels because a single empty string
+  used to mean both, so a model that returned nothing was reported as an iteration limit on a
+  run with most of its budget left (#271). **A blank turn is never appended to the
+  transcript**: it re-encodes to a content-less assistant message that Bifrost's Anthropic
+  adapter serializes as `"content": []` and its OpenAI adapter as a bare role, both rejected by
+  those APIs; Gemini's adapter drops it, which is why replaying one went unnoticed. Tool
+  failures and unknown-tool names come back as tool-result content, never a
   Go error, so the model can self-correct. `Run` seeds the working transcript from the agent's
   clean Q&A history (prior questions and final answers only; intermediate plans/steps/tool
   output render live but are not replayed) plus the system message and the new question, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,11 +372,12 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     one block per response part and collapses to `ContentStr` **only when there is exactly
     one**. Reading `ContentStr` alone therefore silently dropped the whole answer of any
     multi-part Gemini reply, which reached the agent loop as an empty turn and ended the run
-    (#271). A provider that splits content is covered by this. The **other** carriers
-    Bifrost already has today are not read: `ChatAssistantMessage.Refusal`/`.Reasoning` and
-    the `refusal` content-block type. An OpenAI-style refusal therefore still reaches the
-    loop as a blank turn and is retried and reported as an empty response rather than shown
-    to the operator — tracked separately, alongside surfacing `FinishReason`.
+    (#271). Refusals are read too, from **both** carriers Bifrost uses (the `refusal`
+    content-block type and the OpenAI-shaped `ChatAssistantMessage.Refusal` field beside a
+    null content), so a refusal becomes the run's answer instead of a blank turn the loop
+    retries three times and reports as an empty response. `.Reasoning`/`.ReasoningDetails`
+    stay unread on purpose: a reasoning-only turn is not an answer and should be retried.
+    A provider that adds a further prose carrier would present as an empty turn again.
   - Env references resolve through the injected `LookupEnv`, never the process environment:
     `ResolveEnvVar` turns `env.X` strings into Bifrost `SecretVar`s, `ProviderEnvKeys` enumerates
     the dotted key paths that `CYNATIVE_LLM_*` vars map onto, and `ValidateEnvVars` verifies

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -213,14 +213,19 @@ func (a *Agent) Run(ctx context.Context, task string, w io.Writer) error {
 
 			return nil
 		}
+		if errors.Is(err, errIterationLimit) {
+			fmt.Fprintln(w, "\n⚠️  Reached the iteration limit without a final answer.")
+
+			return nil
+		}
+		if errors.Is(err, errNoAnswer) {
+			fmt.Fprintf(w, "\n⚠️  The model returned %d empty responses in a row and could not "+
+				"produce an answer. Try rerunning, or switch models.\n", maxConsecutiveEmpty)
+
+			return nil
+		}
 
 		return err
-	}
-
-	if answer == "" {
-		fmt.Fprintln(w, "\n⚠️  Reached the iteration limit without a final answer.")
-
-		return nil
 	}
 
 	a.history = append(a.history, schema.UserMessage(task), schema.AssistantMessage(answer, nil))

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -169,8 +169,8 @@ func TestRun_IterationGuardExhausts(t *testing.T) {
 	a := newTestAgent(model, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
 
 	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, errIterationLimit) {
+		t.Fatalf("err = %v, want errIterationLimit", err)
 	}
 	if answer != "" {
 		t.Errorf("answer = %q, want empty (iteration limit)", answer)
@@ -185,8 +185,8 @@ func TestRun_ZeroIterations(t *testing.T) {
 	a := newTestAgent(model, map[string]schema.InvokableTool{})
 
 	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 0)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, errIterationLimit) {
+		t.Fatalf("err = %v, want errIterationLimit", err)
 	}
 	if answer != "" {
 		t.Errorf("answer = %q, want empty", answer)
@@ -1834,5 +1834,348 @@ func TestRun_NilOnFirstResponseIsSafe(t *testing.T) {
 	}
 	if answer != "done" {
 		t.Errorf("answer = %q, want %q", answer, "done")
+	}
+}
+
+// transcriptModel returns its scripted messages in order and keeps a copy of the
+// transcript it was handed on every call, so a test can assert what the retry
+// after an empty turn actually saw. capturingModel overwrites its record each
+// call, which cannot show a retry's input.
+type transcriptModel struct {
+	msgs []*schema.Message
+	seen [][]*schema.Message
+}
+
+var _ schema.ChatModel = (*transcriptModel)(nil)
+
+func (m *transcriptModel) Generate(
+	_ context.Context,
+	msgs []*schema.Message,
+	_ []*schema.ToolInfo,
+) (*schema.Message, error) {
+	m.seen = append(m.seen, append([]*schema.Message(nil), msgs...))
+	if len(m.seen) > len(m.msgs) {
+		return nil, errors.New("transcriptModel: out of scripted messages")
+	}
+
+	return m.msgs[len(m.seen)-1], nil
+}
+
+func TestRun_EmptyTurnRetriesInsteadOfEndingTheRun(t *testing.T) {
+	t.Parallel()
+
+	// A turn with neither text nor tool calls is not an answer. The loop used to
+	// return it as the final answer, discarding the whole investigation.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("the real answer", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "the real answer" {
+		t.Errorf("answer = %q, want the answer produced after the retry", answer)
+	}
+	if len(model.seen) != 2 {
+		t.Fatalf("Generate called %d times, want 2 (the empty turn then the retry)", len(model.seen))
+	}
+}
+
+func TestRun_EmptyTurnRetryCarriesDirectiveNotTheBlankMessage(t *testing.T) {
+	t.Parallel()
+
+	// The blank turn must not reach the transcript. Bifrost's Anthropic adapter
+	// serializes a content-less assistant message as "content": [] and its OpenAI
+	// adapter as a bare role, and both APIs reject that; Gemini's adapter drops it,
+	// which is why replaying one went unnoticed. The retry carries a host
+	// directive in its place.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("answer", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	seed := []*schema.Message{schema.UserMessage("q")}
+	if _, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, seed, 8); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retry := model.seen[1]
+	for _, m := range retry {
+		if m.Role == schema.Assistant && len(m.Content) == 0 {
+			t.Fatal("retry transcript carries the blank assistant message")
+		}
+	}
+	last := retry[len(retry)-1]
+	if last.Role != schema.User || last.Text() != emptyTurnDirective {
+		t.Errorf("retry ends with %v %q, want the user directive", last.Role, last.Text())
+	}
+}
+
+func TestRun_RepeatedEmptyTurnsGiveUpBeforeExhaustingIterations(t *testing.T) {
+	t.Parallel()
+
+	// A deterministically blank model must not burn every remaining iteration on
+	// billed round-trips: the token budget is unbounded by default.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("never reached", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if !errors.Is(err, errNoAnswer) {
+		t.Fatalf("err = %v, want errNoAnswer", err)
+	}
+	if answer != "" {
+		t.Errorf("answer = %q, want empty", answer)
+	}
+	if len(model.seen) != maxConsecutiveEmpty {
+		t.Errorf("Generate called %d times, want %d", len(model.seen), maxConsecutiveEmpty)
+	}
+}
+
+func TestRun_WhitespaceOnlyTurnIsRetried(t *testing.T) {
+	t.Parallel()
+
+	// A turn of pure whitespace is no more an answer than an empty one; the
+	// failure-summary path already treats blank this way.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("  \n\t ", nil),
+		schema.AssistantMessage("real", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "real" {
+		t.Errorf("answer = %q, want the retried answer", answer)
+	}
+}
+
+func TestRun_NilMessageIsRetriedNotDereferenced(t *testing.T) {
+	t.Parallel()
+
+	// schema.Message's accessors dereference their receiver, so a ChatModel
+	// returning (nil, nil) would panic in the loop rather than retry.
+	model := &transcriptModel{msgs: []*schema.Message{
+		nil,
+		schema.AssistantMessage("recovered", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "recovered" {
+		t.Errorf("answer = %q, want the retried answer", answer)
+	}
+}
+
+func TestRun_EmptyStreakResetsOnAProductiveTurn(t *testing.T) {
+	t.Parallel()
+
+	// The ceiling counts CONSECUTIVE blanks. A run that keeps making progress
+	// between occasional blanks must not accumulate its way into a give-up.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		toolCall("c1", "echo", "{}"),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("done", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "done" {
+		t.Errorf("answer = %q, want done", answer)
+	}
+}
+
+func TestRun_NoAnswerNotice(t *testing.T) {
+	t.Parallel()
+
+	cfg := baseConfig()
+	cfg.Cfg.MaxIterations = 32
+	cfg.Model = &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+	}}
+
+	a := New(context.Background(), cfg)
+
+	var buf bytes.Buffer
+	if err := a.Run(context.Background(), "q", &buf); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "empty responses in a row") {
+		t.Errorf("output = %q, want the empty-response notice", buf.String())
+	}
+	if strings.Contains(buf.String(), "iteration limit") {
+		t.Errorf("output = %q, must not blame the iteration limit", buf.String())
+	}
+	if len(a.history) != 0 {
+		t.Errorf("history length = %d, want 0", len(a.history))
+	}
+}
+
+func TestRun_BlankTurnOnTheLastIterationReportsTheIterationLimit(t *testing.T) {
+	t.Parallel()
+
+	// A blank turn consumes an iteration like any other. When it is the last one
+	// there is no budget left to retry in, and the iteration limit is then the
+	// honest reason the run stopped — not the empty-response ceiling, which was
+	// never reached.
+	model := &transcriptModel{msgs: []*schema.Message{schema.AssistantMessage("", nil)}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 1)
+	if !errors.Is(err, errIterationLimit) {
+		t.Fatalf("err = %v, want errIterationLimit", err)
+	}
+	if errors.Is(err, errNoAnswer) {
+		t.Error("a single blank turn must not report the empty-response ceiling")
+	}
+}
+
+// blankBudgetModel spends usage and always returns a blank turn, so a run hits
+// the token budget and the empty-response ceiling in the same stretch.
+type blankBudgetModel struct {
+	acc   *metrics.Accumulator
+	usage schema.Usage
+	calls int
+}
+
+var _ schema.ChatModel = (*blankBudgetModel)(nil)
+
+func (m *blankBudgetModel) Generate(
+	_ context.Context,
+	_ []*schema.Message,
+	_ []*schema.ToolInfo,
+) (*schema.Message, error) {
+	m.acc.AddUsage(m.usage)
+	m.calls++
+
+	return schema.AssistantMessage("", nil), nil
+}
+
+func TestRun_BudgetWinsOverTheEmptyResponseCeiling(t *testing.T) {
+	t.Parallel()
+
+	// The post-Generate halt check runs before a turn is classified, so an
+	// operator-facing halt is never reported as a model problem: a blank turn that
+	// also crossed the budget stops with the budget notice.
+	acc := metrics.NewAccumulator("p", "m", metrics.WithBudget(10))
+	model := &blankBudgetModel{acc: acc, usage: schema.Usage{TotalTokens: 50}, calls: 0}
+
+	cfg := baseConfig()
+	cfg.Model = model
+	cfg.Metrics = acc
+
+	a := New(context.Background(), cfg)
+
+	var buf bytes.Buffer
+	if err := a.Run(context.Background(), "q", &buf); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Budget reached") {
+		t.Errorf("output = %q, want the budget notice", out)
+	}
+	if strings.Contains(out, "empty responses in a row") {
+		t.Errorf("output = %q, a budget halt must not be reported as a model failure", out)
+	}
+}
+
+func TestRun_InterruptDuringABlankStreakBeatsTheEmptyCeiling(t *testing.T) {
+	t.Parallel()
+
+	// The blank path returns without another halt check of its own, so a stop that
+	// lands after the post-Generate check would otherwise be reported as a model
+	// failure — and Run maps that to exit 0, swallowing the operator's Ctrl-C.
+	// Checks per blank iteration: top-of-loop, post-Generate, then the terminal
+	// one. Trip on the 7th (0-based 6): the third iteration's terminal check.
+	ci := &countInterrupter{target: 6, calls: 0}
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+	a.interrupter = ci
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if !errors.Is(err, errInterrupted) {
+		t.Fatalf("err = %v, want errInterrupted", err)
+	}
+	if errors.Is(err, errNoAnswer) {
+		t.Error("an operator stop must not be reported as a model failure")
+	}
+}
+
+func TestRun_InterruptOnTheLastIterationBeatsTheIterationLimit(t *testing.T) {
+	t.Parallel()
+
+	// Same hazard at the other terminal return: exhausting maxIter must not mask a
+	// stop that landed during the final iteration. A single blank turn under
+	// maxIter=1 is the only shape that reaches that return without passing a
+	// dispatch checkpoint first, so it uses the top-of-loop and post-Generate
+	// checks (0 and 1) and trips on the terminal one.
+	ci := &countInterrupter{target: 2, calls: 0}
+	model := &transcriptModel{msgs: []*schema.Message{schema.AssistantMessage("", nil)}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+	a.interrupter = ci
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 1)
+	if !errors.Is(err, errInterrupted) {
+		t.Fatalf("err = %v, want errInterrupted", err)
+	}
+	if errors.Is(err, errIterationLimit) {
+		t.Error("an operator stop must not be reported as an iteration limit")
+	}
+}
+
+func TestRun_BlankTurnDoesNotDisturbTheToolFailureStreak(t *testing.T) {
+	t.Parallel()
+
+	// The two ceilings count different things: consecutiveFailures counts failed
+	// tool calls, consecutiveEmpty counts blank model turns. A blank turn between
+	// two failing tool calls must neither credit the failure streak nor reset it,
+	// so the failure halt still fires on the second failure.
+	model := &transcriptModel{msgs: []*schema.Message{
+		toolCall("c1", "boom", "{}"),
+		schema.AssistantMessage("", nil),
+		toolCall("c2", "boom", "{}"),
+		schema.AssistantMessage("stuck: I need credentials", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{"boom": &errTool{}})
+	a.maxConsecutiveFailures = 2
+
+	rs := &runState{depth: 0, out: io.Discard}
+	answer, err := a.run(context.Background(), rs, nil, 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "stuck: I need credentials" {
+		t.Errorf("answer = %q, want the failure summary", answer)
+	}
+	if rs.consecutiveFailures != 2 {
+		t.Errorf("consecutiveFailures = %d, want 2 (the blank turn neither credits nor resets)",
+			rs.consecutiveFailures)
 	}
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/cynative/cynative/internal/audit"
@@ -33,6 +34,34 @@ var errInterrupted = errors.New("agent: interrupted")
 // exit code 130 and the interactive loop can treat it as non-fatal.
 var ErrInterrupted = errInterrupted
 
+// errIterationLimit ends a run that exhausted maxIter without reaching a final
+// answer. It exists so the exhaustion notice is only ever printed for actual
+// exhaustion: before it, every non-answer shared one empty string, and a model
+// turn carrying no answer was reported as an iteration limit on a run that had
+// most of its budget left. Errname-compliant; the error type exempts it from
+// gochecknoglobals.
+var errIterationLimit = errors.New("agent: iteration limit reached")
+
+// errNoAnswer ends a run whose model returned maxConsecutiveEmpty blank turns in
+// a row. Run renders its own notice and recovers; like the iteration limit it is
+// not fatal.
+var errNoAnswer = errors.New("agent: model returned no answer")
+
+// maxConsecutiveEmpty is how many blank assistant turns a run tolerates in a row
+// before giving up. A blank turn is retried because it is usually transient, but
+// a model that is deterministically blank (a content filter, an output budget
+// consumed by reasoning) would otherwise burn every remaining iteration on
+// billed round-trips: the token budget is unbounded by default, so maxIter is
+// the only other stop. Three means one blank plus two retries.
+const maxConsecutiveEmpty = 3
+
+// emptyTurnDirective is appended as a trusted host message after a blank turn.
+// Resending the transcript unchanged tends to reproduce the same blank response,
+// so the retry carries an explicit instruction instead — the same shape as
+// stopSummaryDirective.
+const emptyTurnDirective = "Your previous response was empty: it contained neither text nor a " +
+	"tool call. Continue the investigation with a tool call, or give your final answer as text."
+
 // deniedInterruptResult is the model-facing message returned by invokeIO when the
 // operator interrupted before the tool was dispatched; it matches the unframed
 // denial convention (trusted host/user signal, not untrusted tool output).
@@ -57,6 +86,10 @@ type runState struct {
 	// consecutiveFailures counts no-progress tool calls in this run; reset on any
 	// progress. At maxConsecutiveFailures the run halts into a model summary.
 	consecutiveFailures int
+	// consecutiveEmpty counts blank assistant turns in this run; reset on any turn
+	// that carries text or a tool call. At maxConsecutiveEmpty the run gives up.
+	// It lives here, not on *Agent, so concurrent sub-runs share no mutable state.
+	consecutiveEmpty int
 }
 
 // runScopedTool is implemented by the in-package orchestration tools that need
@@ -69,11 +102,14 @@ type runScopedTool interface {
 
 // run drives one tool-calling loop to a final answer. turn is the working
 // transcript seeded by the caller; rs is this run's private state. The loop
-// terminates when the model emits an assistant turn with no tool calls (the
-// final answer) or after maxIter iterations (returns ""). Tool failures and
-// unknown tools come back as tool-result content, never as a Go error, so the
-// model can self-correct. A non-nil error from dispatch (fatal audit failure)
-// aborts the run immediately.
+// terminates when the model emits an assistant turn that carries text and no
+// tool calls — the final answer. A turn carrying neither is not an answer: it is
+// retried with a directive, and after maxConsecutiveEmpty in a row the run ends
+// with errNoAnswer. Exhausting maxIter ends it with errIterationLimit. Both are
+// non-fatal and distinguishable, so the caller reports the stop that actually
+// happened. Tool failures and unknown tools come back as tool-result content,
+// never as a Go error, so the model can self-correct. A non-nil error from
+// dispatch (fatal audit failure) aborts the run immediately.
 func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, maxIter int) (string, error) {
 	firstResponse := true
 	for range maxIter {
@@ -113,22 +149,19 @@ func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, m
 		// concurrent depth-0 runs race-free; depth>0 sub-runs never fire it.
 		a.maybeFireFirstResponse(&firstResponse, rs.depth)
 
-		turn = append(turn, msg)
-		a.renderTurn(msg, rs.out)
-
-		calls := msg.ToolCalls()
-		if len(calls) == 0 {
-			// Re-check after rendering: a stop that landed while the final answer was
-			// being written still surfaces ErrInterrupted/130 instead of recording the
-			// answer and exiting 0.
-			if herr := a.haltErr(); herr != nil {
-				return "", herr
-			}
-
-			return msg.Text(), nil
+		var answer string
+		var done bool
+		turn, answer, done, err = a.acceptTurn(turn, msg, rs)
+		if err != nil {
+			return "", err
+		}
+		if done {
+			return answer, nil
 		}
 
-		for _, tc := range calls {
+		// A retried blank turn carries no tool calls, so this loop is a no-op and
+		// the run falls through to the next iteration.
+		for _, tc := range toolCallsOf(msg) {
 			a.metrics.AddToolCall()
 			var halt string
 			turn, halt, err = a.dispatchAndTrack(ctx, rs, tc, turn)
@@ -141,7 +174,84 @@ func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, m
 		}
 	}
 
-	return "", nil
+	return "", a.haltOr(errIterationLimit)
+}
+
+// haltOr returns a pending operator-facing halt (interrupt, then budget) in
+// preference to fallback. Every terminal return that is not itself a halt goes
+// through it: Run maps errIterationLimit and errNoAnswer to a notice and exit 0,
+// so a stop that landed after the last checkpoint would otherwise be reported as
+// a model or budget-shaped failure and swallow the operator's Ctrl-C.
+func (a *Agent) haltOr(fallback error) error {
+	if err := a.haltErr(); err != nil {
+		return err
+	}
+
+	return fallback
+}
+
+// toolCallsOf returns a turn's tool calls, tolerating the nil message blankTurn
+// admits: schema.Message's accessors dereference their receiver, so the retry
+// path must not reach for them directly.
+func toolCallsOf(msg *schema.Message) []schema.ToolCallBlock {
+	if msg == nil {
+		return nil
+	}
+
+	return msg.ToolCalls()
+}
+
+// blankTurn reports whether an assistant turn carries nothing the run can use:
+// no tool call, and no text once trimmed. Providers produce these on truncation,
+// a content filter, or a reasoning-only response, and a lossy provider
+// conversion can strip a real answer down to one. A nil message counts as blank,
+// so a ChatModel returning (nil, nil) is retried rather than dereferenced.
+func blankTurn(msg *schema.Message) bool {
+	if msg == nil {
+		return true
+	}
+
+	return len(msg.ToolCalls()) == 0 && strings.TrimSpace(msg.Text()) == ""
+}
+
+// acceptTurn classifies one assistant turn and extends the transcript. It
+// returns the updated turn, the final answer when the run is over, whether it is
+// over, and a halt error.
+//
+// A blank turn is NOT appended: an assistant message with neither content nor
+// tool calls re-encodes to a content-less message that Bifrost's Anthropic
+// adapter serializes as "content": [] and its OpenAI adapter as a bare role,
+// both of which those APIs reject. Gemini's adapter drops it instead, which is
+// why appending one went unnoticed. The retry therefore carries a host directive
+// in place of the blank turn rather than a repaired version of it.
+func (a *Agent) acceptTurn(
+	turn []*schema.Message, msg *schema.Message, rs *runState,
+) ([]*schema.Message, string, bool, error) {
+	if blankTurn(msg) {
+		rs.consecutiveEmpty++
+		if rs.consecutiveEmpty >= maxConsecutiveEmpty {
+			return turn, "", false, a.haltOr(errNoAnswer)
+		}
+
+		return append(turn, schema.UserMessage(emptyTurnDirective)), "", false, nil
+	}
+
+	rs.consecutiveEmpty = 0
+	turn = append(turn, msg)
+	a.renderTurn(msg, rs.out)
+
+	if len(msg.ToolCalls()) > 0 {
+		return turn, "", false, nil
+	}
+
+	// Re-check after rendering: a stop that landed while the final answer was
+	// being written still surfaces ErrInterrupted/130 instead of recording the
+	// answer and exiting 0.
+	if herr := a.haltErr(); herr != nil {
+		return turn, "", false, herr
+	}
+
+	return turn, msg.Text(), true, nil
 }
 
 // dispatchAndTrack dispatches one tool call, appends its result to turn, updates the

--- a/internal/agent/render.go
+++ b/internal/agent/render.go
@@ -43,7 +43,8 @@ func (a *Agent) renderTaskStart(description string, w io.Writer) {
 }
 
 // renderTaskEnd closes a sub-task bracket on w. ok reports whether the sub-run
-// returned without a Go error.
+// finished cleanly: no Go error, or one of the non-fatal stop conditions the task
+// tool converts into a conclusion for the parent model (see subagentStop).
 func (a *Agent) renderTaskEnd(ok bool, w io.Writer) {
 	notice := "■ Sub-task complete"
 	if !ok {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/cynative/cynative/internal/schema"
 )
@@ -42,6 +43,28 @@ const maxTaskDepth = 1
 // inline instead of recursing.
 const subagentDelegationGuidance = "Sub-agents cannot themselves delegate with task; " +
 	"do the work directly in this sub-agent."
+
+// subagentIterationLimit and subagentNoAnswer are the model-facing conclusions for
+// a sub-run that stopped without one. They are returned unfenced: a host notice is
+// trusted output, unlike the sub-agent's own summary.
+const (
+	subagentIterationLimit = "Sub-agent reached its iteration limit without a conclusion."
+	subagentNoAnswer       = "Sub-agent stopped: the model returned repeated empty responses."
+)
+
+// subagentStop maps a sub-run's non-fatal stop conditions to the notice the parent
+// model sees. It reports false for a nil error and for the fatal ones (interrupt,
+// budget, audit failure), which must propagate to the parent run instead.
+func subagentStop(err error) (bool, string) {
+	switch {
+	case errors.Is(err, errIterationLimit):
+		return true, subagentIterationLimit
+	case errors.Is(err, errNoAnswer):
+		return true, subagentNoAnswer
+	default:
+		return false, ""
+	}
+}
 
 // newTaskTool builds the task tool bound to a.
 func newTaskTool(a *Agent) *taskTool {
@@ -104,12 +127,18 @@ func (t *taskTool) runScoped(ctx context.Context, rs *runState, argumentsInJSON 
 
 	t.agent.renderTaskStart(args.Description, rs.out)
 	answer, err := t.agent.run(ctx, sub, seed, t.agent.maxSubagentIter)
-	t.agent.renderTaskEnd(err == nil, rs.out)
+	// A sub-agent that ran out of iterations or could not produce an answer still
+	// completed as far as the parent is concerned: it reports the outcome as a tool
+	// result so the parent model can adapt, exactly as it did when both arrived as
+	// an empty answer. Only a genuine error closes the bracket as failed, so this
+	// classification has to happen before the error check, not after it.
+	stopped, notice := subagentStop(err)
+	t.agent.renderTaskEnd(err == nil || stopped, rs.out)
+	if stopped {
+		return notice, nil
+	}
 	if err != nil {
 		return "", err
-	}
-	if answer == "" {
-		return "Sub-agent reached its iteration limit without a conclusion.", nil
 	}
 
 	// The summary is shaped by a sub-investigation of external data, so fence it

--- a/internal/agent/task_internal_test.go
+++ b/internal/agent/task_internal_test.go
@@ -284,3 +284,36 @@ func TestTaskTool_RunNoBracketOnRefusedCalls(t *testing.T) {
 		t.Errorf("rendered = %q, want no bracket notices", buf.String())
 	}
 }
+
+func TestTaskTool_RunNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	// A sub-agent whose model went blank returns a conclusion string rather than an
+	// error, distinct from the iteration-limit notice, and still closes its bracket
+	// as complete. dispatch turns that string into the parent's tool result; this
+	// test pins runScoped's contract, not the dispatch hop.
+	model := &transcriptModel{msgs: []*schema.Message{
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+		schema.AssistantMessage("", nil),
+	}}
+	a := newTestAgent(model, map[string]schema.InvokableTool{})
+	a.maxSubagentIter = 32
+	a.renderer = echoRenderer
+
+	var buf bytes.Buffer
+
+	out, err := newTaskTool(a).runScoped(context.Background(), rootState(&buf), `{"description":"go blank"}`)
+	if err != nil {
+		t.Fatalf("runScoped: %v", err)
+	}
+	if out != subagentNoAnswer {
+		t.Errorf("out = %q, want the no-answer notice", out)
+	}
+	if strings.Contains(out, "iteration limit") {
+		t.Errorf("out = %q, must not blame the iteration limit", out)
+	}
+	if !strings.Contains(buf.String(), "■ Sub-task complete") {
+		t.Errorf("rendered = %q, want the completion notice", buf.String())
+	}
+}

--- a/internal/llm/convert.go
+++ b/internal/llm/convert.go
@@ -113,13 +113,37 @@ func schemaToBifrostToolCalls(in []schema.ToolCallBlock) []bschemas.ChatAssistan
 	return calls
 }
 
+// textBlocks extracts a message's assistant prose as schema text blocks. Bifrost
+// carries content in one of two shapes and providers disagree on which: Anthropic
+// joins every text part into ContentStr, while Gemini emits one ContentBlock per
+// response part and collapses to ContentStr only when exactly one text block
+// exists. Reading ContentStr alone therefore dropped the entire answer of any
+// multi-part Gemini reply, which reached the agent loop as an empty turn and
+// ended the run. Empty and non-text blocks contribute nothing.
+func textBlocks(c *bschemas.ChatMessageContent) []schema.Block {
+	if c == nil {
+		return nil
+	}
+
+	var out []schema.Block
+	if c.ContentStr != nil && *c.ContentStr != "" {
+		out = append(out, schema.TextBlock{Text: *c.ContentStr})
+	}
+	for _, blk := range c.ContentBlocks {
+		if blk.Type != bschemas.ChatContentBlockTypeText || blk.Text == nil || *blk.Text == "" {
+			continue
+		}
+		out = append(out, schema.TextBlock{Text: *blk.Text})
+	}
+
+	return out
+}
+
 // schemaFromBifrostMessage converts a Bifrost chat message into an internal schema message.
 func schemaFromBifrostMessage(bm bschemas.ChatMessage) *schema.Message {
 	out := &schema.Message{Role: schema.Role(bm.Role)} //nolint:exhaustruct // optional fields set below
 
-	if bm.Content != nil && bm.Content.ContentStr != nil && *bm.Content.ContentStr != "" {
-		out.Content = append(out.Content, schema.TextBlock{Text: *bm.Content.ContentStr})
-	}
+	out.Content = append(out.Content, textBlocks(bm.Content)...)
 
 	if bm.ChatAssistantMessage != nil {
 		for _, tc := range bm.ChatAssistantMessage.ToolCalls {

--- a/internal/llm/convert.go
+++ b/internal/llm/convert.go
@@ -125,14 +125,32 @@ func textBlocks(c *bschemas.ChatMessageContent) []schema.Block {
 		return nil
 	}
 
-	var out []schema.Block
-	if c.ContentStr != nil && *c.ContentStr != "" {
-		out = append(out, schema.TextBlock{Text: *c.ContentStr})
+	// Size the result up front so a many-part reply appends without regrowing.
+	// Bifrost sets only one of the two halves, so this is an upper bound, and it is
+	// computed from one evaluation of the text rather than a repeated nil-and-empty
+	// test that could drift from the append below.
+	str := deref(c.ContentStr)
+	n := len(c.ContentBlocks)
+	if str != "" {
+		n++
+	}
+	if n == 0 {
+		return nil
+	}
+
+	out := make([]schema.Block, 0, n)
+	if str != "" {
+		out = append(out, schema.TextBlock{Text: str})
 	}
 	for _, blk := range c.ContentBlocks {
 		if text := blockText(blk); text != "" {
 			out = append(out, schema.TextBlock{Text: text})
 		}
+	}
+	// A message whose blocks were all non-prose (images, audio, files) has nothing
+	// for the operator; report that as no blocks rather than an empty slice.
+	if len(out) == 0 {
+		return nil
 	}
 
 	return out

--- a/internal/llm/convert.go
+++ b/internal/llm/convert.go
@@ -130,13 +130,37 @@ func textBlocks(c *bschemas.ChatMessageContent) []schema.Block {
 		out = append(out, schema.TextBlock{Text: *c.ContentStr})
 	}
 	for _, blk := range c.ContentBlocks {
-		if blk.Type != bschemas.ChatContentBlockTypeText || blk.Text == nil || *blk.Text == "" {
-			continue
+		if text := blockText(blk); text != "" {
+			out = append(out, schema.TextBlock{Text: text})
 		}
-		out = append(out, schema.TextBlock{Text: *blk.Text})
 	}
 
 	return out
+}
+
+// blockText returns the operator-facing prose of one content block, or "" for a
+// block that carries none. A refusal counts: it is what the model said, and
+// dropping it left the loop with a blank turn to retry instead of an answer to
+// show.
+func blockText(blk bschemas.ChatContentBlock) string {
+	if blk.Type == bschemas.ChatContentBlockTypeText {
+		return deref(blk.Text)
+	}
+	if blk.Type == bschemas.ChatContentBlockTypeRefusal {
+		return deref(blk.Refusal)
+	}
+
+	// Image, audio and file blocks carry no prose for the operator.
+	return ""
+}
+
+// deref reads an optional Bifrost string field.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
 }
 
 // schemaFromBifrostMessage converts a Bifrost chat message into an internal schema message.
@@ -146,6 +170,11 @@ func schemaFromBifrostMessage(bm bschemas.ChatMessage) *schema.Message {
 	out.Content = append(out.Content, textBlocks(bm.Content)...)
 
 	if bm.ChatAssistantMessage != nil {
+		// A refusal can arrive as a message field rather than a content block, which
+		// is the OpenAI shape: null content plus a refusal string.
+		if refusal := deref(bm.ChatAssistantMessage.Refusal); refusal != "" {
+			out.Content = append(out.Content, schema.TextBlock{Text: refusal})
+		}
 		for _, tc := range bm.ChatAssistantMessage.ToolCalls {
 			call := schema.ToolCallBlock{Arguments: tc.Function.Arguments} //nolint:exhaustruct // ID/Name set below
 			if tc.ID != nil {

--- a/internal/llm/convert_internal_test.go
+++ b/internal/llm/convert_internal_test.go
@@ -465,3 +465,54 @@ func TestSchemaToolsToParams_Empty(t *testing.T) {
 		t.Errorf("expected nil for no tools")
 	}
 }
+
+func TestSchemaFromBifrostMessage_MultipleTextContentBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Bifrost's Gemini adapter emits one content block per response part and
+	// collapses to ContentStr only when there is exactly one text block, so a
+	// reply split across parts arrives as ContentBlocks. Reading ContentStr
+	// alone dropped the whole answer and the agent loop saw an empty turn.
+	first, second := "The project has ", "three findings."
+	bm := bschemas.ChatMessage{ //nolint:exhaustruct // only fields under test
+		Role: bschemas.ChatMessageRoleAssistant,
+		Content: &bschemas.ChatMessageContent{ //nolint:exhaustruct // only ContentBlocks
+			ContentBlocks: []bschemas.ChatContentBlock{
+				{Type: bschemas.ChatContentBlockTypeText, Text: &first},  //nolint:exhaustruct // text block only
+				{Type: bschemas.ChatContentBlockTypeText, Text: &second}, //nolint:exhaustruct // text block only
+			},
+		},
+	}
+
+	out := schemaFromBifrostMessage(bm)
+
+	if got := out.Text(); got != "The project has three findings." {
+		t.Errorf("text = %q, want the joined parts", got)
+	}
+}
+
+func TestSchemaFromBifrostMessage_SkipsEmptyAndNonTextBlocks(t *testing.T) {
+	t.Parallel()
+
+	empty, wanted := "", "the answer"
+	bm := bschemas.ChatMessage{ //nolint:exhaustruct // only fields under test
+		Role: bschemas.ChatMessageRoleAssistant,
+		Content: &bschemas.ChatMessageContent{ //nolint:exhaustruct // only ContentBlocks
+			ContentBlocks: []bschemas.ChatContentBlock{
+				{Type: bschemas.ChatContentBlockTypeImage, Text: &wanted}, //nolint:exhaustruct // non-text block
+				{Type: bschemas.ChatContentBlockTypeText, Text: nil},      //nolint:exhaustruct // nil text
+				{Type: bschemas.ChatContentBlockTypeText, Text: &empty},   //nolint:exhaustruct // empty text
+				{Type: bschemas.ChatContentBlockTypeText, Text: &wanted},  //nolint:exhaustruct // the only text block
+			},
+		},
+	}
+
+	out := schemaFromBifrostMessage(bm)
+
+	if got := out.Text(); got != "the answer" {
+		t.Errorf("text = %q, want only the non-empty text block", got)
+	}
+	if len(out.Content) != 1 {
+		t.Errorf("content blocks = %d, want 1", len(out.Content))
+	}
+}

--- a/internal/llm/convert_internal_test.go
+++ b/internal/llm/convert_internal_test.go
@@ -516,3 +516,46 @@ func TestSchemaFromBifrostMessage_SkipsEmptyAndNonTextBlocks(t *testing.T) {
 		t.Errorf("content blocks = %d, want 1", len(out.Content))
 	}
 }
+
+func TestSchemaFromBifrostMessage_RefusalBecomesTheAnswer(t *testing.T) {
+	t.Parallel()
+
+	// An OpenAI-family refusal arrives with null content and a refusal string. Read
+	// only from content, it looked like a blank turn: the agent loop retried it and
+	// reported repeated empty responses instead of showing the operator what the
+	// model actually said.
+	refusal := "I can't help with that request."
+	bm := bschemas.ChatMessage{ //nolint:exhaustruct // only fields under test
+		Role: bschemas.ChatMessageRoleAssistant,
+		ChatAssistantMessage: &bschemas.ChatAssistantMessage{ //nolint:exhaustruct // only Refusal
+			Refusal: &refusal,
+		},
+	}
+
+	out := schemaFromBifrostMessage(bm)
+
+	if got := out.Text(); got != refusal {
+		t.Errorf("text = %q, want the refusal", got)
+	}
+}
+
+func TestSchemaFromBifrostMessage_RefusalContentBlock(t *testing.T) {
+	t.Parallel()
+
+	// The same refusal can arrive as a content block instead of a message field.
+	refusal := "I won't do that."
+	bm := bschemas.ChatMessage{ //nolint:exhaustruct // only fields under test
+		Role: bschemas.ChatMessageRoleAssistant,
+		Content: &bschemas.ChatMessageContent{ //nolint:exhaustruct // only ContentBlocks
+			ContentBlocks: []bschemas.ChatContentBlock{
+				{Type: bschemas.ChatContentBlockTypeRefusal, Refusal: &refusal}, //nolint:exhaustruct // refusal block
+			},
+		},
+	}
+
+	out := schemaFromBifrostMessage(bm)
+
+	if got := out.Text(); got != refusal {
+		t.Errorf("text = %q, want the refusal", got)
+	}
+}

--- a/internal/llm/convert_internal_test.go
+++ b/internal/llm/convert_internal_test.go
@@ -559,3 +559,31 @@ func TestSchemaFromBifrostMessage_RefusalContentBlock(t *testing.T) {
 		t.Errorf("text = %q, want the refusal", got)
 	}
 }
+
+func TestTextBlocks_EmptyContentAllocatesNothing(t *testing.T) {
+	t.Parallel()
+
+	// A turn with no prose must produce no blocks and no backing array: the agent
+	// loop distinguishes a blank turn from an answer, and every response goes
+	// through here.
+	blank := ""
+	cases := map[string]*bschemas.ChatMessageContent{
+		"nil content":  nil,
+		"zero content": {},                   //nolint:exhaustruct // both halves unset on purpose.
+		"blank string": {ContentStr: &blank}, //nolint:exhaustruct // only ContentStr.
+		"no-prose blocks": {ContentBlocks: []bschemas.ChatContentBlock{ //nolint:exhaustruct // only ContentBlocks.
+			{Type: bschemas.ChatContentBlockTypeImage},      //nolint:exhaustruct // type only.
+			{Type: bschemas.ChatContentBlockTypeInputAudio}, //nolint:exhaustruct // type only.
+		}},
+	}
+
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := textBlocks(in); got != nil {
+				t.Errorf("textBlocks = %#v, want nil", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #271.

## What was wrong

A run could stop after a handful of iterations and print "Reached the iteration limit without a final answer" while most of its budget was untouched. Two separate defects combined to produce that, and only the second one is in the agent loop.

**1. The response converter silently dropped whole answers.** `schemaFromBifrostMessage` read assistant text only from Bifrost's `ContentStr` and never from `ContentBlocks`. Providers disagree on which they use: Anthropic joins every text part into `ContentStr`, but Gemini emits one block per response part and collapses to `ContentStr` **only when there is exactly one** (`providers/gemini/chat.go:298`). So any Gemini reply split across two or more parts arrived as a message with no content at all.

That is the root cause of the reported failures, and it explains the reporter's evidence exactly: flash splits parts more often, and the one pro run that returned a single part completed normally.

**2. The loop accepted that empty message as the final answer.** A turn with no tool calls was returned regardless of whether it carried text, and the resulting empty answer was indistinguishable from genuine iteration exhaustion. So the run reported the wrong reason for stopping and recorded nothing.

## What changed

**Converter.** Read text from both content shapes. Refusals are read too, from both carriers Bifrost uses, so a refusal becomes the run's answer instead of a blank turn that gets retried three times and reported as an empty response. Reasoning fields stay unread on purpose: a reasoning-only turn genuinely carries no answer and should be retried.

**Loop.** A turn must carry text before it is accepted as an answer. A blank turn is retried with a directive and gives up after three in a row.

A blank turn is **never appended to the transcript**. This one is easy to get wrong: a content-less assistant message re-encodes to `"content": []` for Anthropic and to a bare role for OpenAI, and both APIs reject it. Gemini's adapter drops it instead, which is why replaying one went unnoticed. A keep-and-retry design would pass a Gemini-driven smoke test and break Anthropic in production.

**Signalling.** Iteration exhaustion and repeated empty responses are now distinct sentinels, so the run reports the stop that actually happened. Both terminal returns defer to a pending interrupt or budget halt via `haltOr`, which also closes a gap the iteration-limit path already had: a stop landing after the final checkpoint was reported as an iteration limit and exited 0 instead of 130.

The sub-agent path gets the same treatment, and `renderTaskEnd`'s condition moves ahead of the error check so the bracket still closes as complete on both non-fatal stops.

## Verification

`make check` passes: 0 lint issues, gofumpt clean, 100% core coverage, `-race -shuffle=on`, Windows cross-build, plus the script gate.

`run` was sitting at exactly the gocognit cap of 20, so the new logic lives in helpers; `go tool gocognit -over 20 internal/agent/*.go` prints nothing.

Every new behavior was mutation-checked: removing the behavior makes a specific named test fail. That covers the blank message not being appended, the empty ceiling, the streak reset, the sub-agent bracket classification, and both refusal carriers.

**Live, against Vertex `gemini-2.5-flash`** (the model from the report), same prompt throughout:

| config | before | after |
|---|---|---|
| default | 7/8 runs produced a report | **8/8** |
| `reasoning_effort=medium` | 6/12 | **9/12** |

The bug reproduced cleanly before the fix: three of four baseline runs died after a single model call.

## Known limitation

The fix does not eliminate every empty turn. Under forced reasoning, some runs still end without a report, because a thinking model can spend its whole output budget before emitting a visible token. A retry cannot fix that. Those runs now at least stop with an accurate message instead of a false iteration-limit claim.

Telling that case apart from a transient glitch needs `finish_reason`, which `Generate` currently discards. Surfacing it means changing the `schema.ChatModel` return type, which reaches every implementation and fake, so it is filed separately rather than bundled here.
