### PR TITLE
docs: clarify that the action gate does not replace least-privileged credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ configuration reference.
 
 `cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`). The exit code carries the verdict for scripts: 0 when a report was produced, 2 when the run completed without an answer (the notice names the reason - iteration or token budget, an empty or filtered model response), 130 on interrupt, 143 on SIGTERM, and 1 for any other failure.
 
-Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged, read-only credential needed**.
+Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged credentials needed, the action gate is not a substitute for them**.
 
 **Approvals:** each tool call waits for a single keystroke: `y` runs it once, `a` clears every later call to *that tool* for the session (scripts still print before running), any other key denies. With no controlling terminal, use `--auto-approve`.
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ configuration reference.
 
 `cynative` opens an interactive session (full line editing and history with arrow keys); `cynative "task"` runs the task then stays interactive; `-p` / `--print` runs a single task non-interactively and exits - for scripts and pipes (e.g. `cat main.tf | cynative -p "review this Terraform for misconfigurations"`). The exit code carries the verdict for scripts: 0 when a report was produced, 2 when the run completed without an answer (the notice names the reason - iteration or token budget, an empty or filtered model response), 130 on interrupt, 143 on SIGTERM, and 1 for any other failure.
 
-Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged credentials needed, the action gate is not a substitute for them**.
+Cynative calls your stack using the credentials already in your shell - it keeps no separate credential store. **Always provide the least-privileged credentials needed; the action gate is not a substitute for them**.
 
 **Approvals:** each tool call waits for a single keystroke: `y` runs it once, `a` clears every later call to *that tool* for the session (scripts still print before running), any other key denies. With no controlling terminal, use `--auto-approve`.
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -8,7 +8,7 @@ Single static Go binary, no server, no external state.
 - **Agent loop** - drives the model, bounded by iteration and token limits.
 - **Tools** - `http_request`, `code_execution`, `verify_findings`.
 - **Action gate** - resolves each call to its required IAM actions and
-  authorizes against a read-only policy before credentials are attached.
+  authorizes against the configured policy before credentials are attached.
   Fails closed.
 - **Network layer** - pins each request host to its mapped service and
   region, verifies the resolved IP before connect.

--- a/docs/project/threat-model.md
+++ b/docs/project/threat-model.md
@@ -31,10 +31,9 @@ cannot move any of these lines.
 - **Least privilege** - SecurityAudit, roles/viewer, Reader, live view
   RBAC. For AWS assumed-role identities, credentials are re-vended
   through STS scoped to a managed policy, so IAM enforces the boundary
-  independently. Always provide the least-privileged credentials needed,
-  the action gate is not a substitute for them. A provider's ceiling can
-  be disabled by the operator; the credentials' own policy is then the
-  only boundary.
+  independently. Always provide the least-privileged credentials needed;
+  the action gate is not a substitute for them. A connector's ceiling can
+  be configured by the operator.
 - **Fail closed** - anything unclassified, unresolvable, or not allowed
   by the configured policy is denied.
 - **Complete mediation** - authorization is per request, not per session.

--- a/docs/project/threat-model.md
+++ b/docs/project/threat-model.md
@@ -31,8 +31,12 @@ cannot move any of these lines.
 - **Least privilege** - SecurityAudit, roles/viewer, Reader, live view
   RBAC. For AWS assumed-role identities, credentials are re-vended
   through STS scoped to a managed policy, so IAM enforces the boundary
-  independently.
-- **Fail closed** - anything not classified as a read is denied.
+  independently. Always provide the least-privileged credentials needed,
+  the action gate is not a substitute for them. A provider's ceiling can
+  be disabled by the operator; the credentials' own policy is then the
+  only boundary.
+- **Fail closed** - anything unclassified, unresolvable, or not allowed
+  by the configured policy is denied.
 - **Complete mediation** - authorization is per request, not per session.
 - **Defense in depth** - action gate, host pinning, provider-side IAM.
 


### PR DESCRIPTION
<!-- PR title must be a Conventional Commit, e.g. `feat: …` / `fix: …`. -->

## What & why

## Checklist
- [ ] `make check` passes locally
- [ ] Tests added/updated for the change
- [ ] Docs updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that each tool call is authorized according to the configured policy.
  - Emphasized that least-privilege credentials remain necessary, including when provider-side restrictions are disabled.
  - Documented fail-closed behavior for unclassified, unresolvable, or disallowed actions.
  - Updated credential guidance to avoid implying that read-only credentials are always required.
  - Clarified that credential policies remain an important security boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->