### PR TITLE
ci: pin the internal/schema pure-leaf import rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -258,6 +258,25 @@ linters:
           deny:
             - pkg: log$
               desc: Use log/slog instead, see https://go.dev/blog/slog
+        # internal/schema is a pure leaf (see its package doc and the AGENTS.md
+        # bullet): it imports only the standard library and
+        # github.com/invopop/jsonschema, and no internal import may ever be
+        # added, because the whole llm/agent/tools/ui spine depends on it, so
+        # an upward import here is a cycle waiting to happen. The
+        # allowlist pins that contract exactly. The '$'-suffixed entries are
+        # exact matches, so the self-import exception (schema's external tests
+        # import the package under test) cannot widen into a prefix hole, and
+        # test files are deliberately in scope. depguard sees only the active
+        # build context and golangci-lint drops diagnostics from generated
+        # files; internal/schema's TestPackageIsPureLeaf closes those gaps by
+        # parsing every file in the package directory.
+        "schema-pure-leaf":
+          files:
+            - "**/internal/schema/**"
+          allow:
+            - $gostd
+            - github.com/invopop/jsonschema$
+            - github.com/cynative/cynative/internal/schema$
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,11 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
 - **`internal/schema`**: the provider-agnostic message/tool currency shared by `llm`, `agent`,
   `tools`, and `ui`. A pure leaf: it imports only the standard library and
   `github.com/invopop/jsonschema`, and **no internal import may ever be added** (nothing it
-  depends on can create a cycle). `Message{Role, Content []Block}` with three sealed block
+  depends on can create a cycle). The contract is pinned twice: the depguard `schema-pure-leaf`
+  rule in `.golangci.yaml` fails lint at the point of the edit (exact-match allowlist; the
+  external tests' self-import is the one sanctioned extra), and `TestPackageIsPureLeaf` parses
+  every file in the package directory, covering the build-tagged and generated files depguard
+  cannot see. `Message{Role, Content []Block}` with three sealed block
   variants: `TextBlock`, `ToolCallBlock` (the raw JSON arguments as the model produced them),
   `ToolResultBlock`. `ChatModel{Generate}` takes the offered tools as a direct
   `tools []*ToolInfo` argument (tool-less calls pass nil; there is no per-call options

--- a/internal/schema/imports_test.go
+++ b/internal/schema/imports_test.go
@@ -1,0 +1,89 @@
+package schema_test
+
+import (
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestPackageIsPureLeaf pins the pure-leaf contract from the package doc: every
+// Go file under this directory imports only the standard library, the JSON
+// Schema generator, or (external test files only) the package itself. The
+// depguard "schema-pure-leaf" rule enforces the same contract at lint time, but
+// it sees only the active build context and golangci-lint drops diagnostics
+// from generated files, so this test parses every file regardless of build
+// tags or generated markers.
+func TestPackageIsPureLeaf(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	walkErr := filepath.WalkDir(".", func(path string, entry fs.DirEntry, walkErr error) error {
+		switch {
+		case walkErr != nil:
+			return walkErr
+		case entry.IsDir():
+			return dirAction(path, entry.Name())
+		case !strings.HasSuffix(entry.Name(), ".go"):
+			return nil
+		default:
+			return checkFileImports(t, fset, path)
+		}
+	})
+	if walkErr != nil {
+		t.Fatalf("walking the package directory: %v", walkErr)
+	}
+}
+
+// dirAction skips directories the go tool would not compile (none exist
+// today) and descends into the rest.
+func dirAction(path, name string) error {
+	if path == "." {
+		return nil
+	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") || name == "testdata" {
+		return fs.SkipDir
+	}
+	return nil
+}
+
+// checkFileImports parses one Go file and reports every import outside the
+// pure-leaf allowlist as a test failure.
+func checkFileImports(t *testing.T, fset *token.FileSet, path string) error {
+	t.Helper()
+
+	file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		return err
+	}
+	for _, imp := range file.Imports {
+		impPath, unquoteErr := strconv.Unquote(imp.Path.Value)
+		if unquoteErr != nil {
+			return unquoteErr
+		}
+		if !importAllowed(impPath, file.Name.Name, path) {
+			t.Errorf("%s imports %q: internal/schema is a pure leaf (see the package doc)", path, impPath)
+		}
+	}
+	return nil
+}
+
+// importAllowed reports whether the file at path, whose package clause is pkg,
+// may import impPath. Beyond the two exact-match exceptions, an import is
+// allowed only if it resolves into GOROOT, so a lookup failure is a violation,
+// never a pass; that also rejects cgo's "C" pseudo-import, which no leaf
+// serialization package has business using.
+func importAllowed(impPath, pkg, path string) bool {
+	if impPath == "github.com/invopop/jsonschema" {
+		return true
+	}
+	if impPath == "github.com/cynative/cynative/internal/schema" {
+		return pkg == "schema_test" && strings.HasSuffix(path, "_test.go")
+	}
+	resolved, err := build.Import(impPath, "", build.FindOnly)
+	return err == nil && resolved.Goroot
+}

--- a/internal/schema/message.go
+++ b/internal/schema/message.go
@@ -1,7 +1,10 @@
 // Package schema is the provider-agnostic message and tool "currency" shared by
 // the llm, agent, tools, and ui packages. It is a pure leaf: it imports only the
 // standard library and github.com/invopop/jsonschema, so nothing it depends on can
-// create an import cycle. No internal import may ever be added here.
+// create an import cycle. No internal import may ever be added here. The contract
+// is pinned twice: the depguard "schema-pure-leaf" rule fails lint at the point of
+// the edit, and TestPackageIsPureLeaf parses every file in this directory, covering
+// the build-tagged and generated files depguard cannot see.
 package schema
 
 import "strings"


### PR DESCRIPTION
## What

`internal/schema` is documented (package doc, AGENTS.md) as a pure leaf: standard library plus `github.com/invopop/jsonschema` only, and no internal import may ever be added. Nothing enforced it; adding `internal/metrics` to the package would have linted and tested clean. This pins the contract with two thin layers (closes #279).

## How

- **depguard `schema-pure-leaf` rule** (`.golangci.yaml`): a pure allowlist over `**/internal/schema/**` - `$gostd`, `github.com/invopop/jsonschema$`, and `github.com/cynative/cynative/internal/schema$`. The `$`-suffixed entries are exact matches, so the sanctioned self-import (schema's external tests import the package under test) cannot widen into a prefix hole. Test files are deliberately in scope. Fails at the point of the edit, in `make lint`.
- **`TestPackageIsPureLeaf`** (`internal/schema/imports_test.go`): parses every Go file in the package directory and asserts the same allowlist. This closes the two gaps depguard structurally cannot cover: it only sees the active build context (a `//go:build windows` file goes unlinted on Linux CI) and golangci-lint drops diagnostics from generated files. Imports must resolve into GOROOT via `go/build`, so an unresolvable path or cgo's `"C"` is a violation rather than a pass, and the self-import exception additionally requires the importing file to end in `_test.go`.
- One-sentence doc updates in the package doc and the AGENTS.md bullet naming both enforcement points.

## Verification

Both layers were proven to fire before landing, in both directions:

- With canary imports planted (`internal/interrupt` in `message.go`, `internal/metrics` in `message_test.go`), `make lint` and the new test each failed naming exactly those two files - proving the glob matches the absolute paths golangci hands depguard, and that test files are in scope.
- With parse-only probes planted (a build-tagged file importing `"C"` and `corp/pkg`, and a non-test file in a nested directory claiming `package schema_test` to grab the self-import exception), the test flags all three; depguard alone cannot see the build-tagged file, which is why the second layer exists.
- Canaries removed; full `make check` is green.