### PR TITLE
ci: ignore the gobwas/glob v1 major bump in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,16 @@ updates:
       # (via glamour and via goreleaser -> fang). Revisit if charmbracelet tags
       # the x/exp submodules.
       - dependency-name: "github.com/charmbracelet/x/exp/*"
+      # glob v1.0.0 restructured the repo: the syntax/ast and syntax/lexer
+      # packages are gone, but goreleaser/fileglob (v1.4.0, the latest
+      # release, an indirect module via the goreleaser/v2 tool dependency)
+      # still imports both, so forcing the major bump fails the whole gomod
+      # update outright (dependency_file_not_resolvable at the go mod tidy
+      # step). Minor/patch updates stay allowed, and once fileglob/goreleaser
+      # ship a release built against the v1 layout the module graph will
+      # follow without Dependabot's help. Drop this entry when that happens.
+      - dependency-name: "github.com/gobwas/glob"
+        update-types: ["version-update:semver-major"]
       # go-header v1 is a breaking API rewrite that golangci-lint (which pins
       # the v0.5.x API) cannot compile against, so forcing the major bump on
       # this indirect module breaks `go tool golangci-lint`. Minor/patch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1349,17 +1349,21 @@ supplies the shared message/tool types, and `internal/llm` supplies the Bifrost-
 - `.github/dependabot.yml` runs one daily `multi-ecosystem-group` (`all-dependencies`) across
   gomod, github-actions, cargo (`/tools/rcodesign`), and gitsubmodule, with the `deps` commit
   prefix. `allow: dependency-type: all` is what turns on **indirect** (transitive) module updates.
-  Four `ignore:` entries exist purely to keep the gate green, each with a documented exit
+  Five `ignore:` entries exist purely to keep the gate green, each with a documented exit
   condition: `github.com/charmbracelet/x/exp/*` wholesale (untagged monorepo submodules that
   Dependabot mis-resolves to the tagged root, failing the gomod update outright),
-  `denis-tingaikin/go-header` semver-major (v1 is an API rewrite `golangci-lint` cannot compile
-  against, so it breaks `make lint`), `alecthomas/go-check-sumtype` semver-major plus
-  semver-minor (v0.5.0 replaced the exported Config/Run API with an analyzer-style one
+  `github.com/gobwas/glob` semver-major (v1.0.0 restructured the repo and dropped the
+  `syntax/ast`/`syntax/lexer` packages that `goreleaser/fileglob` v1.4.0, its latest release,
+  still imports via the `goreleaser/v2` tool dependency, so the bump fails the whole gomod
+  update outright; drop it when fileglob/goreleaser ship a release built against the v1
+  layout), `denis-tingaikin/go-header` semver-major (v1 is an API rewrite `golangci-lint`
+  cannot compile against, so it breaks `make lint`), `alecthomas/go-check-sumtype` semver-major
+  plus semver-minor (v0.5.0 replaced the exported Config/Run API with an analyzer-style one
   `golangci-lint` cannot compile against, so it breaks `make lint`; the minor ignore is
   load-bearing because Dependabot classifies 0.4 -> 0.5 positionally as semver-minor), and
   `go.digitalxero.dev/go-msix` semver-major (v1 breaks goreleaser's nfpm MSIX packager, so it
-  breaks `make snapshot`). Minor/patch stay allowed on go-header and go-msix, patch only on
-  go-check-sumtype.
+  breaks `make snapshot`). Minor/patch stay allowed on go-header, go-msix, and gobwas/glob,
+  patch only on go-check-sumtype.
 - The macOS packaging toolchain (the `pkg-tools.yaml` required check) is built by
   `scripts/release/install-pkg-tools.sh` from two git submodules, `third_party/bomutils` and
   `third_party/xar`, plus `tools/rcodesign` (a Cargo stub that pins the `apple-codesign`


### PR DESCRIPTION
## What & why

The daily Dependabot `all-dependencies` update started failing outright with `Dependabot can't resolve your Go dependency files` ([update job log](https://github.com/cynative/cynative/network/updates/1549711686)), which blocks every update in the group.

Root cause: `github.com/gobwas/glob` tagged `v1.0.0`, its first release since `v0.2.3`, and restructured the repo: the `syntax/ast` and `syntax/lexer` packages are gone. `goreleaser/fileglob` `v1.4.0` (its latest release, in our graph via the `goreleaser/v2` tool dependency) still imports both, so Dependabot's `0.2.3 -> 1.0.0` bump attempt fails `go mod tidy`:

```
go: github.com/goreleaser/goreleaser/v2 imports
	...
	github.com/goreleaser/fileglob imports
	github.com/gobwas/glob/syntax/ast: module github.com/gobwas/glob@latest found (v1.0.0), but does not contain package github.com/gobwas/glob/syntax/ast
```

Reproduced locally with `go get github.com/gobwas/glob@v1.0.0 && go mod tidy`. Plain `go mod tidy` on main is unaffected (the graph stays on `v0.2.3`), so nothing else needs to change.

Fix: ignore the semver-major update for `github.com/gobwas/glob`, the same shape as the existing go-header/go-msix entries. Minor/patch stay allowed. Exit condition (documented in the config comment and AGENTS.md): drop the entry once fileglob/goreleaser ship a release built against the v1 layout, at which point the module graph follows without Dependabot's help.

The ignore takes effect on Dependabot's next scheduled daily run after merge; it can also be triggered immediately from Insights -> Dependency graph -> Dependabot -> "Check for updates" on the gomod entry.

## Checklist
- [x] `make check` passes locally
- [x] Tests added/updated for the change (not applicable: no in-repo gate covers `dependabot.yml`)
- [x] Docs updated if behavior changed (AGENTS.md ignore-list paragraph)