### PR TITLE
fix: exit 2 when a scripted run produces no answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,12 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   once; a TTY without `-p` enters an interactive follow-up loop (optionally seeded by a
   positional arg) that survives transient turn errors; `exit`/`quit`/EOF ends it, and it
   aborts only on context cancellation, a fail-closed audit-write failure, or an LLM generation
-  failure before the first successful turn. Piped stdin (1 MiB-capped, UTF-8-repaired)
+  failure before the first successful turn. A one-shot whose run ends in a futile stop
+  (`agent.ErrNoAnswer`) exits `exitNoAnswer` (2), distinct from the generic 1, so a scripted
+  caller can tell "no answer produced" from an execution failure without parsing stdout; an
+  interactive session swallows the same sentinel (`runTask`/`handleTurnError`) and continues,
+  and a failing deferred audit close still replaces it (exit 1), so the outcome sentinel
+  cannot mask a durability failure. Piped stdin (1 MiB-capped, UTF-8-repaired)
   combined with a positional task is folded in as untrusted `<piped_input>` context
   (`agent.WrapPipedInput`). A bare interactive session opens with `Agent.Welcome`, gated on all
   four of: interactive, no seed task, no configured token budget, and at least one registered
@@ -384,7 +389,7 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     content-block type and the OpenAI-shaped `ChatAssistantMessage.Refusal` field beside a
     null content), so a refusal becomes the run's answer instead of a blank turn whose fate
     then depends on the reported stop reason, anywhere from an immediate `errStoppedEarly`
-    halt to the bounded retry that ends in `errNoAnswer`. `.Reasoning`/`.ReasoningDetails`
+    halt to the bounded retry that ends in `errEmptyResponses`. `.Reasoning`/`.ReasoningDetails`
     stay unread on purpose: a reasoning-only turn is not an answer and should be retried.
     A provider that adds a further prose carrier would present as an empty turn again.
   - Env references resolve through the injected `LookupEnv`, never the process environment:
@@ -409,8 +414,8 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
   advisory, since Bifrost does not guarantee it describes content, so it can only refine the
   response, never override the content classification. A blank turn reporting `stop`,
   `tool_calls`, or nothing keeps the original behavior: `acceptTurn` retries it with
-  `emptyTurnDirective` and ends the run with `errNoAnswer` after `maxConsecutiveEmpty` (3) in a
-  row, while exhausting `maxIter` ends it with `errIterationLimit`. The two are distinct
+  `emptyTurnDirective` and ends the run with `errEmptyResponses` after `maxConsecutiveEmpty` (3)
+  in a row, while exhausting `maxIter` ends it with `errIterationLimit`. The two are distinct
   sentinels because a single empty string used to mean both, so a model that returned nothing
   was reported as an iteration limit on a run with most of its budget left (#271); the retry
   stays bounded rather than reason-gated because seven distinct Gemini conditions produce a
@@ -452,7 +457,11 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
     loop checks `BudgetExceeded()` at the top of every iteration, after each model response,
     and after each tool dispatch; on exceed it returns the `errBudgetExceeded` sentinel and
     `Run` renders a
-    one-line notice and stops the turn with no partial answer recorded. The bound is cumulative
+    one-line notice and stops the turn with no partial answer recorded. Every such futile stop
+    (budget, iteration limit, repeated-empty, output limit, content filter, stopped-early)
+    leaves `Run` as the exported `ErrNoAnswer` wrapping the specific cause — rendered notice
+    first, history untouched — which the cli maps to exit 2 in one-shot and swallows in an
+    interactive session. The bound is cumulative
     across the main loop, `task` sub-runs, and the verifier, and is per-session (it survives
     `StartTurn`). Interrupt: Esc or a first Ctrl-C (via the host `Interrupter`, checked at the
     top of each iteration, after `Generate`, and before every I/O dispatch) surfaces as

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ configuration reference.
 
 ## Sessions and approvals
 
-`cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`). The exit code carries the verdict for scripts: 0 when a report was produced, 2 when the run completed without an answer (the notice names the reason - iteration or token budget, an empty or filtered model response), 130 on interrupt, and 1 for any other failure.
+`cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`). The exit code carries the verdict for scripts: 0 when a report was produced, 2 when the run completed without an answer (the notice names the reason - iteration or token budget, an empty or filtered model response), 130 on interrupt, 143 on SIGTERM, and 1 for any other failure.
 
 Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ configuration reference.
 
 ## Sessions and approvals
 
-`cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`).
+`cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`). The exit code carries the verdict for scripts: 0 when a report was produced, 2 when the run completed without an answer (the notice names the reason - iteration or token budget, an empty or filtered model response), 130 on interrupt, and 1 for any other failure.
 
 Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -220,7 +220,9 @@ func (a *Agent) Run(ctx context.Context, task string, w io.Writer) error {
 		if notice, ok := a.stopNotice(err); ok {
 			fmt.Fprint(w, notice)
 
-			return nil
+			// The notice explains the outcome to the operator; the umbrella lets a
+			// scripted one-shot exit non-zero while errors.Is still reaches the cause.
+			return fmt.Errorf("%w: %w", ErrNoAnswer, err)
 		}
 
 		return err
@@ -243,7 +245,7 @@ func (a *Agent) stopNotice(err error) (string, bool) {
 			a.metrics.BudgetReason()), true
 	case errors.Is(err, errIterationLimit):
 		return "\n⚠️  Reached the iteration limit without a final answer.\n", true
-	case errors.Is(err, errNoAnswer):
+	case errors.Is(err, errEmptyResponses):
 		return fmt.Sprintf("\n⚠️  The model returned %d empty responses in a row and could not "+
 			"produce an answer. Try rerunning, or switch models.\n", maxConsecutiveEmpty), true
 	case errors.Is(err, errOutputLimit):

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -535,7 +535,7 @@ func TestRun_IterationLimitNotice(t *testing.T) {
 	t.Parallel()
 
 	// The model always calls a tool, so run exhausts maxIter and returns "":
-	// Run prints the notice and records nothing.
+	// Run prints the notice, records nothing, and reports the no-answer sentinel.
 	cfg := baseConfig()
 	cfg.Cfg.MaxIterations = 1
 	cfg.Model = &scriptedModel{msgs: []*schema.Message{toolCall("c1", "echo", "{}")}}
@@ -544,8 +544,8 @@ func TestRun_IterationLimitNotice(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	if !strings.Contains(buf.String(), "Reached the iteration limit") {
@@ -973,8 +973,8 @@ func TestRun_BudgetHaltsTurnWithNotice(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	if model.calls != 1 {
@@ -1025,8 +1025,8 @@ func TestRun_BudgetHaltsOnOverBudgetFinalAnswer(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	if model.calls != 1 {
@@ -1090,8 +1090,8 @@ func TestRun_BudgetHaltsBeforeRemainingToolCalls(t *testing.T) {
 	a.maxSubagentIter = 3
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "go", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "go", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	if ran {
@@ -1603,8 +1603,8 @@ func TestRun_MaxConsecutiveFailuresZeroDisables(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "scan", &buf); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := a.Run(context.Background(), "scan", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer (iteration limit)", err)
 	}
 	out := buf.String()
 	if strings.Contains(out, "Stopped after") {
@@ -2008,8 +2008,8 @@ func TestRun_RepeatedEmptyTurnsGiveUpBeforeExhaustingIterations(t *testing.T) {
 	a := newTestAgent(model, map[string]schema.InvokableTool{})
 
 	answer, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 32)
-	if !errors.Is(err, errNoAnswer) {
-		t.Fatalf("err = %v, want errNoAnswer", err)
+	if !errors.Is(err, errEmptyResponses) {
+		t.Fatalf("err = %v, want errEmptyResponses", err)
 	}
 	if answer != "" {
 		t.Errorf("answer = %q, want empty", answer)
@@ -2097,8 +2097,8 @@ func TestRun_NoAnswerNotice(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	if !strings.Contains(buf.String(), "empty responses in a row") {
@@ -2164,8 +2164,8 @@ func TestRun_BlankTurn_RetryableReasonStillRetriesToTheCeiling(t *testing.T) {
 			a := newTestAgent(m, map[string]schema.InvokableTool{})
 
 			_, err := a.run(context.Background(), &runState{depth: 0, out: io.Discard}, nil, 5)
-			if !errors.Is(err, errNoAnswer) {
-				t.Fatalf("err = %v, want errNoAnswer", err)
+			if !errors.Is(err, errEmptyResponses) {
+				t.Fatalf("err = %v, want errEmptyResponses", err)
 			}
 			if m.calls != maxConsecutiveEmpty {
 				t.Errorf("Generate called %d times, want %d", m.calls, maxConsecutiveEmpty)
@@ -2195,8 +2195,8 @@ func TestRun_BlankTurn_RendersReasonSpecificNotice(t *testing.T) {
 			a := New(context.Background(), cfg)
 
 			var buf bytes.Buffer
-			if err := a.Run(context.Background(), "q", &buf); err != nil {
-				t.Fatalf("Run returned %v, want nil (a non-fatal stop)", err)
+			if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+				t.Fatalf("Run = %v, want ErrNoAnswer (a non-fatal stop)", err)
 			}
 			if !strings.Contains(buf.String(), tc.wantNotice) {
 				t.Errorf("notice = %q, want it to contain %q", buf.String(), tc.wantNotice)
@@ -2218,8 +2218,8 @@ func TestRun_BlankTurn_RawReasonCannotForgeOutput(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 	if strings.Contains(buf.String(), "evil\n") {
 		t.Errorf("raw reason was rendered unescaped: %q", buf.String())
@@ -2237,8 +2237,8 @@ func TestRun_BlankTurn_LongRawReasonIsBounded(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 	if strings.Contains(buf.String(), strings.Repeat("x", maxRawReasonBytes+1)) {
 		t.Errorf("raw reason was not bounded: %q", buf.String())
@@ -2306,7 +2306,7 @@ func TestRun_BlankTurnOnTheLastIterationReportsTheIterationLimit(t *testing.T) {
 	if !errors.Is(err, errIterationLimit) {
 		t.Fatalf("err = %v, want errIterationLimit", err)
 	}
-	if errors.Is(err, errNoAnswer) {
+	if errors.Is(err, errEmptyResponses) {
 		t.Error("a single blank turn must not report the empty-response ceiling")
 	}
 }
@@ -2348,8 +2348,8 @@ func TestRun_BudgetWinsOverTheEmptyResponseCeiling(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 
 	out := buf.String()
@@ -2382,7 +2382,7 @@ func TestRun_InterruptDuringABlankStreakBeatsTheEmptyCeiling(t *testing.T) {
 	if !errors.Is(err, errInterrupted) {
 		t.Fatalf("err = %v, want errInterrupted", err)
 	}
-	if errors.Is(err, errNoAnswer) {
+	if errors.Is(err, errEmptyResponses) {
 		t.Error("an operator stop must not be reported as a model failure")
 	}
 }
@@ -2849,7 +2849,7 @@ func TestRun_TruncationCeilingOnTheLastIterationStillReportsTheOutputLimit(t *te
 	// When the third truncated turn is also the last allowed iteration, the
 	// ceiling's specific diagnosis wins over the generic iteration limit, the
 	// same resolution the blank-turn ceiling uses (handleBlankTurn returns
-	// errNoAnswer inside the iteration). A truncation streak still below its
+	// errEmptyResponses inside the iteration). A truncation streak still below its
 	// ceiling when maxIter expires keeps reporting errIterationLimit, since the
 	// loop exit stays authoritative for plain exhaustion.
 	m := &genScriptModel{gens: []schema.Generation{
@@ -2958,8 +2958,8 @@ func TestRun_BlankTruncatedTurn_HasNoTruncationNotice(t *testing.T) {
 	a := New(context.Background(), cfg)
 
 	var buf bytes.Buffer
-	if err := a.Run(context.Background(), "q", &buf); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := a.Run(context.Background(), "q", &buf); !errors.Is(err, ErrNoAnswer) {
+		t.Fatalf("Run = %v, want ErrNoAnswer", err)
 	}
 	if strings.Contains(buf.String(), truncatedAnswerNotice) {
 		t.Errorf("output = %q, want only the output-limit notice", buf.String())

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -43,10 +43,18 @@ var ErrInterrupted = errInterrupted
 // gochecknoglobals.
 var errIterationLimit = errors.New("agent: iteration limit reached")
 
-// errNoAnswer ends a run whose model returned maxConsecutiveEmpty blank turns in
-// a row. Run renders its own notice and recovers; like the iteration limit it is
-// not fatal.
-var errNoAnswer = errors.New("agent: model returned no answer")
+// errEmptyResponses ends a run whose model returned maxConsecutiveEmpty blank
+// turns in a row. Run renders its own notice and recovers; like the iteration
+// limit it is not fatal.
+var errEmptyResponses = errors.New("agent: model returned no answer")
+
+// ErrNoAnswer is the exported umbrella for every futile stop Run recovers from
+// (budget, iteration limit, repeated-empty, output limit, content filter,
+// stopped-early): the run completed without producing an answer. Run wraps the
+// specific cause with it after rendering the operator notice, so the cli can map
+// a scripted one-shot to a distinct exit code while the interactive loop keeps
+// treating the turn as non-fatal.
+var ErrNoAnswer = errors.New("agent: run produced no answer")
 
 // maxConsecutiveEmpty is how many blank assistant turns a run tolerates in a row
 // before giving up. A blank turn is retried because it is usually transient, but
@@ -185,7 +193,7 @@ type runScopedTool interface {
 // terminates when the model emits an assistant turn that carries text and no
 // tool calls — the final answer. A turn carrying neither is not an answer: it is
 // retried with a directive, and after maxConsecutiveEmpty in a row the run ends
-// with errNoAnswer. A blank turn whose stop reason is length, content_filter, or
+// with errEmptyResponses. A blank turn whose stop reason is length, content_filter, or
 // unrecognized ends the run at once instead, since re-asking cannot change a
 // futile stop. A tool-call turn reporting StopLength is quarantined: nothing
 // dispatches, the retry carries truncatedCallsDirective, and after
@@ -267,9 +275,10 @@ func (a *Agent) run(ctx context.Context, rs *runState, turn []*schema.Message, m
 
 // haltOr returns a pending operator-facing halt (interrupt, then budget) in
 // preference to fallback. Every terminal return that is not itself a halt goes
-// through it: Run maps errIterationLimit and errNoAnswer to a notice and exit 0,
-// so a stop that landed after the last checkpoint would otherwise be reported as
-// a model or budget-shaped failure and swallow the operator's Ctrl-C.
+// through it: Run maps errIterationLimit and errEmptyResponses to a notice and
+// ErrNoAnswer, so a stop that landed after the last checkpoint would otherwise
+// be reported as a model or budget-shaped failure and swallow the operator's
+// Ctrl-C.
 func (a *Agent) haltOr(fallback error) error {
 	if err := a.haltErr(); err != nil {
 		return err
@@ -406,7 +415,7 @@ func (a *Agent) handleBlankTurn(
 
 	rs.consecutiveEmpty++
 	if rs.consecutiveEmpty >= maxConsecutiveEmpty {
-		return turn, a.haltOr(errNoAnswer)
+		return turn, a.haltOr(errEmptyResponses)
 	}
 
 	return append(turn, schema.UserMessage(emptyTurnDirective)), nil

--- a/internal/agent/noanswer_internal_test.go
+++ b/internal/agent/noanswer_internal_test.go
@@ -115,3 +115,24 @@ func TestRun_FutileStopsReturnErrNoAnswer(t *testing.T) {
 		})
 	}
 }
+
+// TestRun_StoppedEarlyKeepsRawReasonThroughTheWrap pins that the umbrella wrap
+// preserves the concrete *stoppedEarlyError, not just the bare sentinel: the
+// raw backend reason must stay reachable via errors.As for diagnostics.
+func TestRun_StoppedEarlyKeepsRawReasonThroughTheWrap(t *testing.T) {
+	t.Parallel()
+
+	cfg := baseConfig()
+	cfg.Model = &blankReasonModel{reason: schema.StopOther, raw: "guardrail_x", calls: 0}
+	a := New(context.Background(), cfg)
+
+	var buf bytes.Buffer
+	err := a.Run(context.Background(), "q", &buf)
+	stoppedEarly, ok := errors.AsType[*stoppedEarlyError](err)
+	if !ok {
+		t.Fatalf("Run = %v, want the concrete *stoppedEarlyError preserved through the wrap", err)
+	}
+	if stoppedEarly.raw != "guardrail_x" {
+		t.Errorf("raw = %q, want the backend reason preserved", stoppedEarly.raw)
+	}
+}

--- a/internal/agent/noanswer_internal_test.go
+++ b/internal/agent/noanswer_internal_test.go
@@ -118,7 +118,7 @@ func TestRun_FutileStopsReturnErrNoAnswer(t *testing.T) {
 
 // TestRun_StoppedEarlyKeepsRawReasonThroughTheWrap pins that the umbrella wrap
 // preserves the concrete *stoppedEarlyError, not just the bare sentinel: the
-// raw backend reason must stay reachable via errors.As for diagnostics.
+// raw backend reason must stay reachable via [errors.As] for diagnostics.
 func TestRun_StoppedEarlyKeepsRawReasonThroughTheWrap(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/noanswer_internal_test.go
+++ b/internal/agent/noanswer_internal_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cynative/cynative/internal/metrics"
+	"github.com/cynative/cynative/internal/schema"
+)
+
+// TestRun_FutileStopsReturnErrNoAnswer pins the exit-code contract (#281): a run
+// that ends without a final answer renders its operator notice and returns
+// ErrNoAnswer wrapping the specific cause, so a scripted one-shot can exit
+// non-zero while the interactive loop keeps treating the turn as non-fatal.
+// History stays untouched: no partial answer is recorded.
+func TestRun_FutileStopsReturnErrNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		cfg   func() Config
+		cause error
+	}{
+		{
+			name: "iteration limit",
+			cfg: func() Config {
+				cfg := baseConfig()
+				cfg.Cfg.MaxIterations = 1
+				cfg.Model = &scriptedModel{msgs: []*schema.Message{toolCall("c1", "echo", "{}")}}
+				cfg.Tools = []schema.InvokableTool{&echoTool{ran: nil}}
+
+				return cfg
+			},
+			cause: errIterationLimit,
+		},
+		{
+			name: "empty responses",
+			cfg: func() Config {
+				cfg := baseConfig()
+				cfg.Model = &transcriptModel{msgs: []*schema.Message{
+					schema.AssistantMessage("", nil),
+					schema.AssistantMessage("", nil),
+					schema.AssistantMessage("", nil),
+				}}
+
+				return cfg
+			},
+			cause: errEmptyResponses,
+		},
+		{
+			name: "budget exceeded",
+			cfg: func() Config {
+				acc := metrics.NewAccumulator("p", "m", metrics.WithBudget(10))
+				cfg := baseConfig()
+				cfg.Model = &budgetLoopModel{acc: acc, usage: schema.Usage{TotalTokens: 50}, calls: 0}
+				cfg.Metrics = acc
+				cfg.Tools = []schema.InvokableTool{&echoTool{ran: nil}}
+
+				return cfg
+			},
+			cause: errBudgetExceeded,
+		},
+		{
+			name: "output limit",
+			cfg: func() Config {
+				cfg := baseConfig()
+				cfg.Model = &blankReasonModel{reason: schema.StopLength, raw: "", calls: 0}
+
+				return cfg
+			},
+			cause: errOutputLimit,
+		},
+		{
+			name: "content filter",
+			cfg: func() Config {
+				cfg := baseConfig()
+				cfg.Model = &blankReasonModel{reason: schema.StopContentFilter, raw: "", calls: 0}
+
+				return cfg
+			},
+			cause: errContentFiltered,
+		},
+		{
+			name: "stopped early",
+			cfg: func() Config {
+				cfg := baseConfig()
+				cfg.Model = &blankReasonModel{reason: schema.StopOther, raw: "guardrail", calls: 0}
+
+				return cfg
+			},
+			cause: errStoppedEarly,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := New(context.Background(), tc.cfg())
+
+			var buf bytes.Buffer
+			err := a.Run(context.Background(), "q", &buf)
+			if !errors.Is(err, ErrNoAnswer) {
+				t.Fatalf("Run = %v, want ErrNoAnswer", err)
+			}
+			if !errors.Is(err, tc.cause) {
+				t.Fatalf("Run = %v, want the cause %v preserved for errors.Is", err, tc.cause)
+			}
+			if buf.Len() == 0 {
+				t.Error("the operator notice must still render before the sentinel returns")
+			}
+			if len(a.history) != 0 {
+				t.Errorf("history length = %d, want 0 (no partial answer recorded)", len(a.history))
+			}
+		})
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -71,7 +71,7 @@ func subagentStop(err error) (bool, string) {
 	switch {
 	case errors.Is(err, errIterationLimit):
 		return true, subagentIterationLimit
-	case errors.Is(err, errNoAnswer):
+	case errors.Is(err, errEmptyResponses):
 		return true, subagentNoAnswer
 	case errors.Is(err, errOutputLimit):
 		return true, subagentOutputLimit

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -6,15 +6,23 @@ import (
 	"github.com/cynative/cynative/internal/agent"
 )
 
+// exitNoAnswer is the exit code for a run that completed without producing an
+// answer (agent.ErrNoAnswer). It is distinct from the generic 1 so a scripted
+// `cynative -p` caller can tell "the model gave up" from an execution failure
+// without parsing stdout; the rendered notice names the specific reason.
+const exitNoAnswer = 2
+
 // ExitCodeFor maps a top-level command error to a process exit code: a graceful
-// operator interrupt maps to the conventional 130 (128+SIGINT), any other error
-// maps to 1, and nil maps to 0.
+// operator interrupt maps to the conventional 130 (128+SIGINT), a run that
+// produced no answer maps to 2, any other error maps to 1, and nil maps to 0.
 func ExitCodeFor(err error) int {
 	switch {
 	case err == nil:
 		return 0
 	case errors.Is(err, agent.ErrInterrupted):
 		return exitInterrupted
+	case errors.Is(err, agent.ErrNoAnswer):
+		return exitNoAnswer
 	default:
 		return 1
 	}

--- a/internal/cli/exit_internal_test.go
+++ b/internal/cli/exit_internal_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cynative/cynative/internal/agent"
+)
+
+// TestExitCodeFor pins the process exit-code contract scripted callers depend
+// on: 0 for success, 130 for a graceful interrupt, 2 for a run that completed
+// without producing an answer, and 1 for everything else.
+func TestExitCodeFor(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "generic error", err: errors.New("boom"), want: 1},
+		{name: "interrupt", err: agent.ErrInterrupted, want: exitInterrupted},
+		{
+			name: "wrapped interrupt",
+			err:  fmt.Errorf("research run failed: %w", agent.ErrInterrupted),
+			want: exitInterrupted,
+		},
+		{name: "no answer", err: agent.ErrNoAnswer, want: exitNoAnswer},
+		{name: "wrapped no answer", err: fmt.Errorf("x: %w", agent.ErrNoAnswer), want: exitNoAnswer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ExitCodeFor(tc.err); got != tc.want {
+				t.Errorf("ExitCodeFor(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExitNoAnswerValue pins the documented number itself: it is a public
+// contract (README), so a renumbering must be deliberate, not incidental.
+func TestExitNoAnswerValue(t *testing.T) {
+	t.Parallel()
+
+	if exitNoAnswer != 2 {
+		t.Errorf("exitNoAnswer = %d, want 2", exitNoAnswer)
+	}
+}

--- a/internal/cli/exit_internal_test.go
+++ b/internal/cli/exit_internal_test.go
@@ -10,7 +10,8 @@ import (
 
 // TestExitCodeFor pins the process exit-code contract scripted callers depend
 // on: 0 for success, 130 for a graceful interrupt, 2 for a run that completed
-// without producing an answer, and 1 for everything else.
+// without producing an answer, and 1 for everything else. The wants are literal
+// on purpose: comparing against the production constants would pin nothing.
 func TestExitCodeFor(t *testing.T) {
 	t.Parallel()
 
@@ -21,14 +22,14 @@ func TestExitCodeFor(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: 0},
 		{name: "generic error", err: errors.New("boom"), want: 1},
-		{name: "interrupt", err: agent.ErrInterrupted, want: exitInterrupted},
+		{name: "interrupt", err: agent.ErrInterrupted, want: 130},
 		{
 			name: "wrapped interrupt",
 			err:  fmt.Errorf("research run failed: %w", agent.ErrInterrupted),
-			want: exitInterrupted,
+			want: 130,
 		},
-		{name: "no answer", err: agent.ErrNoAnswer, want: exitNoAnswer},
-		{name: "wrapped no answer", err: fmt.Errorf("x: %w", agent.ErrNoAnswer), want: exitNoAnswer},
+		{name: "no answer", err: agent.ErrNoAnswer, want: 2},
+		{name: "wrapped no answer", err: fmt.Errorf("x: %w", agent.ErrNoAnswer), want: 2},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -40,11 +41,19 @@ func TestExitCodeFor(t *testing.T) {
 	}
 }
 
-// TestExitNoAnswerValue pins the documented number itself: it is a public
+// TestExitCodeValues pins the documented numbers themselves: they are a public
 // contract (README), so a renumbering must be deliberate, not incidental.
-func TestExitNoAnswerValue(t *testing.T) {
+// exitTerminated bypasses ExitCodeFor (the signal handler exits directly), so
+// this is its only value pin.
+func TestExitCodeValues(t *testing.T) {
 	t.Parallel()
 
+	if exitInterrupted != 130 {
+		t.Errorf("exitInterrupted = %d, want 130", exitInterrupted)
+	}
+	if exitTerminated != 143 {
+		t.Errorf("exitTerminated = %d, want 143", exitTerminated)
+	}
 	if exitNoAnswer != 2 {
 		t.Errorf("exitNoAnswer = %d, want 2", exitNoAnswer)
 	}

--- a/internal/cli/research.go
+++ b/internal/cli/research.go
@@ -303,8 +303,10 @@ func (d *deps) runResearch(ctx context.Context, req runRequest, cfg config.Confi
 	}
 	defer func() {
 		// Fail-closed: a close/flush failure means the final audit records may not be
-		// durable, so surface it as the command's error — without masking an earlier one.
-		if cerr := closeAudit(); cerr != nil && err == nil {
+		// durable, so surface it as the command's error — without masking an earlier
+		// one. ErrNoAnswer is an outcome, not a failure: the close error replaces it
+		// (exit 1), so the no-answer sentinel cannot mask a durability failure.
+		if cerr := closeAudit(); cerr != nil && (err == nil || errors.Is(err, agent.ErrNoAnswer)) {
 			err = fmt.Errorf("audit log close: %w", cerr)
 		}
 	}()
@@ -468,6 +470,16 @@ func (d *deps) runTask(
 	// first turn is treated as a graceful shutdown, not a dead-LLM startup failure.
 	if ctx.Err() != nil {
 		return false, nil //nolint:nilerr // context cancel is a graceful exit, not an error.
+	}
+	// A no-answer stop already rendered its notice inside Run. Interactive: the
+	// session continues into the REPL (the model responded, so a recorded
+	// response also proves liveness); one-shot: propagate so main exits 2.
+	if errors.Is(runErr, agent.ErrNoAnswer) {
+		if interactive {
+			return modelResponded(acc, respBefore), nil
+		}
+
+		return false, runErr
 	}
 	if errors.Is(runErr, llm.ErrGenerate) {
 		// Only treat as a dead LLM when the model never responded this turn (no
@@ -677,6 +689,17 @@ func (d *deps) handleTurnError(
 		// later transient llm.ErrGenerate is a normal turn error rather than a
 		// failed-startup abort. A pre-Generate interrupt (no response) proves
 		// nothing, so established is left unchanged.
+		if modelResponded(acc, respBefore) {
+			established = true
+		}
+
+		return established, true, nil
+	}
+
+	// A no-answer stop already rendered its notice inside Run; resume the loop.
+	// Like the interrupt arm, established is promoted only on a recorded model
+	// response (a blank turn is still a live response).
+	if errors.Is(err, agent.ErrNoAnswer) {
 		if modelResponded(acc, respBefore) {
 			established = true
 		}

--- a/internal/cli/research_internal_test.go
+++ b/internal/cli/research_internal_test.go
@@ -1369,24 +1369,6 @@ func newInterruptedAgent(t *testing.T) *agent.Agent {
 	return a
 }
 
-// TestExitCodeFor verifies that ExitCodeFor maps nil→0, ErrInterrupted→130, and
-// any other error→1.
-func TestExitCodeFor(t *testing.T) {
-	t.Parallel()
-
-	if got := ExitCodeFor(nil); got != 0 {
-		t.Errorf("nil → %d, want 0", got)
-	}
-
-	if got := ExitCodeFor(agent.ErrInterrupted); got != 130 {
-		t.Errorf("ErrInterrupted → %d, want 130", got)
-	}
-
-	if got := ExitCodeFor(errors.New("other")); got != 1 {
-		t.Errorf("other error → %d, want 1", got)
-	}
-}
-
 // TestInteractiveLoop_InterruptContinues verifies that agent.ErrInterrupted from
 // a.Run is treated as non-fatal: the loop continues to the next prompt rather than
 // returning, so the operator can keep the session going after a Ctrl-C.
@@ -2240,5 +2222,158 @@ func TestHandleTurnError_AuditErrTerminates(t *testing.T) {
 	// established is returned as-is.
 	if !established {
 		t.Error("established must be preserved (true) on audit error")
+	}
+}
+
+// noAnswerModel returns three blank assistant turns, driving a real agent.Run
+// into its repeated-empty futile stop so cli tests exercise the ErrNoAnswer
+// path end-to-end rather than hand-constructing the sentinel.
+func noAnswerModel() *fakeChatModel {
+	return &fakeChatModel{ //nolint:exhaustruct // errs/calls not pre-set.
+		responses: []*schema.Message{assistantMsg(""), assistantMsg(""), assistantMsg("")},
+	}
+}
+
+// TestRunTask_OneShotNoAnswerPropagates verifies that a non-interactive run
+// whose model produced no answer propagates agent.ErrNoAnswer (for exit code 2)
+// instead of swallowing it, and renders no ✗ LLM block (the model was live; the
+// stop notice already explained the outcome).
+func TestRunTask_OneShotNoAnswerPropagates(t *testing.T) {
+	t.Parallel()
+
+	fu := &fakeUI{} //nolint:exhaustruct // only llmStatuses is checked.
+	d := testDeps()
+	d.ui = fu
+	a := newTestAgent(t, noAnswerModel())
+	acc := metrics.NewAccumulator("p", "m")
+	acc.StartTurn()
+
+	established, err := d.runTask(context.Background(), a, acc, validCfg(), "task", false)
+	if !errors.Is(err, agent.ErrNoAnswer) {
+		t.Fatalf("runTask = %v, want agent.ErrNoAnswer", err)
+	}
+	if established {
+		t.Error("a no-answer one-shot must not mark the session established")
+	}
+	if len(fu.llmStatuses) != 0 {
+		t.Errorf("no LLM status block should render for a no-answer stop, got %#v", fu.llmStatuses)
+	}
+}
+
+// TestRunTask_InteractiveNoAnswerContinues verifies the seeded interactive path
+// keeps its pre-#281 behavior: the no-answer stop is swallowed (nil error, the
+// REPL follows) and the session counts as established because the model did
+// respond this turn.
+func TestRunTask_InteractiveNoAnswerContinues(t *testing.T) {
+	t.Parallel()
+
+	fu := &fakeUI{} //nolint:exhaustruct // only llmStatuses is checked.
+	d := testDeps()
+	d.ui = fu
+	acc := metrics.NewAccumulator("p", "m")
+	a := newTestAgentWithMetrics(t, noAnswerModel(), acc)
+	acc.StartTurn()
+
+	established, err := d.runTask(context.Background(), a, acc, validCfg(), "task", true)
+	if err != nil {
+		t.Fatalf("interactive runTask must swallow the no-answer stop, got %v", err)
+	}
+	if !established {
+		t.Error("the model responded (blank turns are still responses), so the session is established")
+	}
+}
+
+// TestHandleTurnError_NoAnswerContinuesLoop verifies the interactive follow-up
+// loop treats a no-answer turn like an interrupt: continue to the next prompt,
+// promoting established only when the model actually responded this turn.
+func TestHandleTurnError_NoAnswerContinuesLoop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no model response leaves established unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		d := testDeps()
+		acc := metrics.NewAccumulator("p", "m")
+
+		established, cont, err := d.handleTurnError(
+			context.Background(), acc, validCfg(), agent.ErrNoAnswer, false, 0,
+		)
+		if err != nil {
+			t.Fatalf("no-answer must not terminate the session, got %v", err)
+		}
+		if !cont {
+			t.Error("no-answer must continue the loop")
+		}
+		if established {
+			t.Error("no response recorded → established must stay false")
+		}
+	})
+
+	t.Run("model response promotes established", func(t *testing.T) {
+		t.Parallel()
+
+		d := testDeps()
+		acc := metrics.NewAccumulator("p", "m")
+		acc.AddResponse() // the blank turns were still live responses.
+
+		established, cont, err := d.handleTurnError(
+			context.Background(), acc, validCfg(), agent.ErrNoAnswer, false, 0,
+		)
+		if err != nil {
+			t.Fatalf("no-answer must not terminate the session, got %v", err)
+		}
+		if !cont {
+			t.Error("no-answer must continue the loop")
+		}
+		if !established {
+			t.Error("a live model response must promote established")
+		}
+	})
+}
+
+// TestRunResearch_OneShotNoAnswerReturnsErrNoAnswer drives the full one-shot
+// path: a run producing no answer must surface agent.ErrNoAnswer from
+// runResearch so main exits 2.
+func TestRunResearch_OneShotNoAnswerReturnsErrNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return noAnswerModel(), nil
+	}
+
+	err := d.runResearch(
+		context.Background(), taskReq("task"), validCfg(),
+		researchFlags{}, //nolint:exhaustruct // non-interactive defaults.
+	)
+	if !errors.Is(err, agent.ErrNoAnswer) {
+		t.Fatalf("runResearch = %v, want agent.ErrNoAnswer", err)
+	}
+}
+
+// TestRunResearch_AuditCloseFailureWinsOverNoAnswer pins the fail-closed audit
+// precedence: when the deferred audit close fails on a no-answer run, the close
+// error (exit 1) must win over agent.ErrNoAnswer (exit 2) — the sentinel must
+// not mask a durability failure.
+func TestRunResearch_AuditCloseFailureWinsOverNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps()
+	d.newChatModel = func(context.Context, config.Config, func(schema.Usage)) (chatModel, error) {
+		return noAnswerModel(), nil
+	}
+	d.newAuditSink = func(config.Config, *audit.AgentProvenance) (audit.Sink, func() error, error) {
+		return nil, func() error { return errors.New("disk full") }, nil
+	}
+
+	err := d.runResearch(
+		context.Background(), taskReq("task"), validCfg(),
+		researchFlags{}, //nolint:exhaustruct // non-interactive defaults.
+	)
+	if err == nil || errors.Is(err, agent.ErrNoAnswer) {
+		t.Fatalf("audit close failure must replace ErrNoAnswer, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "audit log close") {
+		t.Errorf("err = %v, want the audit-close failure surfaced", err)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -88,11 +88,12 @@ starting a research session.`,
 }
 
 // silenceGracefulStop suppresses Cobra's duplicate "Error: ..." line for a graceful
-// operator interrupt — the agent already rendered the stop notice — while still
-// returning the error so ExitCodeFor maps it to 130. Any other error prints as usual.
+// operator interrupt or a no-answer stop — the agent already rendered the stop
+// notice — while still returning the error so ExitCodeFor maps it (130 for the
+// interrupt, 2 for no answer). Any other error prints as usual.
 func silenceGracefulStop(cmd *cobra.Command, err error) error {
-	if errors.Is(err, agent.ErrInterrupted) || errors.Is(err, ErrLLMUnavailable) ||
-		errors.Is(err, ErrDoctorNotReady) {
+	if errors.Is(err, agent.ErrInterrupted) || errors.Is(err, agent.ErrNoAnswer) ||
+		errors.Is(err, ErrLLMUnavailable) || errors.Is(err, ErrDoctorNotReady) {
 		cmd.SilenceErrors = true
 	}
 

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -206,6 +206,21 @@ func TestSilenceGracefulStop_SilencesLLMUnavailable(t *testing.T) {
 	}
 }
 
+func TestSilenceGracefulStop_SilencesNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	// The no-answer notice was already rendered inside Run, so cobra must not
+	// print a duplicate Error line; the error still propagates for ExitCodeFor.
+	cmd := &cobra.Command{} //nolint:exhaustruct // only SilenceErrors is under test.
+	err := silenceGracefulStop(cmd, agent.ErrNoAnswer)
+	if !errors.Is(err, agent.ErrNoAnswer) {
+		t.Errorf("must return the no-answer error so ExitCodeFor maps it to 2, got %v", err)
+	}
+	if !cmd.SilenceErrors {
+		t.Error("SilenceErrors should be set for ErrNoAnswer (notice already rendered)")
+	}
+}
+
 func TestNewRootCmd_Version(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e-guardrails.unit.test.sh
+++ b/test/e2e-guardrails.unit.test.sh
@@ -150,8 +150,10 @@ if (
 	printf 'answer text\n' > "$td/ok.out"
 	: > "$td/empty.err"
 	printf 'boom\n' > "$td/boom.err"
-	# The agent writes the budget notice to STDOUT and exits 0 on a budget hit;
-	# only the ASCII "Budget reached" substring is load-bearing.
+	# The agent writes the budget notice to STDOUT and exits 2 (no answer
+	# produced) on a budget hit; only the ASCII "Budget reached" substring is
+	# load-bearing, and the budget classification must win over the generic
+	# non-zero-rc branch.
 	printf 'Budget reached - token budget reached: 100 / 50 tokens. Stopping;\n' > "$td/budget.out"
 
 	# Capture classify_run's rc without tripping set -e on its intentional
@@ -162,8 +164,10 @@ if (
 
 	[ "$(classrc 0   "$td/ok.out"     "$td/empty.err" 60)" -eq 0 ] || exit 1  # ok
 	[ "$(classrc 124 "$td/ok.out"     "$td/empty.err" 60)" -eq 2 ] || exit 1  # timeout
-	[ "$(classrc 0   "$td/budget.out" "$td/empty.err" 60)" -eq 3 ] || exit 1  # budget (rc 0!)
+	[ "$(classrc 2   "$td/budget.out" "$td/empty.err" 60)" -eq 3 ] || exit 1  # budget (live shape: exit 2)
+	[ "$(classrc 0   "$td/budget.out" "$td/empty.err" 60)" -eq 3 ] || exit 1  # budget beats a clean rc too
 	[ "$(classrc 1   "$td/ok.out"     "$td/boom.err"  60)" -eq 1 ] || exit 1  # generic
+	[ "$(classrc 2   "$td/ok.out"     "$td/empty.err" 60)" -eq 1 ] || exit 1  # non-budget no-answer: retryable
 	[ "$(classrc 124 "$td/budget.out" "$td/empty.err" 60)" -eq 2 ] || exit 1  # timeout dominates
 ); then pass "classify_run maps ok/timeout/budget/failure to 0/2/3/1"; else fail "classify_run"; fi
 

--- a/test/lib/e2e-guardrails.sh
+++ b/test/lib/e2e-guardrails.sh
@@ -141,9 +141,11 @@ e2e_run_bounded() {
 #      must run before the generic rc branch or a budget hit would read as a
 #      retryable provider failure. Callers treat 3 as fatal and do NOT retry
 #      (a retry only burns more credits and re-hits the ceiling).
-#   1  any other non-zero rc (a no-answer exit 2 for a non-budget reason lands
-#      here too: retryable, like the "answer missing" miss it used to be).
-# Order matters: timeout, then budget, then the generic rc branch.
+#   1  any other non-zero rc. A non-budget no-answer exit 2 is retryable (the
+#      same miss it classified as "answer missing" when such runs exited 0) but
+#      gets its own message and a STDOUT tail, since the agent renders the stop
+#      notice to stdout, not stderr.
+# Order matters: timeout, then budget, then no-answer, then the generic branch.
 e2e_classify_run() {
 	if [ "$1" -eq 124 ]; then
 		printf 'FAIL: timed out after %ss\n' "$4" >&2
@@ -153,6 +155,11 @@ e2e_classify_run() {
 		printf 'FAIL: token budget reached - raise the token limit (E2E_MAX_TOKENS / SMOKE_MAX_TOKENS / GCP_E2E_MAX_TOKENS / AWS_E2E_MAX_TOKENS / GH_E2E_MAX_TOKENS). Notice:\n' >&2
 		grep -F 'Budget reached' "$2" >&2 || true
 		return 3
+	fi
+	if [ "$1" -eq 2 ]; then
+		printf 'FAIL: run completed without an answer (exit 2). stdout tail:\n' >&2
+		tail -n 5 "$2" >&2
+		return 1
 	fi
 	if [ "$1" -ne 0 ]; then
 		printf 'FAIL: provider/config/access (exit %s). stderr tail:\n' "$1" >&2

--- a/test/lib/e2e-guardrails.sh
+++ b/test/lib/e2e-guardrails.sh
@@ -136,12 +136,14 @@ e2e_run_bounded() {
 # clear, distinct failure. Returns:
 #   0  success (rc 0 and no budget notice on stdout) - run domain assertions.
 #   2  timeout (rc 124).
-#   3  budget hit: "Budget reached" appears on stdout. The agent writes this to
-#      stdout and exits 0, so the answer never lands; without this branch a
-#      budget hit reads as a bogus "answer missing". Callers treat 3 as fatal and
-#      do NOT retry (a retry only burns more credits and re-hits the ceiling).
-#   1  any other non-zero rc (provider / config / access).
-# Order matters: timeout, then budget (exits 0), then the generic rc branch.
+#   3  budget hit: "Budget reached" appears on stdout. The agent renders the
+#      notice to stdout and exits 2 (no answer produced), so the budget grep
+#      must run before the generic rc branch or a budget hit would read as a
+#      retryable provider failure. Callers treat 3 as fatal and do NOT retry
+#      (a retry only burns more credits and re-hits the ceiling).
+#   1  any other non-zero rc (a no-answer exit 2 for a non-budget reason lands
+#      here too: retryable, like the "answer missing" miss it used to be).
+# Order matters: timeout, then budget, then the generic rc branch.
 e2e_classify_run() {
 	if [ "$1" -eq 124 ]; then
 		printf 'FAIL: timed out after %ss\n' "$4" >&2


### PR DESCRIPTION
## What & why

Closes #281.

A `-p` one-shot that produced no answer exited 0, so a scripted caller could not tell "a report was written" from "the model gave up" without parsing stdout.

`Agent.Run` now returns the exported `ErrNoAnswer` wrapping the specific cause after rendering the stop notice, for every futile stop: budget, iteration limit, repeated-empty, output limit, content filter, stopped-early. The internal repeated-empty sentinel is renamed `errEmptyResponses` to free the name.

On the CLI side:
- `ExitCodeFor` maps the sentinel to a new exit code 2; 0/1/130/143 keep their meanings, and the numbers are now literal-pinned in tests (the previous test compared against the production constant, so renumbering 130 would have shipped unnoticed).
- Interactive sessions are unchanged: the seeded turn and follow-up turns swallow the sentinel and continue, with `established` promoted only on a recorded model response.
- `silenceGracefulStop` silences cobra's duplicate error line; the notice on stdout already explains the outcome.
- A failing deferred audit close still replaces the sentinel, so a durability failure keeps exit 1 rather than being masked by exit 2.

The consecutive-failure halt still exits 0 (its summary is recorded as the answer), as does a truncated but non-empty final answer.

On the shell side, `e2e_classify_run`'s budget branch relied on budget hits exiting 0. The grep-before-rc ordering now carries that contract: budget still classifies fatal (no retry), while a non-budget exit 2 is retryable with a distinct message and a stdout tail (the stop notice lands on stdout, not stderr). The guardrails unit test pins the new shapes.

Verified with a live smoke on top of the hermetic gate: a normal run answers and exits 0; a forced budget stop renders the notice and exits 2.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for runs that finish without producing an answer.
  * Scripted runs now return exit code 2 for no-answer outcomes.
  * Interactive sessions can continue after recoverable no-answer outcomes.

* **Bug Fixes**
  * Audit-close failures now take precedence over no-answer results.
  * Repeated empty responses and other stop conditions are reported consistently.
  * Guardrails now distinguish budget exhaustion from other no-answer outcomes.

* **Documentation**
  * Documented exit codes for successful, interrupted, terminated, failed, and no-answer runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->