### PR TITLE
ci: retry the pinned tool downloads on transient network errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Bootstrap pinned script-check tools
+        # Bounds the whole bootstrap, so the download's own deadline has a declared
+        # budget to sit inside rather than an invented constant.
+        timeout-minutes: 10
         run: |
           set -euo pipefail
           # Versions come from the Makefile (single source of truth).
@@ -27,7 +30,14 @@ jobs:
           pester_ver="$(make -s print-PESTER_VERSION)"
           pssa_ver="$(make -s print-PSSCRIPTANALYZER_VERSION)"
           # Pinned shellcheck: download + verify SHA-256, no Docker; prepend to PATH.
-          curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/v${sc_ver}/shellcheck-v${sc_ver}.linux.x86_64.tar.xz" -o /tmp/sc.tar.xz
+          # --retry-all-errors because a reset while the TLS connection is being
+          # established can surface as exit 35, which plain --retry does not treat
+          # as retryable. --max-time bounds each attempt; the asset is about
+          # 2.4 MiB. The shell reaches the sha256sum below only after curl exits
+          # clean, so retrying never weakens the pin. The outer timeout covers what
+          # --max-time cannot: a 429/503 Retry-After replaces --retry-delay with a
+          # server-chosen sleep, which no curl flag caps.
+          timeout 300 curl -sSfL --max-time 60 --retry 3 --retry-all-errors --retry-delay 2 "https://github.com/koalaman/shellcheck/releases/download/v${sc_ver}/shellcheck-v${sc_ver}.linux.x86_64.tar.xz" -o /tmp/sc.tar.xz
           echo "${sc_sha}  /tmp/sc.tar.xz" | sha256sum -c -
           tar -xJf /tmp/sc.tar.xz -C /tmp
           mkdir -p "$HOME/.local/bin"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,7 +215,13 @@ jobs:
           # Version and digest come from the Makefile (single source of truth).
           ver="$(make -s print-COSIGN_VERSION)"
           sha="$(make -s print-COSIGN_SHA256)"
-          curl -sSfL --max-time 240 \
+          # curl's own timers do not enforce a hard overall deadline: --retry-max-time
+          # does not stop an attempt that already started, and a 429/503 Retry-After
+          # overrides --retry-delay with a server-chosen sleep. `timeout` supplies
+          # one, and reserves 30s of headroom for the verify and install below
+          # inside this step's timeout-minutes: 5. --max-time stays at 240 so a
+          # slow but healthy download of this 134 MiB asset still wins.
+          timeout 270 curl -sSfL --max-time 240 --retry 3 --retry-all-errors --retry-delay 2 \
             "https://github.com/sigstore/cosign/releases/download/v${ver}/cosign-linux-amd64" \
             -o /tmp/cosign
           echo "${sha}  /tmp/cosign" | sha256sum -c -

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,10 @@ pwsh-test:
 # (test/release-signing.unit.test.sh: the .goreleaser.yaml signs stanza, the asset gate's
 # admitted type set, the snapshot sign skip, and the release workflow's OIDC permission,
 # guarded steps and pinned verification identity, none of which any other gate checks and
-# all of which would first fail during a live release), an AST
+# all of which would first fail during a live release), the two pinned tool downloads'
+# contract (test/tool-downloads.unit.test.sh: the outer deadline, retry-all-errors,
+# positive retry count and per-attempt bound on the shellcheck and cosign bootstraps,
+# every one of which leaves both workflows green when it is deleted), an AST
 # syntax check of every file in the shared connector audit-parser package
 # (test/lib/connector-audit-parser.py,
 # test/lib/connector_audit/*.py, and its specs/), the connector gate's roster golden
@@ -180,6 +183,7 @@ sh-test:
 	@sh test/dependabot-override.unit.test.sh
 	@sh test/assert-assets.unit.test.sh
 	@sh test/release-signing.unit.test.sh
+	@sh test/tool-downloads.unit.test.sh
 	@sh test/ci-gate-contract.unit.test.sh
 	@sh test/ci-gate-assert.unit.test.sh
 	@sh test/llm-smoke-roster.unit.test.sh

--- a/test/tool-downloads.unit.test.sh
+++ b/test/tool-downloads.unit.test.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# tool-downloads.unit.test.sh - offline contract pins for the two pinned tool downloads
+# (cynative#324). Hermetic: reads tracked workflow files only, no network, no downloads.
+#
+# Two steps fetch a pinned binary over the network before their job can do any work:
+# ci.yaml bootstraps shellcheck for the required Lint & Test check, and release.yaml
+# bootstraps cosign for signing. Both carry the same hardening against a flaky or
+# throttling GitHub Releases, and every part of it is silent when deleted, because its
+# whole job is to suppress a symptom rather than to produce a result:
+#
+#   - an outer `timeout`, the only hard deadline on the download. curl's
+#     --retry-max-time does not stop an attempt that already started, and a 429 or 503
+#     Retry-After replaces --retry-delay with a server-chosen sleep, so without it the
+#     step waits however long the server asks.
+#   - --retry-all-errors, which is what makes a reset during TLS setup (curl exit 35)
+#     retryable at all; plain --retry does not treat that as retryable.
+#   - a positive --retry count, without which --retry-all-errors does nothing.
+#   - a positive --max-time no larger than the outer deadline, so one stalled attempt
+#     cannot eat the whole budget.
+#
+# Drop any of them and both workflows stay green. CI goes back to dying on the occasional
+# reset, which reads as flake and gets a re-run rather than a diagnosis, and the release
+# goes back to a download that can hold its runner. The sha256sum on the next line is an
+# integrity check, not a liveness one, so nothing else observes these values.
+#
+# Values are parsed and compared, never matched as text: `timeout 0` and `--max-time 0`
+# disable the very timers they look like they pin, and `--retry 0` disables retrying
+# while --retry-all-errors still reads as present. The outer deadline is compared with
+# the step's own timeout-minutes rather than a literal, so retuning either is free while
+# a deadline that no longer fits inside the step fails here. Run by `make sh-test`.
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+root=$(CDPATH='' cd -- "$here/.." && pwd)
+
+fails=0
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+# First capture of a sed expression over a blob, or empty when nothing matches.
+num() { # sed-expression blob
+	printf '%s\n' "$2" | sed -n "$1" | head -n 1
+}
+
+# The step's own lines. Ends at the next step (`      - `), the next job (two-space key)
+# or the next top-level key, so a step that is last in its job cannot adopt the next
+# job's timeout-minutes or borrow a later step's curl.
+step_block() { # file step-name
+	awk -v want="      - name: $2" '
+		$0 == want { f = 1; next }
+		f && (/^      - / || /^  [A-Za-z0-9_-]+:[[:space:]]*$/ || /^[A-Za-z0-9_-]+:/) { f = 0 }
+		f
+	' "$1"
+}
+
+# Live shell from a run: body. Strips comments to end of line before joining
+# continuations, so a commented-out hardened command cannot vouch for a live bare one,
+# and a trailing comment cannot hide the rest of a line.
+live_cmds() { # block
+	printf '%s\n' "$1" |
+		sed 's/[[:space:]]#.*$//; s/^[[:space:]]*#.*$//' |
+		awk '/\\$/ { sub(/[[:space:]]*\\$/, " "); buf = buf $0; next } { print buf $0; buf = "" }'
+}
+
+# workflow:step name. Both rows are checked by the same rule; neither is special.
+for row in \
+	".github/workflows/ci.yaml:Bootstrap pinned script-check tools" \
+	".github/workflows/release.yaml:Bootstrap pinned cosign"; do
+	wf=${row%%:*}
+	step=${row#*:}
+	file="$root/$wf"
+	[ -f "$file" ] || { fail "$wf not found"; continue; }
+
+	# Exactly one step of this name: a duplicate carrying a bare curl must not pass on
+	# the strength of the hardened original.
+	step_count=$(grep -cxF "      - name: $step" "$file" || true)
+	if [ "$step_count" -ne 1 ]; then
+		fail "$wf: expected exactly one step named '$step', found $step_count"
+		continue
+	fi
+
+	block=$(step_block "$file" "$step")
+	cmd=$(live_cmds "$block" | grep '[[:space:]]curl[[:space:]]' || true)
+	cmd_count=$(printf '%s' "$cmd" | grep -c . || true)
+	if [ "$cmd_count" -ne 1 ]; then
+		fail "$wf: expected exactly one live curl invocation in '$step', found $cmd_count"
+		continue
+	fi
+
+	budget=$(num 's/^[[:space:]]*timeout-minutes:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$block")
+	outer=$(num 's/.*[[:space:]]timeout[[:space:]][[:space:]]*\([0-9][0-9]*\)[[:space:]][[:space:]]*curl[[:space:]].*/\1/p' "$cmd")
+	attempt=$(num 's/.*--max-time[[:space:]][[:space:]]*\([0-9][0-9]*\).*/\1/p' "$cmd")
+	retries=$(num 's/.*--retry[[:space:]][[:space:]]*\([0-9][0-9]*\).*/\1/p' "$cmd")
+	[ -n "$budget" ] || budget=0
+	[ -n "$outer" ] || outer=0
+	[ -n "$attempt" ] || attempt=0
+	[ -n "$retries" ] || retries=0
+
+	if [ "$budget" -le 0 ]; then
+		fail "$wf: step '$step' must declare timeout-minutes - it is the budget the download's own deadline is checked against, and without it this pin has nothing to compare"
+	elif [ "$outer" -le 0 ]; then
+		# A duration suffix or a -k flag lands here rather than reading as no timeout:
+		# the comparison needs bare seconds, so say that instead of claiming it is absent.
+		case "$cmd" in
+		*timeout*curl*) fail "$wf: the '$step' download must run under an outer timeout written as bare seconds (as in 'timeout 300 curl'), so this pin can compare it with the step's ${budget}m budget" ;;
+		*) fail "$wf: the '$step' download must run under an outer timeout - curl's --retry-max-time does not stop an attempt that already started and a Retry-After overrides --retry-delay, so nothing else holds the step to its deadline" ;;
+		esac
+	elif [ "$outer" -ge $((budget * 60)) ]; then
+		fail "$wf: the '$step' download's outer timeout (${outer}s) must be shorter than the step's own budget (${budget}m), or the step is killed mid-download instead of failing on it"
+	else
+		pass "$wf: '$step' download runs under a ${outer}s deadline, inside the step's ${budget}m"
+	fi
+
+	case "$cmd" in
+	*--retry-all-errors*)
+		if [ "$retries" -gt 0 ]; then
+			pass "$wf: '$step' download retries a transport error (--retry $retries)"
+		else
+			fail "$wf: --retry-all-errors does nothing without a positive --retry count (got $retries)"
+		fi
+		;;
+	*) fail "$wf: the '$step' download must pass --retry-all-errors - a reset during TLS setup surfaces as curl exit 35, which plain --retry does not treat as retryable" ;;
+	esac
+
+	if [ "$attempt" -le 0 ]; then
+		fail "$wf: the '$step' download must pass a positive --max-time, so one stalled attempt cannot consume the whole deadline"
+	elif [ "$outer" -gt 0 ] && [ "$attempt" -gt "$outer" ]; then
+		fail "$wf: the '$step' download's --max-time (${attempt}s) must not exceed its outer timeout (${outer}s), or the per-attempt bound is dead weight"
+	else
+		pass "$wf: '$step' download bounds each attempt at ${attempt}s"
+	fi
+done
+
+if [ "$fails" -ne 0 ]; then
+	printf 'FAIL: tool download contract pins (%d)\n' "$fails" >&2
+	exit 1
+fi
+printf 'OK: tool download contract pins\n'


### PR DESCRIPTION
## What & why

Both required gates fetch a pinned binary from GitHub Releases with a bare `curl`, so one connection reset kills the job. [Run 34310728236](https://github.com/cynative/cynative/actions/runs/34310728236) died exactly that way, with `curl: (35) Recv failure: Connection reset by peer` while bootstrapping shellcheck, and only a manual re-run recovered it.

`--retry-all-errors` rather than plain `--retry`: a reset while the TLS connection is being established can surface as exit 35, which curl does not count as a retryable transient response. The shell reaches the `sha256sum -c` only after curl exits clean, so retrying cannot weaken either pin.

The cosign download runs under `timeout` because curl's own timers do not give a hard overall deadline. `--retry-max-time` does not stop an attempt that already started, and a 429 or 503 `Retry-After` replaces `--retry-delay` with a server-chosen sleep that no curl flag caps. `--max-time` stays at 240 so a slow but healthy download of that 134 MiB asset still succeeds, and the outer `timeout 270` reserves headroom for the verify and install inside the step's `timeout-minutes: 5`.

Scoped to bounding and retrying the two downloads: no mirror, no cache, no fallback path, and both SHA-256 pins are untouched.

## Verification

`make check` passes on this branch (exit 0), including the `sh-test` goldens that parse these workflows.

`test/release-signing.unit.test.sh` pins the goreleaser stanza and the assert-assets filter, not the cosign install step, so the `release.yaml` edit sits outside every golden. Checked with `grep -n 'curl\|max-time' test/release-signing.unit.test.sh`, which matches nothing.

Two adversarial review passes were run locally against the changed lines before pushing. The first rejected an earlier revision that relied on `--retry-max-time 120` as an overall bound and on reducing `--max-time` to 60, which would have regressed a slow but healthy download since retries discard partial progress. The second confirmed both issues resolved and found no further P1/P2, verifying that `timeout` is present on the runner image, that curl does not trap SIGTERM (so no `--kill-after` is needed), that exit 124 propagates correctly under `set -euo pipefail`, and that a terminated attempt cannot reach the checksum or the install.

## Checklist
- [x] `make check` passes locally
- [ ] Tests added/updated for the change
- [ ] Docs updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved automated tool downloads with retries, per-attempt limits, and overall time limits.
  - Reduced the risk of stalled or flaky downloads blocking validation and release workflows.

- **Tests**
  - Added automated checks to verify download safeguards remain configured correctly.
  - Integrated these checks into the standard test gate to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->