### PR TITLE
fix: refuse to dispatch tool calls from a turn truncated at the output limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,7 +417,19 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   outcomes. **A blank turn is never appended to the transcript**: it re-encodes to a
   content-less assistant message that Bifrost's Anthropic adapter serializes as `"content": []`
   and its OpenAI adapter as a bare role, both rejected by those APIs; Gemini's adapter drops
-  it, which is why replaying one went unnoticed. A non-blank final answer that stops on
+  it, which is why replaying one went unnoticed. A **tool-call turn reporting `length` is
+  quarantined** (#277): none of its calls dispatch, because the model demonstrably did not
+  finish writing them and truncation can land on a valid-JSON boundary, so even parseable
+  arguments prove nothing (this is the one place the reason refines a non-blank turn, since no
+  content signal can replace it). The refused calls are never replayed either: Bifrost's
+  Anthropic adapter re-encodes invalid-JSON arguments raw into `tool_use.input`, so a truncated
+  call kept in the transcript can fail every later request in the session. The turn's prose is
+  kept byte-identical in a text-only projection, the retry carries `truncatedCallsDirective`,
+  and `maxConsecutiveTruncated` (3) in a row ends the run with `errOutputLimit`; the streak is
+  reset by any accepted turn, while a blank turn neither counts nor resets it, so alternating
+  failure shapes cannot stretch the retry budget. Refused calls credit neither
+  `metrics.AddToolCall` nor the consecutive-failure streak, and write no audit records: nothing
+  was dispatched. A non-blank final answer that stops on
   `length` instead renders a one-line truncation notice; the notice is rendered, never
   recorded, so session history stays byte-identical to the model's own text. Tool failures and
   unknown-tool names come back as tool-result content, never a

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -2528,7 +2528,7 @@ func truncatedCallTurn(text, args string) schema.Generation {
 
 // plainTurn builds a generation with no stop reason from an assistant message.
 func plainTurn(msg *schema.Message) schema.Generation {
-	return schema.Generation{Message: msg} //nolint:exhaustruct // no reason reported
+	return schema.Generation{Message: msg} //nolint:exhaustruct // no reason reported.
 }
 
 // countingTool counts its runs under the tool name "echo".
@@ -2572,7 +2572,7 @@ func TestRun_TruncatedTurnWithToolCalls_RefusesDispatch(t *testing.T) {
 	t.Parallel()
 
 	// The stop reason gates dispatch: a turn cut at the output limit may carry a
-	// half-written call, and truncation can land on a valid-JSON boundary — the
+	// half-written call, and truncation can land on a valid-JSON boundary; the
 	// {} arguments here parse cleanly and must be refused anyway.
 	var ran bool
 	m := &toolCallReasonModel{reason: schema.StopLength}
@@ -2605,8 +2605,11 @@ func TestRun_TruncatedToolCallTurn_ReplaysTextAndDirectiveNotTheCalls(t *testing
 	// re-encodes invalid-JSON arguments raw into tool_use.input, so a truncated
 	// call kept in the transcript can fail every subsequent request. The turn's
 	// prose is kept byte-identical; the calls and their arguments vanish.
+	// The prose carries deliberate edge whitespace: byte-identical means no
+	// trimming on the way into the projection.
+	const prose = "  partial plan\n"
 	m := &genScriptModel{gens: []schema.Generation{
-		truncatedCallTurn("partial plan", `{"url": "https://exa`),
+		truncatedCallTurn(prose, `{"url": "https://exa`),
 		plainTurn(schema.AssistantMessage("final", nil)),
 	}}
 	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
@@ -2628,8 +2631,8 @@ func TestRun_TruncatedToolCallTurn_ReplaysTextAndDirectiveNotTheCalls(t *testing
 	if projected == nil {
 		t.Fatal("retry transcript has no assistant message: the turn's prose must be kept")
 	}
-	if got := projected.Text(); got != "partial plan" {
-		t.Errorf("projected text = %q, want it byte-identical to the model's prose", got)
+	if got := projected.Text(); got != prose {
+		t.Errorf("projected text = %q, want it byte-identical to the model's prose %q", got, prose)
 	}
 	if n := len(projected.ToolCalls()); n != 0 {
 		t.Errorf("projected message carries %d tool calls, want 0", n)
@@ -2646,29 +2649,42 @@ func TestRun_TruncatedToolCallTurn_ReplaysTextAndDirectiveNotTheCalls(t *testing
 func TestRun_TruncatedToolCallTurn_TextlessTurnRetriesWithOnlyTheDirective(t *testing.T) {
 	t.Parallel()
 
-	// A truncated turn with calls but no prose leaves nothing worth keeping: the
-	// retry carries the directive alone, never an empty assistant message (which
-	// re-encodes to a content-less message some providers reject).
-	m := &genScriptModel{gens: []schema.Generation{
-		truncatedCallTurn("", `{"x":`),
-		plainTurn(schema.AssistantMessage("final", nil)),
-	}}
-	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+	// A truncated turn with calls but no usable prose leaves nothing worth
+	// keeping: the retry is EXACTLY the directive, never an empty or
+	// whitespace-only assistant message (which re-encodes to a content-less
+	// message some providers reject).
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{"empty", ""},
+		{"whitespace only", " \t\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	if _, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 5); err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	if len(m.seen) != 2 {
-		t.Fatalf("Generate called %d times, want 2", len(m.seen))
-	}
-	for _, msg := range m.seen[1] {
-		if msg.Role == schema.Assistant {
-			t.Errorf("retry transcript carries an assistant message %+v, want none", msg)
-		}
-	}
-	last := m.seen[1][len(m.seen[1])-1]
-	if last.Role != schema.User || !strings.Contains(last.Text(), "none of them were run") {
-		t.Errorf("last message = %+v, want the host truncation directive", last)
+			m := &genScriptModel{gens: []schema.Generation{
+				truncatedCallTurn(tc.text, `{"x":`),
+				plainTurn(schema.AssistantMessage("final", nil)),
+			}}
+			a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+			if _, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 5); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if len(m.seen) != 2 {
+				t.Fatalf("Generate called %d times, want 2", len(m.seen))
+			}
+			// The run was seeded with a nil transcript, so the whole retry
+			// transcript is the one host directive.
+			if len(m.seen[1]) != 1 {
+				t.Fatalf("retry transcript = %d messages, want exactly the directive", len(m.seen[1]))
+			}
+			only := m.seen[1][0]
+			if only.Role != schema.User || !strings.Contains(only.Text(), "none of them were run") {
+				t.Errorf("retry message = %+v, want the host truncation directive", only)
+			}
+		})
 	}
 }
 
@@ -2819,9 +2835,71 @@ func TestRun_TruncatedToolCallTurn_RendersRefusalNoticeAndRecordsCleanHistory(t 
 	if len(a.history) != 2 {
 		t.Fatalf("history length = %d, want 2", len(a.history))
 	}
+	if got := a.history[0].Text(); got != "q" {
+		t.Errorf("recorded question = %q, want %q", got, "q")
+	}
 	if got := a.history[1].Text(); got != "done" {
 		t.Errorf("recorded answer = %q, want %q", got, "done")
 	}
+}
+
+func TestRun_TruncationCeilingOnTheLastIterationStillReportsTheOutputLimit(t *testing.T) {
+	t.Parallel()
+
+	// When the third truncated turn is also the last allowed iteration, the
+	// ceiling's specific diagnosis wins over the generic iteration limit, the
+	// same resolution the blank-turn ceiling uses (handleBlankTurn returns
+	// errNoAnswer inside the iteration). A truncation streak still below its
+	// ceiling when maxIter expires keeps reporting errIterationLimit, since the
+	// loop exit stays authoritative for plain exhaustion.
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		truncatedCallTurn("b", `{"x":`),
+		truncatedCallTurn("c", `{"x":`),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 3)
+	if !errors.Is(err, errOutputLimit) {
+		t.Fatalf("err = %v, want errOutputLimit", err)
+	}
+	if errors.Is(err, errIterationLimit) {
+		t.Error("the ceiling's diagnosis must not be reported as a plain iteration limit")
+	}
+}
+
+func TestRefuseTruncatedCalls_CeilingReportsThroughHaltOr(t *testing.T) {
+	t.Parallel()
+
+	// Tested at the helper directly: in a full run the next top-of-loop halt
+	// check would catch the interrupt anyway, so only this level can prove the
+	// ceiling's own return goes through haltOr.
+	msg := schema.AssistantMessage("x", []schema.ToolCallBlock{{ID: "c1", Name: "echo", Arguments: `{`}})
+
+	t.Run("interrupt wins at the ceiling", func(t *testing.T) {
+		t.Parallel()
+
+		a := newTestAgent(nil, nil)
+		a.interrupter = &fakeInterrupter{tripped: true} //nolint:exhaustruct // began/ended zero.
+		rs := &runState{depth: 0, out: io.Discard, consecutiveTruncated: maxConsecutiveTruncated - 1}
+
+		_, err := a.refuseTruncatedCalls(nil, msg, rs)
+		if !errors.Is(err, errInterrupted) {
+			t.Fatalf("err = %v, want errInterrupted", err)
+		}
+	})
+
+	t.Run("output limit otherwise", func(t *testing.T) {
+		t.Parallel()
+
+		a := newTestAgent(nil, nil)
+		rs := &runState{depth: 0, out: io.Discard, consecutiveTruncated: maxConsecutiveTruncated - 1}
+
+		_, err := a.refuseTruncatedCalls(nil, msg, rs)
+		if !errors.Is(err, errOutputLimit) {
+			t.Fatalf("err = %v, want errOutputLimit", err)
+		}
+	})
 }
 
 func TestRun_InterruptBeatsTheTruncationCeiling(t *testing.T) {

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -2492,28 +2492,381 @@ func TestRun_FinalAnswer_NoNoticeWhenNotTruncated(t *testing.T) {
 	}
 }
 
-func TestRun_TruncatedTurnWithToolCalls_StillDispatches(t *testing.T) {
+// genScriptModel returns scripted Generations in order (so a turn can carry
+// both tool calls and a stop reason) and records the transcript passed to each
+// call, so a test can assert what a retry replays. Once exhausted it errors.
+type genScriptModel struct {
+	gens []schema.Generation
+	seen [][]*schema.Message
+}
+
+var _ schema.ChatModel = (*genScriptModel)(nil)
+
+func (m *genScriptModel) Generate(
+	_ context.Context,
+	msgs []*schema.Message,
+	_ []*schema.ToolInfo,
+) (schema.Generation, error) {
+	m.seen = append(m.seen, append([]*schema.Message(nil), msgs...))
+	if len(m.seen) > len(m.gens) {
+		return schema.Generation{}, errors.New("genScriptModel: out of scripted generations")
+	}
+
+	return m.gens[len(m.seen)-1], nil
+}
+
+// truncatedCallTurn builds a StopLength generation carrying text and one echo
+// tool call with the given arguments.
+func truncatedCallTurn(text, args string) schema.Generation {
+	return schema.Generation{
+		Message: schema.AssistantMessage(text, []schema.ToolCallBlock{
+			{ID: "c1", Name: "echo", Arguments: args},
+		}),
+		StopReason: schema.StopLength,
+	}
+}
+
+// plainTurn builds a generation with no stop reason from an assistant message.
+func plainTurn(msg *schema.Message) schema.Generation {
+	return schema.Generation{Message: msg} //nolint:exhaustruct // no reason reported
+}
+
+// countingTool counts its runs under the tool name "echo".
+type countingTool struct{ runs int }
+
+var _ schema.InvokableTool = (*countingTool)(nil)
+
+func (*countingTool) Info() *schema.ToolInfo {
+	return &schema.ToolInfo{Name: "echo", Desc: "echo tool", Params: nil}
+}
+
+func (t *countingTool) Run(context.Context, string) (string, error) {
+	t.runs++
+
+	return "echoed", nil
+}
+
+// transcriptContains reports whether substr appears anywhere in the transcript:
+// text blocks, tool-call names or arguments, or tool-result content.
+func transcriptContains(msgs []*schema.Message, substr string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m.Text(), substr) {
+			return true
+		}
+		for _, tc := range m.ToolCalls() {
+			if strings.Contains(tc.Name, substr) || strings.Contains(tc.Arguments, substr) {
+				return true
+			}
+		}
+		for _, tr := range m.ToolResults() {
+			if strings.Contains(tr.Content, substr) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func TestRun_TruncatedTurnWithToolCalls_RefusesDispatch(t *testing.T) {
 	t.Parallel()
 
-	// Content stays authoritative: the stop reason refines only the blank case.
-	// Bifrost itself warns the field cannot be trusted to describe content.
+	// The stop reason gates dispatch: a turn cut at the output limit may carry a
+	// half-written call, and truncation can land on a valid-JSON boundary — the
+	// {} arguments here parse cleanly and must be refused anyway.
 	var ran bool
 	m := &toolCallReasonModel{reason: schema.StopLength}
 	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: &ran}})
 
 	var buf bytes.Buffer
-	answer, err := a.run(context.Background(), &runState{depth: 0, out: &buf}, nil, 5)
+	rs := &runState{depth: 0, out: &buf}
+	answer, err := a.run(context.Background(), rs, nil, 5)
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if !ran {
-		t.Error("tool did not run: a truncated turn's tool calls must still dispatch")
+	if ran {
+		t.Error("tool ran: a truncated turn's tool calls must not dispatch")
 	}
 	if answer != "final" {
 		t.Errorf("answer = %q, want %q", answer, "final")
 	}
+	if rs.answerTruncated {
+		t.Error("answerTruncated = true, want false: the final answer itself was not truncated")
+	}
 	if strings.Contains(buf.String(), truncatedAnswerNotice) {
 		t.Errorf("output = %q, a tool-call turn is not a final answer", buf.String())
+	}
+}
+
+func TestRun_TruncatedToolCallTurn_ReplaysTextAndDirectiveNotTheCalls(t *testing.T) {
+	t.Parallel()
+
+	// The retry must not replay the refused calls: Bifrost's Anthropic adapter
+	// re-encodes invalid-JSON arguments raw into tool_use.input, so a truncated
+	// call kept in the transcript can fail every subsequent request. The turn's
+	// prose is kept byte-identical; the calls and their arguments vanish.
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("partial plan", `{"url": "https://exa`),
+		plainTurn(schema.AssistantMessage("final", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+	if _, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 5); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(m.seen) != 2 {
+		t.Fatalf("Generate called %d times, want 2", len(m.seen))
+	}
+
+	retry := m.seen[1]
+	var projected *schema.Message
+	for _, msg := range retry {
+		if msg.Role == schema.Assistant {
+			projected = msg
+		}
+	}
+	if projected == nil {
+		t.Fatal("retry transcript has no assistant message: the turn's prose must be kept")
+	}
+	if got := projected.Text(); got != "partial plan" {
+		t.Errorf("projected text = %q, want it byte-identical to the model's prose", got)
+	}
+	if n := len(projected.ToolCalls()); n != 0 {
+		t.Errorf("projected message carries %d tool calls, want 0", n)
+	}
+	if transcriptContains(retry, `{"url"`) {
+		t.Error("the truncated arguments were replayed; they must be dropped from the transcript")
+	}
+	last := retry[len(retry)-1]
+	if last.Role != schema.User || !strings.Contains(last.Text(), "none of them were run") {
+		t.Errorf("last message = %+v, want the host truncation directive", last)
+	}
+}
+
+func TestRun_TruncatedToolCallTurn_TextlessTurnRetriesWithOnlyTheDirective(t *testing.T) {
+	t.Parallel()
+
+	// A truncated turn with calls but no prose leaves nothing worth keeping: the
+	// retry carries the directive alone, never an empty assistant message (which
+	// re-encodes to a content-less message some providers reject).
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("", `{"x":`),
+		plainTurn(schema.AssistantMessage("final", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+	if _, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 5); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(m.seen) != 2 {
+		t.Fatalf("Generate called %d times, want 2", len(m.seen))
+	}
+	for _, msg := range m.seen[1] {
+		if msg.Role == schema.Assistant {
+			t.Errorf("retry transcript carries an assistant message %+v, want none", msg)
+		}
+	}
+	last := m.seen[1][len(m.seen[1])-1]
+	if last.Role != schema.User || !strings.Contains(last.Text(), "none of them were run") {
+		t.Errorf("last message = %+v, want the host truncation directive", last)
+	}
+}
+
+func TestRun_RepeatedTruncatedToolCallTurns_StopWithTheOutputLimit(t *testing.T) {
+	t.Parallel()
+
+	// A model that keeps truncating mid-call would otherwise burn every
+	// remaining iteration on billed round-trips; the fourth scripted answer must
+	// never be requested.
+	tool := &countingTool{runs: 0}
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		truncatedCallTurn("b", `{"x":`),
+		truncatedCallTurn("c", `{"x":`),
+		plainTurn(schema.AssistantMessage("should not appear", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": tool})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if !errors.Is(err, errOutputLimit) {
+		t.Fatalf("err = %v, want errOutputLimit", err)
+	}
+	if answer != "" {
+		t.Errorf("answer = %q, want empty", answer)
+	}
+	if len(m.seen) != 3 {
+		t.Errorf("Generate called %d times, want 3", len(m.seen))
+	}
+	if tool.runs != 0 {
+		t.Errorf("tool ran %d times, want 0", tool.runs)
+	}
+}
+
+func TestRun_TruncatedStreakResetsOnAProductiveTurn(t *testing.T) {
+	t.Parallel()
+
+	// The ceiling counts CONSECUTIVE truncated turns. Occasional truncation
+	// between productive turns must not accumulate into a give-up, and only the
+	// productive turn's call dispatches.
+	tool := &countingTool{runs: 0}
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		truncatedCallTurn("b", `{"x":`),
+		plainTurn(toolCall("c1", "echo", "{}")),
+		truncatedCallTurn("c", `{"x":`),
+		truncatedCallTurn("d", `{"x":`),
+		plainTurn(schema.AssistantMessage("done", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": tool})
+
+	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "done" {
+		t.Errorf("answer = %q, want done", answer)
+	}
+	if tool.runs != 1 {
+		t.Errorf("tool ran %d times, want 1 (only the productive turn dispatches)", tool.runs)
+	}
+}
+
+func TestRun_ABlankTurnDoesNotResetTheTruncationStreak(t *testing.T) {
+	t.Parallel()
+
+	// A retryable blank between truncated turns is not progress: the truncation
+	// ceiling still fires on the third truncated turn, so alternating failure
+	// shapes cannot stretch the retry budget.
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		truncatedCallTurn("b", `{"x":`),
+		plainTurn(schema.AssistantMessage("", nil)),
+		truncatedCallTurn("c", `{"x":`),
+		plainTurn(schema.AssistantMessage("should not appear", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if !errors.Is(err, errOutputLimit) {
+		t.Fatalf("err = %v, want errOutputLimit", err)
+	}
+	if len(m.seen) != 4 {
+		t.Errorf("Generate called %d times, want 4", len(m.seen))
+	}
+}
+
+func TestRun_TruncatedToolCallTurn_DoesNotDisturbTheToolFailureStreak(t *testing.T) {
+	t.Parallel()
+
+	// The two ceilings count different things: consecutiveFailures counts failed
+	// tool calls, the truncation streak counts refused turns. A truncated turn
+	// between two failing tool calls must neither credit the failure streak
+	// (nothing was dispatched) nor reset it, so the failure halt still fires on
+	// the second failure.
+	tool := &countingTool{runs: 0}
+	m := &genScriptModel{gens: []schema.Generation{
+		plainTurn(toolCall("c1", "boom", "{}")),
+		truncatedCallTurn("mid plan", `{"x":`),
+		plainTurn(toolCall("c2", "boom", "{}")),
+		plainTurn(schema.AssistantMessage("stuck: I need credentials", nil)),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"boom": &errTool{}, "echo": tool})
+	a.maxConsecutiveFailures = 2
+
+	rs := &runState{depth: 0, out: io.Discard}
+	answer, err := a.run(context.Background(), rs, nil, 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if answer != "stuck: I need credentials" {
+		t.Errorf("answer = %q, want the failure summary", answer)
+	}
+	if rs.consecutiveFailures != 2 {
+		t.Errorf("consecutiveFailures = %d, want 2 (the truncated turn neither credits nor resets)",
+			rs.consecutiveFailures)
+	}
+	if tool.runs != 0 {
+		t.Errorf("the truncated turn's call ran %d times, want 0", tool.runs)
+	}
+}
+
+func TestRun_TruncatedToolCallTurn_RendersRefusalNoticeAndRecordsCleanHistory(t *testing.T) {
+	t.Parallel()
+
+	cfg := baseConfig()
+	cfg.Model = &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("half a plan", `{"x":`),
+		plainTurn(schema.AssistantMessage("done", nil)),
+	}}
+	a := New(context.Background(), cfg)
+
+	var buf bytes.Buffer
+	if err := a.Run(context.Background(), "q", &buf); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "half a plan") {
+		t.Errorf("output = %q, want the turn's prose rendered", out)
+	}
+	if !strings.Contains(out, "were not run") {
+		t.Errorf("output = %q, want the refusal notice", out)
+	}
+	if strings.Contains(out, truncatedAnswerNotice) {
+		t.Errorf("output = %q, must not claim a truncated final answer", out)
+	}
+	// History keeps only the clean Q&A pair; neither the projection nor the
+	// directive leaks into it.
+	if len(a.history) != 2 {
+		t.Fatalf("history length = %d, want 2", len(a.history))
+	}
+	if got := a.history[1].Text(); got != "done" {
+		t.Errorf("recorded answer = %q, want %q", got, "done")
+	}
+}
+
+func TestRun_InterruptBeatsTheTruncationCeiling(t *testing.T) {
+	t.Parallel()
+
+	// Checks per quarantined iteration: top-of-loop and post-Generate. Trip on
+	// the 7th (0-based 6): the ceiling's own terminal check, so a stop that
+	// landed during the third truncated turn is reported as the operator's
+	// interrupt, not as a model output problem.
+	ci := &countInterrupter{target: 6, calls: 0}
+	m := &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		truncatedCallTurn("b", `{"x":`),
+		truncatedCallTurn("c", `{"x":`),
+	}}
+	a := newTestAgent(m, map[string]schema.InvokableTool{"echo": &echoTool{ran: nil}})
+	a.interrupter = ci
+
+	_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
+	if !errors.Is(err, errInterrupted) {
+		t.Fatalf("err = %v, want errInterrupted", err)
+	}
+	if errors.Is(err, errOutputLimit) {
+		t.Error("an operator stop must not be reported as a model output problem")
+	}
+}
+
+func TestRun_TruncatedToolCallTurn_CountsNoToolCallMetric(t *testing.T) {
+	t.Parallel()
+
+	// AddToolCall's contract is a dispatched call; a refused batch counts none.
+	acc := metrics.NewAccumulator("p", "m")
+	cfg := baseConfig()
+	cfg.Metrics = acc
+	cfg.Model = &genScriptModel{gens: []schema.Generation{
+		truncatedCallTurn("a", `{"x":`),
+		plainTurn(schema.AssistantMessage("done", nil)),
+	}}
+	a := New(context.Background(), cfg)
+
+	if err := a.Run(context.Background(), "q", io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := acc.Snapshot().ToolCalls; got != 0 {
+		t.Errorf("ToolCalls = %d, want 0: a refused batch dispatches nothing", got)
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -320,7 +320,8 @@ func (a *Agent) acceptTurn(
 	}
 
 	rs.consecutiveEmpty = 0
-	if len(msg.ToolCalls()) > 0 && gen.StopReason == schema.StopLength {
+	calls := msg.ToolCalls()
+	if len(calls) > 0 && gen.StopReason == schema.StopLength {
 		next, err := a.refuseTruncatedCalls(turn, msg, rs)
 
 		return next, nil, "", false, err
@@ -330,7 +331,7 @@ func (a *Agent) acceptTurn(
 	turn = append(turn, msg)
 	a.renderTurn(msg, rs.out)
 
-	if calls := msg.ToolCalls(); len(calls) > 0 {
+	if len(calls) > 0 {
 		return turn, calls, "", false, nil
 	}
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -56,9 +56,11 @@ var errNoAnswer = errors.New("agent: model returned no answer")
 // the only other stop. Three means one blank plus two retries.
 const maxConsecutiveEmpty = 3
 
-// errOutputLimit ends a run whose model spent its entire output budget before
-// emitting a visible token. Retrying cannot help: neither the request nor the
-// configuration changes between attempts.
+// errOutputLimit ends a run the model's output limit made unwinnable: a blank
+// turn whose entire output budget went to invisible tokens (retrying cannot
+// help: neither the request nor the configuration changes between attempts),
+// or maxConsecutiveTruncated tool-call turns in a row cut off at that limit
+// (the bounded retry with truncatedCallsDirective changed nothing).
 var errOutputLimit = errors.New("agent: model output limit reached")
 
 // errContentFiltered ends a run whose model response was withheld by a content
@@ -106,6 +108,25 @@ func clampRawReason(raw string) string {
 const emptyTurnDirective = "Your previous response was empty: it contained neither text nor a " +
 	"tool call. Continue the investigation with a tool call, or give your final answer as text."
 
+// maxConsecutiveTruncated is how many length-truncated tool-call turns a run
+// tolerates in a row before giving up with errOutputLimit. Like the blank-turn
+// ceiling, the retry is bounded so a model that deterministically overruns its
+// output budget cannot burn every remaining iteration on billed round-trips.
+const maxConsecutiveTruncated = 3
+
+// truncatedCallsDirective is appended as a trusted host message in place of a
+// length-truncated tool-call turn's refused calls, steering the retry toward
+// smaller output the same way emptyTurnDirective steers a blank turn.
+const truncatedCallsDirective = "Your previous response hit the output limit midway through writing " +
+	"tool calls, so none of them were run. Re-issue the work in smaller steps: shorter arguments, " +
+	"or fewer tool calls per turn."
+
+// truncatedCallsNotice warns the operator that a turn's tool calls were refused
+// because the response was cut at the model's output limit. Rendered, never
+// recorded, like truncatedAnswerNotice.
+const truncatedCallsNotice = "\n⚠️  The response was cut off at the model's output limit; " +
+	"its tool calls were not run."
+
 // deniedInterruptResult is the model-facing message returned by invokeIO when the
 // operator interrupted before the tool was dispatched; it matches the unframed
 // denial convention (trusted host/user signal, not untrusted tool output).
@@ -140,6 +161,11 @@ type runState struct {
 	// that carries text or a tool call. At maxConsecutiveEmpty the run gives up.
 	// It lives here, not on *Agent, so concurrent sub-runs share no mutable state.
 	consecutiveEmpty int
+	// consecutiveTruncated counts length-truncated tool-call turns in this run;
+	// reset by any accepted turn. A blank turn neither counts nor resets, so
+	// alternating failure shapes cannot stretch the retry budget. At
+	// maxConsecutiveTruncated the run gives up with errOutputLimit.
+	consecutiveTruncated int
 	// answerTruncated records that this run's final answer stopped on the model's
 	// output limit, so a caller can mark a conclusion the model did not finish.
 	// It lives here, not on *Agent, so concurrent sub-runs stay race-free.
@@ -161,7 +187,10 @@ type runScopedTool interface {
 // retried with a directive, and after maxConsecutiveEmpty in a row the run ends
 // with errNoAnswer. A blank turn whose stop reason is length, content_filter, or
 // unrecognized ends the run at once instead, since re-asking cannot change a
-// futile stop. Exhausting maxIter ends it with errIterationLimit. All are
+// futile stop. A tool-call turn reporting StopLength is quarantined: nothing
+// dispatches, the retry carries truncatedCallsDirective, and after
+// maxConsecutiveTruncated in a row the run ends with errOutputLimit.
+// Exhausting maxIter ends it with errIterationLimit. All are
 // non-fatal and distinguishable, so the caller reports the stop that actually
 // happened. Tool failures and unknown tools come back as tool-result content,
 // never as a Go error, so the model can self-correct. A non-nil error from
@@ -207,7 +236,8 @@ func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, m
 
 		var answer string
 		var done bool
-		turn, answer, done, err = a.acceptTurn(turn, gen, rs)
+		var calls []schema.ToolCallBlock
+		turn, calls, answer, done, err = a.acceptTurn(turn, gen, rs)
 		if err != nil {
 			return "", err
 		}
@@ -215,9 +245,11 @@ func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, m
 			return answer, nil
 		}
 
-		// A retried blank turn carries no tool calls, so this loop is a no-op and
-		// the run falls through to the next iteration.
-		for _, tc := range toolCallsOf(gen.Message) {
+		// The dispatch set comes from acceptTurn, never from gen.Message directly:
+		// a retried blank turn and a quarantined truncated turn both return no
+		// calls, so this loop is a no-op and the run falls through to the next
+		// iteration.
+		for _, tc := range calls {
 			a.metrics.AddToolCall()
 			var halt string
 			turn, halt, err = a.dispatchAndTrack(ctx, rs, tc, turn)
@@ -246,17 +278,6 @@ func (a *Agent) haltOr(fallback error) error {
 	return fallback
 }
 
-// toolCallsOf returns a turn's tool calls, tolerating the nil message blankTurn
-// admits: schema.Message's accessors dereference their receiver, so the retry
-// path must not reach for them directly.
-func toolCallsOf(msg *schema.Message) []schema.ToolCallBlock {
-	if msg == nil {
-		return nil
-	}
-
-	return msg.ToolCalls()
-}
-
 // blankTurn reports whether an assistant turn carries nothing the run can use:
 // no tool call, and no text once trimmed. Providers produce these on truncation,
 // a content filter, or a reasoning-only response, and a lossy provider
@@ -271,8 +292,10 @@ func blankTurn(msg *schema.Message) bool {
 }
 
 // acceptTurn classifies one assistant turn and extends the transcript. It
-// returns the updated turn, the final answer when the run is over, whether it is
-// over, and a halt error.
+// returns the updated turn, the tool calls the run may dispatch, the final
+// answer when the run is over, whether it is over, and a halt error. The
+// dispatch set is the classification's verdict: a blank or quarantined turn
+// returns none, so the loop cannot dispatch what acceptTurn refused.
 //
 // A blank turn is NOT appended: an assistant message with neither content nor
 // tool calls re-encodes to a content-less message that Bifrost's Anthropic
@@ -280,27 +303,42 @@ func blankTurn(msg *schema.Message) bool {
 // both of which those APIs reject. Gemini's adapter drops it instead, which is
 // why appending one went unnoticed. The retry therefore carries a host directive
 // in place of the blank turn rather than a repaired version of it.
+//
+// A tool-call turn reporting StopLength is quarantined the same way: the model
+// demonstrably did not finish writing the calls, so none of them dispatch. This
+// is the one place the stop reason refines a NON-blank turn, and only because
+// no content signal can replace it: truncation can land on a valid-JSON
+// boundary, so even parseable arguments cannot be trusted.
 func (a *Agent) acceptTurn(
 	turn []*schema.Message, gen schema.Generation, rs *runState,
-) ([]*schema.Message, string, bool, error) {
+) ([]*schema.Message, []schema.ToolCallBlock, string, bool, error) {
 	msg := gen.Message
 	if blankTurn(msg) {
-		return a.handleBlankTurn(turn, gen, rs)
+		next, err := a.handleBlankTurn(turn, gen, rs)
+
+		return next, nil, "", false, err
 	}
 
 	rs.consecutiveEmpty = 0
+	if len(msg.ToolCalls()) > 0 && gen.StopReason == schema.StopLength {
+		next, err := a.refuseTruncatedCalls(turn, msg, rs)
+
+		return next, nil, "", false, err
+	}
+	rs.consecutiveTruncated = 0
+
 	turn = append(turn, msg)
 	a.renderTurn(msg, rs.out)
 
-	if len(msg.ToolCalls()) > 0 {
-		return turn, "", false, nil
+	if calls := msg.ToolCalls(); len(calls) > 0 {
+		return turn, calls, "", false, nil
 	}
 
 	// Re-check after rendering: a stop that landed while the final answer was
 	// being written still surfaces ErrInterrupted/130 instead of recording the
 	// answer and exiting 0.
 	if herr := a.haltErr(); herr != nil {
-		return turn, "", false, herr
+		return turn, nil, "", false, herr
 	}
 
 	// A comparison, not a switch: exhaustive does not police it. A future member
@@ -310,7 +348,37 @@ func (a *Agent) acceptTurn(
 		fmt.Fprintln(rs.out, truncatedAnswerNotice)
 	}
 
-	return turn, msg.Text(), true, nil
+	return turn, nil, msg.Text(), true, nil
+}
+
+// refuseTruncatedCalls quarantines a tool-call turn cut off at the model's
+// output limit. The calls are refused wholesale and never replayed: a
+// half-written call re-encodes hazardously (Bifrost's Anthropic adapter passes
+// invalid-JSON arguments through raw, which can fail every subsequent request
+// in the session), and the reason belongs to the whole generation, so a call
+// that happens to parse proves nothing about the batch. The turn's prose is
+// kept byte-identical in a text-only projection (a whitespace-only projection
+// is skipped, like a blank turn); the retry carries a host directive in place
+// of the calls. At maxConsecutiveTruncated in a row the run gives up with
+// errOutputLimit, through haltOr, so an operator stop or budget crossing that
+// raced in is reported as itself.
+func (a *Agent) refuseTruncatedCalls(
+	turn []*schema.Message, msg *schema.Message, rs *runState,
+) ([]*schema.Message, error) {
+	rs.consecutiveTruncated++
+
+	if text := msg.Text(); strings.TrimSpace(text) != "" {
+		projected := schema.AssistantMessage(text, nil)
+		turn = append(turn, projected)
+		a.renderTurn(projected, rs.out)
+	}
+	fmt.Fprintln(rs.out, truncatedCallsNotice)
+
+	if rs.consecutiveTruncated >= maxConsecutiveTruncated {
+		return turn, a.haltOr(errOutputLimit)
+	}
+
+	return append(turn, schema.UserMessage(truncatedCallsDirective)), nil
 }
 
 // handleBlankTurn decides what to do about an assistant turn carrying neither
@@ -321,14 +389,14 @@ func (a *Agent) acceptTurn(
 // that raced in during Generate is reported as itself rather than as truncation.
 func (a *Agent) handleBlankTurn(
 	turn []*schema.Message, gen schema.Generation, rs *runState,
-) ([]*schema.Message, string, bool, error) {
+) ([]*schema.Message, error) {
 	switch gen.StopReason {
 	case schema.StopLength:
-		return turn, "", false, a.haltOr(errOutputLimit)
+		return turn, a.haltOr(errOutputLimit)
 	case schema.StopContentFilter:
-		return turn, "", false, a.haltOr(errContentFiltered)
+		return turn, a.haltOr(errContentFiltered)
 	case schema.StopOther:
-		return turn, "", false, a.haltOr(&stoppedEarlyError{raw: gen.RawReason})
+		return turn, a.haltOr(&stoppedEarlyError{raw: gen.RawReason})
 	case schema.StopUnspecified, schema.StopNormal, schema.StopToolCalls:
 		// Retryable. A blank turn reporting a normal stop is usually transient,
 		// and seven distinct Gemini conditions reach here reporting exactly that,
@@ -337,10 +405,10 @@ func (a *Agent) handleBlankTurn(
 
 	rs.consecutiveEmpty++
 	if rs.consecutiveEmpty >= maxConsecutiveEmpty {
-		return turn, "", false, a.haltOr(errNoAnswer)
+		return turn, a.haltOr(errNoAnswer)
 	}
 
-	return append(turn, schema.UserMessage(emptyTurnDirective)), "", false, nil
+	return append(turn, schema.UserMessage(emptyTurnDirective)), nil
 }
 
 // dispatchAndTrack dispatches one tool call, appends its result to turn, updates the


### PR DESCRIPTION
A turn that stops on `length` can carry a half-written tool call, and truncation can land on a valid-JSON boundary (Anthropic's non-streaming API delivers an incomplete `tool_use` as a parsed object; its docs say to detect the case via the stop reason, not a parse failure), so even arguments that parse prove nothing. The loop dispatched them anyway; #273 made the stop reason available at the decision point.

This also closes a worse path than the billed-call-and-approval-prompt cost the issue describes: the failed dispatch left the truncated arguments in the transcript, and Bifrost's direct Anthropic adapter re-encodes invalid-JSON arguments raw into `tool_use.input`, so one truncated call could fail every later request in the session.

`acceptTurn` now quarantines a tool-call turn reporting `StopLength`:

- None of its calls dispatch: no approval prompt, no `AddToolCall`, no audit records. The dispatch loop takes its calls from `acceptTurn`'s verdict, so a refused call structurally cannot run.
- The model's message is not appended; its prose is kept byte-identical in a text-only projection, and the refused calls (with their untrustworthy arguments) never re-enter the transcript.
- The retry carries a host directive naming the truncation, the same shape as the blank-turn retry; a one-line notice renders to the operator.
- `maxConsecutiveTruncated` (3) in a row ends the run with `errOutputLimit` through `haltOr`, so an operator stop or budget crossing is reported as itself. The streak resets on any accepted turn; blank turns neither count nor reset it. `consecutiveFailures` is untouched: nothing was dispatched.

Prior art: the Vercel AI SDK gates tool execution on the finish reason (`ai@7.0.70`), and goose rewrites length-terminated tool calls into non-executable errors, with a test pinning that valid-JSON arguments under `finish_reason: length` must not execute.

`handleBlankTurn` is simplified to return `(turn, error)`: its answer/done results were constants.

Closes #277