### PR TITLE
fix: rebuild the sandbox runtime after a Run leaves it unusable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,7 +504,32 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   UTF-8-repaired; script errors and timeouts are included in the result string AND signaled
   with the `ErrScript` sentinel (nil error only on success), so callers can record the failure
   without parsing text; the `code_execution` tool converts `ErrScript` back into a plain
-  result string so the model can self-correct.
+  result string so the model can self-correct. **An interrupt that lands inside the VM
+  (rather than while the worker loop is parked) leaves the runtime unusable and forces a
+  rebuild** before the next `Run`, which is what resets `globalThis`: sobek
+  unwinds such an error without unwinding its own call stack, and from then on treats every
+  `RunProgram` as a nested call and stops draining the promise job queue, so `await` never
+  resumes and every later `Run` returns no output and a **nil** error, reporting a script
+  that never ran as a success. The trigger is therefore a non-nil error from `RunProgram` or
+  the worker loop, **or** a still-pending IIFE promise. The rule is "rebuild unless the
+  script finished": only a script that ran to a settled promise, or one that never ran at
+  all (a compile error), keeps `globalThis`. The error arm is deliberately a superset of
+  the errors that really strand the call stack (a top-level throw that escaped the IIFE
+  wrapper is catchable and harmless), since rebuilding needlessly costs one script's
+  `globalThis` while failing to rebuild strands every later `Run`. A
+  rebuild that fails leaves the runtime marked, so the next `Run` retries instead of running
+  on a broken VM. The matching backstop is in `assemble`: an IIFE promise still **pending**
+  once the loop has drained is a failure (`[script did not complete]`), never an empty
+  success, which also covers a script that awaits something no tool call can settle. A
+  pending promise also means the script is still suspended *inside* the runtime, which is
+  why it rebuilds: a script can park on a promise whose resolver it stashed on
+  `globalThis`, and a later `Run` calling that resolver would resume the parked script
+  within itself, running its remaining tool calls under a different `Run`'s context and
+  landing its output in that `Run`'s result. **The pending check is asked of every `Run`,
+  not just the ones that reach that branch**: a `Run` that times out while the worker loop
+  is parked reports no error at all, and a fire-and-forget tool call keeps the loop
+  waiting for exactly as long as the script needs to park itself, so scoping the check to
+  the promise branch left that route open.
   Tool calls are async: each returns a JS Promise backed by a worker goroutine bounded by a
   `maxConcurrency` semaphore (a non-positive value clamps to `DefaultMaxConcurrency` = 16), a
   single loop goroutine drains worker postbacks, and `Run` waits for all workers. The

--- a/README.md
+++ b/README.md
@@ -336,8 +336,9 @@ console.log(JSON.stringify(all.filter((x) => x.clusters.length > 0), null, 2));
   approval before it runs (skip with `--auto-approve`; stream each inner call
   with `-v`).
 - **Stateful within a session**: values saved on `globalThis` persist across
-  calls during an interactive session; top-level `let`/`const`/`var`/
-  `function` are scoped to a single call.
+  calls during an interactive session, as long as the call runs to completion
+  (one that times out or is left suspended resets them); top-level
+  `let`/`const`/`var`/`function` are scoped to a single call.
 - **Bounded**: scripts run under a timeout (default 120s) and a capped output
   size.
 

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,7 +1,9 @@
 // Package sandbox runs untrusted JavaScript in an embedded sobek runtime,
 // exposing host capabilities to scripts only through explicitly registered tool
-// functions. A single runtime persists for the sandbox's lifetime, so state set
-// by one Run is visible to later Runs.
+// functions. One runtime persists across Runs, so state set by one Run is
+// visible to later Runs, but only when the script actually finished: a Run that
+// leaves its script interrupted or suspended forces a rebuild (and a fresh,
+// empty globalThis) before the next Run.
 package sandbox
 
 import (
@@ -33,10 +35,11 @@ var ErrScript = errors.New("sandbox: script execution failed")
 type ToolFunc func(ctx context.Context, argsJSON string) (string, error)
 
 const (
-	noOutputMessage  = "[script completed with no output]"
-	emptyObject      = "{}"
-	verboseClipLimit = 200
-	interruptReason  = "sandbox: execution interrupted"
+	noOutputMessage   = "[script completed with no output]"
+	incompleteMessage = "[script did not complete]"
+	emptyObject       = "{}"
+	verboseClipLimit  = 200
+	interruptReason   = "sandbox: execution interrupted"
 )
 
 // DefaultMaxConcurrency is the default cap on how many inner tool calls run
@@ -54,6 +57,15 @@ type Sandbox struct {
 	verbose   io.Writer
 	redact    func(string) string
 	sem       chan struct{}
+
+	// funcs is retained so a runtime left unusable by an interrupted Run can be
+	// rebuilt; build is the runtime factory, defaulted branch-free to the
+	// shell's buildRuntime so a test can inject a failing one. dirty records
+	// that the last Run left the runtime unusable, so the next one rebuilds
+	// before running anything.
+	funcs map[string]ToolFunc
+	build func(s *Sandbox, funcs map[string]ToolFunc) error
+	dirty bool
 
 	// Per-run state, owned by the loop goroutine (set under mu at the start of
 	// each Run). runCtx is the in-flight Run's timeout context; pending carries
@@ -93,9 +105,11 @@ func New(
 		verbose:   verbose,
 		redact:    redact,
 		sem:       make(chan struct{}, maxConcurrency),
+		funcs:     funcs,
+		build:     buildRuntime,
 	}
 
-	return s, buildRuntime(s, funcs)
+	return s, s.build(s, funcs)
 }
 
 // Run executes code on the persistent runtime and returns its captured output.
@@ -106,6 +120,10 @@ func New(
 func (s *Sandbox) Run(ctx context.Context, code string, timeout time.Duration) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if err := s.refresh(); err != nil {
+		return "", err
+	}
 
 	s.out.Reset()
 
@@ -130,14 +148,19 @@ func (s *Sandbox) Run(ctx context.Context, code string, timeout time.Duration) (
 		}
 	})
 
-	var value sobek.Value
+	var (
+		value   sobek.Value
+		execErr error
+	)
 
 	prog, runErr := compileWrapped(code)
 	if runErr == nil {
-		value, runErr = s.vm.RunProgram(prog)
-		if runErr == nil {
-			runErr = s.loop()
+		value, execErr = s.vm.RunProgram(prog)
+		if execErr == nil {
+			execErr = s.loop()
 		}
+
+		runErr = execErr
 	}
 
 	// Release any parked workers, then wait for every worker and the watchdog to
@@ -152,7 +175,23 @@ func (s *Sandbox) Run(ctx context.Context, code string, timeout time.Duration) (
 
 	// Pass the parent ctx (not runCtx) so assemble/ctxSuffix can distinguish
 	// caller cancellation from an expiring internal timeout.
-	out, failed := s.assemble(ctx, value, runErr, timeout)
+	out, failed, suspendedScript := s.assemble(ctx, value, runErr, timeout)
+
+	// Rebuild unless the script actually finished. Two distinct things strand a
+	// runtime and both are caught here. An error out of RunProgram or the loop
+	// means an interrupt unwound without unwinding sobek's own call stack, after
+	// which sobek treats every later RunProgram as a nested call and stops
+	// draining the promise job queue: awaits never resume, so every later Run
+	// quietly returns no output. A still-pending IIFE promise means the script
+	// is suspended inside the runtime, where a later Run could resume it. Only a
+	// script that ran to a settled promise, or one that never ran at all (a
+	// compile error), keeps globalThis. The error arm is deliberately a superset
+	// of the errors that really strand the call stack (a top-level throw that
+	// escaped the IIFE wrapper is catchable and harmless), because the two
+	// mistakes are not symmetric: rebuilding needlessly costs one script's
+	// globalThis, while not rebuilding strands every later Run of the session.
+	s.dirty = execErr != nil || suspendedScript
+
 	if failed {
 		return out, ErrScript
 	}
@@ -160,14 +199,35 @@ func (s *Sandbox) Run(ctx context.Context, code string, timeout time.Duration) (
 	return out, nil
 }
 
+// refresh rebuilds the runtime when the previous Run left it unusable. It runs
+// under the Run mutex, before anything touches the VM. The dirty flag is
+// cleared only once a rebuild succeeds, so a failed rebuild is retried by the
+// next Run rather than leaving a broken runtime in service.
+func (s *Sandbox) refresh() error {
+	if !s.dirty {
+		return nil
+	}
+
+	if err := s.build(s, s.funcs); err != nil {
+		return fmt.Errorf("sandbox: rebuild runtime: %w", err)
+	}
+
+	s.dirty = false
+
+	return nil
+}
+
 // assemble builds the result string from the output buffer plus a trailing
-// diagnostic and reports whether the run failed. It reports a timeout/cancellation
-// first (the runCtx fired), then an uncatchable run error, then a rejected IIFE
-// promise (an uncaught script or tool error). A fulfilled promise contributes
-// nothing and is not a failure: only console output returns.
+// diagnostic, reports whether the run failed, and reports whether the runtime is
+// left holding a suspended script. It reports a timeout/cancellation
+// first (the runCtx fired), then an uncatchable run error, then an IIFE promise
+// that did not fulfil: either rejected (an uncaught script or tool error) or
+// still pending (the script awaited something that can never settle). A
+// fulfilled promise contributes nothing and is not a failure: only console
+// output returns.
 func (s *Sandbox) assemble(
 	ctx context.Context, value sobek.Value, runErr error, timeout time.Duration,
-) (string, bool) {
+) (string, bool, bool) {
 	out := s.out.String()
 	failed := false
 
@@ -179,13 +239,30 @@ func (s *Sandbox) assemble(
 		out += "\n[error] " + runErr.Error()
 		failed = true
 	default:
-		if p, ok := value.Export().(*sobek.Promise); ok && p.State() == sobek.PromiseStateRejected {
-			out += "\n[error] " + p.Result().String()
+		if p, ok := value.Export().(*sobek.Promise); ok && p.State() != sobek.PromiseStateFulfilled {
+			out += promiseFailure(p)
 			failed = true
 		}
 	}
 
-	return s.finalize(out), failed
+	return s.finalize(out), failed, suspended(value)
+}
+
+// suspended reports whether the script is still parked inside the runtime. It is
+// asked of every Run, not only the ones that reach the promise branch: a Run that
+// times out while the worker loop is parked reports no error at all, and a script
+// can hold exactly that state open on purpose with a fire-and-forget tool call
+// (which keeps the loop waiting) while it awaits a promise whose resolver it
+// stashed on globalThis. A nil value is a Run that never produced one, i.e. a
+// compile error or an interrupt out of RunProgram, so nothing is parked.
+func suspended(value sobek.Value) bool {
+	if value == nil {
+		return false
+	}
+
+	p, ok := value.Export().(*sobek.Promise)
+
+	return ok && p.State() == sobek.PromiseStatePending
 }
 
 // ctxSuffix renders a timeout vs. a parent cancellation.
@@ -195,6 +272,17 @@ func ctxSuffix(ctx context.Context, timeout time.Duration) string {
 	}
 
 	return fmt.Sprintf("\n[execution timed out after %s]", timeout)
+}
+
+// promiseFailure renders why the IIFE promise did not fulfil. Pending means the
+// worker loop drained with the script still suspended; reporting that keeps an
+// unfinishable script from being mistaken for one that simply printed nothing.
+func promiseFailure(p *sobek.Promise) string {
+	if p.State() == sobek.PromiseStatePending {
+		return "\n" + incompleteMessage
+	}
+
+	return "\n[error] " + p.Result().String()
 }
 
 // finalize truncates to maxOutput, repairs invalid UTF-8, and substitutes a

--- a/internal/sandbox/sandbox_internal_test.go
+++ b/internal/sandbox/sandbox_internal_test.go
@@ -23,6 +23,39 @@ func fakeRedact(s string) string {
 // redaction. New requires a non-nil redactor, so call sites pass this not nil.
 func identityRedact(s string) string { return s }
 
+// errRebuild is a static test sentinel for an injected runtime-rebuild failure.
+var errRebuild = errors.New("rebuild failed")
+
+// TestRefresh_RebuildFailureIsRetried pins the fail-closed half of the rebuild:
+// a runtime marked unusable that cannot be rebuilt surfaces the failure and
+// stays marked, so the next Run retries instead of running on a broken VM.
+func TestRefresh_RebuildFailureIsRetried(t *testing.T) {
+	t.Parallel()
+
+	s, err := New(nil, nil, 32*1024, DefaultMaxConcurrency, identityRedact)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	s.dirty = true
+	s.build = func(*Sandbox, map[string]ToolFunc) error { return errRebuild }
+
+	if _, rerr := s.Run(context.Background(), `console.log("x")`, time.Second); !errors.Is(rerr, errRebuild) {
+		t.Fatalf("Run: want errRebuild, got %v", rerr)
+	}
+
+	if !s.dirty {
+		t.Fatal("dirty cleared despite a failed rebuild")
+	}
+
+	s.build = buildRuntime
+
+	out, rerr := s.Run(context.Background(), `console.log("x")`, time.Second)
+	if rerr != nil || out != "x\n" {
+		t.Errorf("after a successful rebuild: out=%q err=%v", out, rerr)
+	}
+}
+
 func TestRunWorker_RedactsToolResult(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -333,6 +333,138 @@ func TestRun_StatePersistsAcrossCalls(t *testing.T) {
 	}
 }
 
+// interruptRun times out a script mid-execution, which is what leaves the
+// runtime unusable. The generous timeout keeps the interrupt inside the VM
+// (rather than arriving while the worker loop is parked) on a loaded machine.
+func interruptRun(t *testing.T, s *sandbox.Sandbox) {
+	t.Helper()
+
+	out, err := s.Run(context.Background(), `while (true) {}`, 50*time.Millisecond)
+	if !errors.Is(err, sandbox.ErrScript) {
+		t.Fatalf("Run: want sandbox.ErrScript, got %v", err)
+	}
+
+	if !strings.Contains(out, "timed out") {
+		t.Fatalf("expected timeout message, got %q", out)
+	}
+}
+
+// TestRun_InterruptedScriptDoesNotPoisonLaterRuns is the regression guard for
+// the silent-no-op bug: an interrupt landing inside the VM used to leave
+// sobek's call stack unwound, after which it treated every later RunProgram as
+// a nested call and stopped draining the promise job queue. Awaits never
+// resumed, so every later Run on that sandbox returned no output and a nil
+// error, reporting a script that never ran as a success.
+func TestRun_InterruptedScriptDoesNotPoisonLaterRuns(t *testing.T) {
+	t.Parallel()
+
+	s := newSandbox(t, map[string]sandbox.ToolFunc{
+		"echo": func(_ context.Context, _ string) (string, error) { return "1", nil },
+	}, nil)
+
+	for range 3 {
+		interruptRun(t, s)
+
+		if got := run(t, s, `await echo({}); console.log("ok");`); got != "ok\n" {
+			t.Fatalf("reuse after interrupt: got %q, want \"ok\\n\"", got)
+		}
+	}
+}
+
+// TestRun_InterruptedScriptResetsGlobalState pins the cost of that rebuild: the
+// runtime is replaced, so globalThis starts empty for the next Run.
+func TestRun_InterruptedScriptResetsGlobalState(t *testing.T) {
+	t.Parallel()
+
+	s := newSandbox(t, nil, nil)
+
+	run(t, s, `globalThis.counter = 7;`)
+	interruptRun(t, s)
+
+	if got := run(t, s, `console.log(String(globalThis.counter))`); got != "undefined\n" {
+		t.Errorf("state survived the rebuild, got %q", got)
+	}
+}
+
+// TestRun_FailedScriptKeepsGlobalState pins the other half: an ordinary script
+// failure leaves the runtime intact, so a rebuild (and the state loss it costs)
+// is reserved for the interrupts that actually need one.
+func TestRun_FailedScriptKeepsGlobalState(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []string{`throw new Error("boom")`, `this is not js`} {
+		s := newSandbox(t, nil, nil)
+
+		run(t, s, `globalThis.counter = 7;`)
+		runFailed(t, s, code)
+
+		if got := run(t, s, `console.log(String(globalThis.counter))`); got != "7\n" {
+			t.Errorf("%s: state did not persist, got %q", code, got)
+		}
+	}
+}
+
+// TestRun_UnsettlableAwaitIsAFailure covers a script suspended on something no
+// tool call can ever settle. The worker loop drains at once (nothing is in
+// flight) so no timeout fires, and the IIFE promise is left pending; reporting
+// that as a failure is what keeps it from reading as an empty success.
+func TestRun_UnsettlableAwaitIsAFailure(t *testing.T) {
+	t.Parallel()
+
+	got := runFailed(t, newSandbox(t, nil, nil), `console.log("before"); await new Promise(() => {});`)
+	if !strings.Contains(got, "before") || !strings.Contains(got, "did not complete") {
+		t.Errorf("got %q", got)
+	}
+}
+
+// TestRun_SuspendedScriptCannotResumeInALaterRun pins what makes that report
+// honest. A script can park on a promise whose resolver it stashed on
+// globalThis; without the rebuild, a later Run calling that resolver resumed the
+// parked script inside itself, so its remaining tool calls ran under a different
+// Run's context and its output landed in that Run's result.
+//
+// The second case reaches the same state through the timeout branch, which
+// reports no error at all: a fire-and-forget tool call keeps the worker loop
+// waiting until the Run times out while the script parks on its own promise, so
+// the resolver outlives the Run. Both are pinned because which one a script hits
+// is a timing question, and only one of them used to be caught.
+func TestRun_SuspendedScriptCannotResumeInALaterRun(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		code string
+	}{
+		{"drains immediately", `await new Promise(r => { globalThis.wake = r; }); await tool({});`},
+		{"times out with a call in flight", `tool({}); await new Promise(r => { globalThis.wake = r; });`},
+	} {
+		var calls atomic.Int64
+
+		s := newSandbox(t, map[string]sandbox.ToolFunc{
+			"tool": func(ctx context.Context, _ string) (string, error) {
+				calls.Add(1)
+				<-ctx.Done()
+
+				return "", ctx.Err()
+			},
+		}, nil)
+
+		if _, err := s.Run(context.Background(), tc.code, 50*time.Millisecond); !errors.Is(err, sandbox.ErrScript) {
+			t.Fatalf("%s: Run: want sandbox.ErrScript, got %v", tc.name, err)
+		}
+
+		before := calls.Load()
+
+		if got := run(t, s, `console.log(typeof globalThis.wake);`); got != "undefined\n" {
+			t.Errorf("%s: parked script survived the rebuild, got %q", tc.name, got)
+		}
+
+		if n := calls.Load() - before; n != 0 {
+			t.Errorf("%s: parked script made %d tool call(s) after its own Run ended", tc.name, n)
+		}
+	}
+}
+
 func TestRun_ConcurrentCallsSerialize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/codeexec.go
+++ b/internal/tools/codeexec.go
@@ -42,7 +42,7 @@ type codeRunner interface {
 
 // codeArgs is the code_execution tool's argument schema.
 type codeArgs struct {
-	Code           string `json:"code"                      jsonschema_description:"JavaScript to run on the sobek engine (see this tool's description for runtime, helpers, and response shapes). console.log(...) to return output; tool functions are async — await them. State persists across calls only via globalThis; let/const/var/function are scoped to one call."` //nolint:lll // struct tags are indivisible
+	Code           string `json:"code"                      jsonschema_description:"JavaScript to run on the sobek engine (see this tool's description for runtime, helpers, and response shapes). console.log(...) to return output; tool functions are async — await them. State persists across calls only via globalThis, and a call that does not run to completion resets it; let/const/var/function are scoped to one call."` //nolint:lll // struct tags are indivisible
 	TimeoutSeconds int    `json:"timeout_seconds,omitempty" jsonschema_description:"Execution timeout in seconds (1-600, default 120)."`
 }
 


### PR DESCRIPTION
## What

A sandbox script that got interrupted **inside** the VM left the whole session's
runtime unusable, and the breakage was silent: every later `code_execution` call
returned empty output with a **nil** error, so a script that never ran was
reported to the model as a success.

Pre-existing on `main`, not introduced by any recent change. It is also what made
`TestLoop_TimeoutThenReuse` flaky in CI.

## Why it happens

`internal/sandbox` runs every script on one persistent sobek runtime per session,
wrapped in an async IIFE. When an uncatchable error unwinds out of `RunProgram`
(a timeout firing mid-execution, deep recursion), sobek's own `vm.callStack` is
left non-empty. From then on `RunProgram` computes `recursive := len(vm.callStack) > 0`
as true for every later call and never reaches `r.leave()`, which is the only thing
that drains the promise job queue. The same guard sits in `runWrapped`, which backs
the `resolve` returned by `NewPromise`. So `await` never resumes: the worker loop
sees nothing in flight, exits immediately, and the IIFE promise is left pending
while `assemble` treated only a *rejected* promise as a failure.

## The fix

**Rebuild the runtime unless the script actually finished.** Two things strand it:

1. An error out of `RunProgram` or the worker loop, which is the case above. That arm
   is deliberately a superset of the errors that really strand the call stack (a
   top-level throw escaping the IIFE wrapper is catchable and harmless), because the
   two mistakes are not symmetric: rebuilding needlessly costs one script's
   `globalThis`, while failing to rebuild strands every later Run of the session.
2. A still-pending IIFE promise, which means the script is suspended *inside* the
   runtime. It can park on a promise whose resolver it stashed on `globalThis`, and a
   later Run calling that resolver resumed the parked script within itself, running
   its remaining tool calls under a different Run's context and landing its output in
   that Run's result.

So `globalThis` survives only when the script ran to a settled promise, or never ran
at all (a compile error). A rebuild that fails leaves the runtime marked, so the next
Run retries rather than running on a broken VM.

The pending check is asked of **every** Run, not only the ones that reach the promise
branch. A Run that times out while the worker loop is parked reports no error at all,
and a fire-and-forget tool call keeps that loop waiting for exactly as long as the
script needs to park itself, so scoping the check to the branch that reports the
promise left that route open. Both routes are pinned by tests, since which one a
script hits is a timing question.

A pending promise is also now reported as a failure (`[script did not complete]`)
rather than an empty success, which additionally covers a script awaiting something
no tool call can ever settle (`await new Promise(() => {})`), which used to return
"no output" and a nil error.

## Verification

- `make check` green, 100% core coverage.
- Reproduced deterministically before the fix, and confirmed across the full matrix
  that a plain throw and a compile error keep `globalThis` while every unfinished
  script rebuilds.
- Reverting the fix fails `InterruptedScriptDoesNotPoisonLaterRuns`,
  `InterruptedScriptResetsGlobalState`, `UnsettlableAwaitIsAFailure` and
  `SuspendedScriptCannotResumeInALaterRun`; reverting only the branch-independence of
  the pending check fails that last test's timeout case specifically.
- `internal/sandbox` and `internal/tools` survive 25 iterations under
  `-race -shuffle=on`; `TestLoop_TimeoutThenReuse` specifically survives 40.

## Known, not fixed here

`assemble` renders a rejected promise with `p.Result().String()`, which runs the
model-controlled value's `toString` **after** the watchdog has been torn down and
the interrupt cleared. `throw { toString() { while (true) {} } }` therefore hangs
`Run` forever and defeats the sandbox timeout entirely (measured: a 200ms-timeout
run had not returned 8s later). That is a separate pre-existing bug on the rejected
path, whose semantics this PR does not change, so it wants its own fix.
